### PR TITLE
Add support for multiple messages per contact

### DIFF
--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -60,8 +60,7 @@ func (b *backend) PopNextOutgoingMsg() (*courier.Msg, error) {
 		}
 
 		// TODO: what other attributes are needed here?
-		msg := courier.NewOutgoingMsg(channel, dbMsg.ID, courier.NilMsgUUID, dbMsg.URN, dbMsg.Text)
-		msg.ExternalID = dbMsg.ExternalID
+		msg := courier.NewOutgoingMsg(channel, dbMsg.URN, dbMsg.Text).WithID(dbMsg.ID).WithExternalID(dbMsg.ExternalID)
 		msg.WorkerToken = token
 
 		return msg, nil

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -46,26 +46,28 @@ func (b *backend) PopNextOutgoingMsg() (*courier.Msg, error) {
 		token, msgJSON, err = queue.PopFromQueue(rc, msgQueueName)
 	}
 
-	var msg *courier.Msg
 	if msgJSON != "" {
-		dbMsg := &DBMsg{}
-		err = json.Unmarshal([]byte(msgJSON), dbMsg)
+		dbMsg := DBMsg{}
+		err = json.Unmarshal([]byte(msgJSON), &dbMsg)
 		if err != nil {
 			return nil, err
 		}
 
-		// load our channel
+		// create courier msg from our db msg
 		channel, err := b.GetChannel(courier.AnyChannelType, dbMsg.ChannelUUID)
 		if err != nil {
 			return nil, err
 		}
 
-		// then create our outgoing msg
-		msg = courier.NewOutgoingMsg(channel, dbMsg.URN, dbMsg.Text)
+		// TODO: what other attributes are needed here?
+		msg := courier.NewOutgoingMsg(channel, dbMsg.ID, courier.NilMsgUUID, dbMsg.URN, dbMsg.Text)
+		msg.ExternalID = dbMsg.ExternalID
 		msg.WorkerToken = token
+
+		return msg, nil
 	}
 
-	return msg, nil
+	return nil, nil
 }
 
 // MarkOutgoingMsgComplete marks the passed in message as having completed processing, freeing up a worker for that channel

--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -49,14 +49,14 @@ func main() {
 	logrus.SetLevel(level)
 
 	// if we have a DSN entry, try to initialize it
-	if config.DSN != "" {
-		hook, err := logrus_sentry.NewSentryHook(config.DSN, []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel})
+	if config.SentryDSN != "" {
+		hook, err := logrus_sentry.NewSentryHook(config.SentryDSN, []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel})
 		hook.Timeout = 0
 		hook.StacktraceConfiguration.Enable = true
 		hook.StacktraceConfiguration.Skip = 4
 		hook.StacktraceConfiguration.Context = 5
 		if err != nil {
-			log.Fatalf("Invalid sentry DSN: '%s': %s", config.DSN, err)
+			log.Fatalf("Invalid sentry DSN: '%s': %s", config.SentryDSN, err)
 		}
 		logrus.StandardLogger().Hooks.Add(hook)
 	}

--- a/config/courier.go
+++ b/config/courier.go
@@ -8,7 +8,7 @@ import (
 type Courier struct {
 	Backend string `default:"rapidpro"`
 
-	DSN string `default:""`
+	SentryDSN string `default:""`
 
 	BaseURL  string `default:"https://localhost:8080"`
 	Port     int    `default:"8080"`

--- a/msg.go
+++ b/msg.go
@@ -66,6 +66,7 @@ func NewMsgUUID() MsgUUID {
 // NewIncomingMsg creates a new message from the given params
 func NewIncomingMsg(channel Channel, urn URN, text string) *Msg {
 	m := &Msg{}
+	m.ID = NilMsgID
 	m.UUID = NewMsgUUID()
 	m.Channel = channel
 	m.Text = text
@@ -78,10 +79,10 @@ func NewIncomingMsg(channel Channel, urn URN, text string) *Msg {
 }
 
 // NewOutgoingMsg creates a new message from the given params
-func NewOutgoingMsg(channel Channel, id MsgID, uuid MsgUUID, urn URN, text string) *Msg {
+func NewOutgoingMsg(channel Channel, urn URN, text string) *Msg {
 	m := &Msg{}
-	m.ID = id
-	m.UUID = uuid
+	m.ID = NilMsgID
+	m.UUID = NilMsgUUID
 	m.Channel = channel
 	m.Text = text
 	m.URN = urn
@@ -119,6 +120,12 @@ func (m *Msg) WithReceivedOn(date time.Time) *Msg { m.ReceivedOn = &date; return
 
 // WithExternalID can be used to set the external id on a msg in a chained call
 func (m *Msg) WithExternalID(id string) *Msg { m.ExternalID = id; return m }
+
+// WithID can be used to set the id on a msg in a chained call
+func (m *Msg) WithID(id MsgID) *Msg { m.ID = id; return m }
+
+// WithUUID can be used to set the id on a msg in a chained call
+func (m *Msg) WithUUID(uuid MsgUUID) *Msg { m.UUID = uuid; return m }
 
 // AddAttachment can be used to append to the media urls for a message
 func (m *Msg) AddAttachment(url string) *Msg { m.Attachments = append(m.Attachments, url); return m }

--- a/msg.go
+++ b/msg.go
@@ -78,9 +78,10 @@ func NewIncomingMsg(channel Channel, urn URN, text string) *Msg {
 }
 
 // NewOutgoingMsg creates a new message from the given params
-func NewOutgoingMsg(channel Channel, urn URN, text string) *Msg {
+func NewOutgoingMsg(channel Channel, id MsgID, uuid MsgUUID, urn URN, text string) *Msg {
 	m := &Msg{}
-	m.UUID = NewMsgUUID()
+	m.ID = id
+	m.UUID = uuid
 	m.Channel = channel
 	m.Text = text
 	m.URN = urn

--- a/test.go
+++ b/test.go
@@ -31,7 +31,7 @@ func (mb *MockBackend) GetLastQueueMsg() (*Msg, error) {
 	return mb.queueMsgs[len(mb.queueMsgs)-1], nil
 }
 
-// PopNextOutgoingMsg returns the next message that should be sent, or nil if there are none to send
+// PopNextOutgoingMsgs returns the next message that should be sent, or nil if there are none to send
 func (mb *MockBackend) PopNextOutgoingMsg() (*Msg, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This sadly complicates our lua/redis queuing even more, but it is the only way I've figured out how to satisfy both max transactions per second on channels as well as fair queueing across channels, having priorities AND spacing out messages on the same contact by a set amount of time. (currently that is at least 5 seconds [could be more depending on what is in the queue but shouldn't be if we set priorities smartly])

Typical push and pop are still in the .15ms range so performance still seems ok.