### PR TITLE
Use callback domain when registering callbacks for sent messages

### DIFF
--- a/backends/rapidpro/channel.go
+++ b/backends/rapidpro/channel.go
@@ -194,6 +194,16 @@ func (c *DBChannel) OrgConfigForKey(key string, defaultValue interface{}) interf
 	return value
 }
 
+// CallbackDomain returns the callback domain to use for this channel
+func (c *DBChannel) CallbackDomain(fallbackDomain string) string {
+	value, found := c.Config_.Map[courier.ConfigCallbackDomain]
+	strValue, isStr := value.(string)
+	if !found || !isStr {
+		return fallbackDomain
+	}
+	return strValue
+}
+
 // StringConfigForKey returns the config value for the passed in key, or defaultValue if it isn't found
 func (c *DBChannel) StringConfigForKey(key string, defaultValue string) string {
 	val := c.ConfigForKey(key, defaultValue)

--- a/channel.go
+++ b/channel.go
@@ -39,6 +39,9 @@ const (
 
 	// ConfigMaxLength is the maximum size of a message in characters
 	ConfigMaxLength = "max_length"
+
+	// ConfigCallbackDomain is the domain that should be used for this channel when registering callbacks
+	ConfigCallbackDomain = "callback_domain"
 )
 
 // ChannelType is our typing of the two char channel types
@@ -102,8 +105,11 @@ type Channel interface {
 	Schemes() []string
 	Country() string
 	Address() string
+
+	// CallbackDomain returns the domain that should be used for any callbacks the channel registers
+	CallbackDomain(fallbackDomain string) string
+
 	ConfigForKey(key string, defaultValue interface{}) interface{}
 	StringConfigForKey(key string, defaultValue string) string
-
 	OrgConfigForKey(key string, defaultValue interface{}) interface{}
 }

--- a/config/courier.go
+++ b/config/courier.go
@@ -10,7 +10,8 @@ type Courier struct {
 
 	SentryDSN string `default:""`
 
-	BaseURL  string `default:"https://localhost:8080"`
+	Scheme   string `default:"https"`
+	Domain   string `default:"localhost"`
 	Port     int    `default:"8080"`
 	DB       string `default:"postgres://courier@localhost/courier?sslmode=disable"`
 	Redis    string `default:"redis://localhost:6379/0"`

--- a/config/courier.go
+++ b/config/courier.go
@@ -6,39 +6,67 @@ import (
 
 // Courier is our top level configuration object
 type Courier struct {
+	// Backend is the backend that will be used by courier (currently only rapidpro is supported)
 	Backend string `default:"rapidpro"`
 
+	// SentryDSN is the DSN used for logging errors to Sentry
 	SentryDSN string `default:""`
 
-	Scheme   string `default:"https"`
-	Domain   string `default:"localhost"`
-	Port     int    `default:"8080"`
-	DB       string `default:"postgres://courier@localhost/courier?sslmode=disable"`
-	Redis    string `default:"redis://localhost:6379/0"`
+	// Domain is the domain courier is exposed on
+	Domain string `default:"localhost"`
+
+	// Port is the port courier will listen on
+	Port int `default:"8080"`
+
+	// DB is a URL describing how to connect to our database
+	DB string `default:"postgres://courier@localhost/courier?sslmode=disable"`
+
+	// Redis is a URL describing how to connect to Redis
+	Redis string `default:"redis://localhost:6379/0"`
+
+	// SpoolDir is the local directory where courier will write statuses or msgs that need to be retried (needs to be writable)
 	SpoolDir string `default:"/var/spool/courier"`
 
-	S3Region      string `default:"us-east-1"`
+	// S3Region is the S3 region we will write attachments to
+	S3Region string `default:"us-east-1"`
+
+	// S3MediaBucket is the S3 bucket we will write attachments to
 	S3MediaBucket string `default:"courier-media"`
+
+	// S3MediaPrefix is the prefix that will be added to attachment filenames
 	S3MediaPrefix string `default:"/media/"`
 
-	AWSAccessKeyID     string `default:"missing_aws_access_key_id"`
+	// AWSAccessKeyID is the access key id to use when authenticating S3
+	AWSAccessKeyID string `default:"missing_aws_access_key_id"`
+
+	// AWSAccessKeyID is the secret access key id to use when authenticating S3
 	AWSSecretAccessKey string `default:"missing_aws_secret_access_key"`
 
+	// MaxWorkers it the maximum number of go routines that will be used for sending (set to 0 to disable sending)
 	MaxWorkers int `default:"32"`
 
+	// LibratoUsername is the username that will be used to authenticate to Librato
 	LibratoUsername string `default:""`
-	LibratoToken    string `default:""`
 
+	// LibratoToken is the token that will be used to authenticate to Librato
+	LibratoToken string `default:""`
+
+	// StatusUsername is the username that is needed to authenticate against the /status endpoint
 	StatusUsername string `default:""`
+
+	// StatusPassword is the password that is needed to authenticate against the /status endpoint
 	StatusPassword string `default:""`
 
+	// LogLevel controls the logging level courier uses
 	LogLevel string `default:"error"`
 
+	// IncludeChannels is the list of channels to enable, empty means include all
 	IncludeChannels []string
+
+	// ExcludeChannels is the list of channels to exclude, empty means exclude none
 	ExcludeChannels []string
 
-	IgnoreTwilioStatus bool `default:"false"`
-
+	// Version is the version that will be sent in headers
 	Version string `default:"Dev"`
 }
 

--- a/config/test.go
+++ b/config/test.go
@@ -13,6 +13,5 @@ func NewTest() *Courier {
 	loader.Load(config)
 
 	// hardcode our test base URL
-	config.BaseURL = "http://courier.test"
 	return config
 }

--- a/handlers/dmark/dmark.go
+++ b/handlers/dmark/dmark.go
@@ -125,7 +125,8 @@ func (h *handler) SendMsg(msg courier.Msg) (courier.MsgStatus, error) {
 		return nil, fmt.Errorf("no authorization token set for DK channel")
 	}
 
-	dlrURL := fmt.Sprintf("%s%s%s/status?id=%s&status=%%s", h.Server().Config().BaseURL, "/c/dk/", msg.Channel().UUID(), msg.ID().String())
+	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
+	dlrURL := fmt.Sprintf("%s://%s%s%s/status?id=%s&status=%%s", h.Server().Config().Scheme, callbackDomain, "/c/dk/", msg.Channel().UUID(), msg.ID().String())
 
 	status := h.Backend().NewMsgStatusForID(msg.Channel(), msg.ID(), courier.MsgErrored)
 	parts := handlers.SplitMsg(msg.Text(), maxMsgLength)

--- a/handlers/dmark/dmark.go
+++ b/handlers/dmark/dmark.go
@@ -126,7 +126,7 @@ func (h *handler) SendMsg(msg courier.Msg) (courier.MsgStatus, error) {
 	}
 
 	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
-	dlrURL := fmt.Sprintf("%s://%s%s%s/status?id=%s&status=%%s", h.Server().Config().Scheme, callbackDomain, "/c/dk/", msg.Channel().UUID(), msg.ID().String())
+	dlrURL := fmt.Sprintf("https://%s%s%s/status?id=%s&status=%%s", callbackDomain, "/c/dk/", msg.Channel().UUID(), msg.ID().String())
 
 	status := h.Backend().NewMsgStatusForID(msg.Channel(), msg.ID(), courier.MsgErrored)
 	parts := handlers.SplitMsg(msg.Text(), maxMsgLength)

--- a/handlers/dmark/dmark_test.go
+++ b/handlers/dmark/dmark_test.go
@@ -59,7 +59,7 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		Status: "W", ExternalID: "6b1c15d3-cba2-46f7-9a25-78265e58057d",
 		ResponseBody: `{ "type": "MT", "sms_id": "6b1c15d3-cba2-46f7-9a25-78265e58057d" }`, ResponseStatus: 200,
 		Headers:    map[string]string{"Authorization": "Token Authy"},
-		PostParams: map[string]string{"text": "Simple Message ☺", "receiver": "250788383383", "sender": "2020", "dlr_url": "http://courier.test/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&status=%s"},
+		PostParams: map[string]string{"text": "Simple Message ☺", "receiver": "250788383383", "sender": "2020", "dlr_url": "https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&status=%s"},
 		SendPrep:   setSendURL},
 	{Label: "Invalid Body",
 		Text: "Error Message", URN: "tel:+250788383383",

--- a/handlers/kannel/kannel.go
+++ b/handlers/kannel/kannel.go
@@ -130,7 +130,8 @@ func (h *handler) SendMsg(msg courier.Msg) (courier.MsgStatus, error) {
 		return nil, fmt.Errorf("no send url set for KN channel")
 	}
 
-	dlrURL := fmt.Sprintf("%s%s%s/status?id=%s&status=%%d", h.Server().Config().BaseURL, "/c/kn/", msg.Channel().UUID(), msg.ID().String())
+	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
+	dlrURL := fmt.Sprintf("%s://%s%s%s/status?id=%s&status=%%d", h.Server().Config().Scheme, callbackDomain, "/c/kn/", msg.Channel().UUID(), msg.ID().String())
 
 	// build our request
 	form := url.Values{

--- a/handlers/kannel/kannel.go
+++ b/handlers/kannel/kannel.go
@@ -131,7 +131,7 @@ func (h *handler) SendMsg(msg courier.Msg) (courier.MsgStatus, error) {
 	}
 
 	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
-	dlrURL := fmt.Sprintf("%s://%s%s%s/status?id=%s&status=%%d", h.Server().Config().Scheme, callbackDomain, "/c/kn/", msg.Channel().UUID(), msg.ID().String())
+	dlrURL := fmt.Sprintf("https://%s%s%s/status?id=%s&status=%%d", callbackDomain, "/c/kn/", msg.Channel().UUID(), msg.ID().String())
 
 	// build our request
 	form := url.Values{

--- a/handlers/kannel/kannel_test.go
+++ b/handlers/kannel/kannel_test.go
@@ -57,7 +57,7 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		Status:       "W",
 		ResponseBody: "0: Accepted for delivery", ResponseStatus: 200,
 		URLParams: map[string]string{"text": "Simple Message", "to": "+250788383383", "coding": "", "priority": "",
-			"dlr-url": "http://courier.test/c/kn/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&status=%d"},
+			"dlr-url": "https://localhost/c/kn/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&status=%d"},
 		SendPrep: setSendURL},
 	{Label: "Unicode Send",
 		Text: "☺", URN: "tel:+250788383383", HighPriority: false,

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -96,7 +96,7 @@ func ensureTestServerUp(host string) {
 func testHandlerRequest(tb testing.TB, s courier.Server, path string, data string, expectedStatus int, expectedBody *string, requestPrepFunc RequestPrepFunc) string {
 	var req *http.Request
 	var err error
-	url := fmt.Sprintf("%s://%s%s", s.Config().Scheme, s.Config().Domain, path)
+	url := fmt.Sprintf("https://%s%s", s.Config().Domain, path)
 
 	if data != "" {
 		req, err = http.NewRequest("POST", url, strings.NewReader(data))

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -93,9 +93,10 @@ func ensureTestServerUp(host string) {
 }
 
 // utility method to make a request to a handler URL
-func testHandlerRequest(tb testing.TB, s courier.Server, url string, data string, expectedStatus int, expectedBody *string, requestPrepFunc RequestPrepFunc) string {
+func testHandlerRequest(tb testing.TB, s courier.Server, path string, data string, expectedStatus int, expectedBody *string, requestPrepFunc RequestPrepFunc) string {
 	var req *http.Request
 	var err error
+	url := fmt.Sprintf("%s://%s%s", s.Config().Scheme, s.Config().Domain, path)
 
 	if data != "" {
 		req, err = http.NewRequest("POST", url, strings.NewReader(data))

--- a/handlers/twilio/twilio.go
+++ b/handlers/twilio/twilio.go
@@ -295,8 +295,7 @@ func (h *handler) validateSignature(channel courier.Channel, r *http.Request) er
 		return fmt.Errorf("invalid or missing auth token in config")
 	}
 
-	url := fmt.Sprintf("%s://%s%s", r.URL.Scheme, r.Host, r.URL.RequestURI())
-	fmt.Printf("URL: %s", url)
+	url := fmt.Sprintf("%s://%s%s", h.Server().Config().Scheme, r.Host, r.URL.RequestURI())
 	expected, err := twCalculateSignature(url, r.PostForm, authToken)
 	if err != nil {
 		return err

--- a/handlers/twilio/twilio.go
+++ b/handlers/twilio/twilio.go
@@ -134,11 +134,6 @@ func (h *handler) StatusMessage(channel courier.Channel, w http.ResponseWriter, 
 		return nil, err
 	}
 
-	// check if we should ignore twilio status updates
-	if h.Server().Config().IgnoreTwilioStatus {
-		return nil, nil
-	}
-
 	// get our params
 	twStatus := &twStatus{}
 	err = handlers.DecodeAndValidateForm(twStatus, r)
@@ -181,7 +176,7 @@ func (h *handler) StatusMessage(channel courier.Channel, w http.ResponseWriter, 
 func (h *handler) SendMsg(msg courier.Msg) (courier.MsgStatus, error) {
 	// build our callback URL
 	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
-	callbackURL := fmt.Sprintf("%s://%s/c/t/%s/status?id=%d&action=callback", h.Server().Config().Scheme, callbackDomain, msg.Channel().UUID(), msg.ID().Int64)
+	callbackURL := fmt.Sprintf("https://%s/c/t/%s/status?id=%d&action=callback", callbackDomain, msg.Channel().UUID(), msg.ID().Int64)
 
 	accountSID := msg.Channel().StringConfigForKey(configAccountSID, "")
 	if accountSID == "" {
@@ -295,7 +290,7 @@ func (h *handler) validateSignature(channel courier.Channel, r *http.Request) er
 		return fmt.Errorf("invalid or missing auth token in config")
 	}
 
-	url := fmt.Sprintf("%s://%s%s", h.Server().Config().Scheme, r.Host, r.URL.RequestURI())
+	url := fmt.Sprintf("https://%s%s", r.Host, r.URL.RequestURI())
 	expected, err := twCalculateSignature(url, r.PostForm, authToken)
 	if err != nil {
 		return err

--- a/handlers/twilio/twilio.go
+++ b/handlers/twilio/twilio.go
@@ -180,7 +180,8 @@ func (h *handler) StatusMessage(channel courier.Channel, w http.ResponseWriter, 
 // SendMsg sends the passed in message, returning any error
 func (h *handler) SendMsg(msg courier.Msg) (courier.MsgStatus, error) {
 	// build our callback URL
-	callbackURL := fmt.Sprintf("%s/c/t/%s/status?id=%d&action=callback", h.Server().Config().BaseURL, msg.Channel().UUID(), msg.ID().Int64)
+	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
+	callbackURL := fmt.Sprintf("%s://%s/c/t/%s/status?id=%d&action=callback", h.Server().Config().Scheme, callbackDomain, msg.Channel().UUID(), msg.ID().Int64)
 
 	accountSID := msg.Channel().StringConfigForKey(configAccountSID, "")
 	if accountSID == "" {
@@ -294,7 +295,8 @@ func (h *handler) validateSignature(channel courier.Channel, r *http.Request) er
 		return fmt.Errorf("invalid or missing auth token in config")
 	}
 
-	url := fmt.Sprintf("https://%s%s", r.Host, r.URL.RequestURI())
+	url := fmt.Sprintf("%s://%s%s", r.URL.Scheme, r.Host, r.URL.RequestURI())
+	fmt.Printf("URL: %s", url)
 	expected, err := twCalculateSignature(url, r.PostForm, authToken)
 	if err != nil {
 		return err

--- a/handlers/twilio/twilio_test.go
+++ b/handlers/twilio/twilio_test.go
@@ -62,7 +62,7 @@ var testCases = []ChannelHandleTestCase{
 
 func addValidSignature(r *http.Request) {
 	r.ParseForm()
-	sig, _ := twCalculateSignature(fmt.Sprintf("https://%s%s", r.Host, r.URL.RequestURI()), r.PostForm, "6789")
+	sig, _ := twCalculateSignature(fmt.Sprintf("%s://%s%s", r.URL.Scheme, r.Host, r.URL.RequestURI()), r.PostForm, "6789")
 	r.Header.Set(twSignatureHeader, string(sig))
 }
 

--- a/server.go
+++ b/server.go
@@ -278,7 +278,7 @@ func (s *server) channelUpdateStatusWrapper(handler ChannelHandler, handlerFunc 
 		if err != nil {
 			return err
 		}
-		url := fmt.Sprintf("%s%s", s.config.BaseURL, r.URL.RequestURI())
+		url := fmt.Sprintf("%s%s%s", r.URL.Scheme, r.URL.Host, r.URL.RequestURI())
 
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		ww.Tee(response)
@@ -326,7 +326,7 @@ func (s *server) channelReceiveMsgWrapper(handler ChannelHandler, handlerFunc Ch
 		if err != nil {
 			return err
 		}
-		url := fmt.Sprintf("%s%s", s.config.BaseURL, r.URL.RequestURI())
+		url := fmt.Sprintf("%s%s%s", r.URL.Scheme, r.URL.Host, r.URL.RequestURI())
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
 		ww.Tee(response)

--- a/server.go
+++ b/server.go
@@ -278,7 +278,7 @@ func (s *server) channelUpdateStatusWrapper(handler ChannelHandler, handlerFunc 
 		if err != nil {
 			return err
 		}
-		url := fmt.Sprintf("%s%s%s", r.URL.Scheme, r.URL.Host, r.URL.RequestURI())
+		url := fmt.Sprintf("%s://%s%s", s.Config().Scheme, r.URL.Host, r.URL.RequestURI())
 
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		ww.Tee(response)
@@ -326,7 +326,7 @@ func (s *server) channelReceiveMsgWrapper(handler ChannelHandler, handlerFunc Ch
 		if err != nil {
 			return err
 		}
-		url := fmt.Sprintf("%s%s%s", r.URL.Scheme, r.URL.Host, r.URL.RequestURI())
+		url := fmt.Sprintf("%s://%s%s", s.Config().Scheme, r.URL.Host, r.URL.RequestURI())
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
 		ww.Tee(response)

--- a/server.go
+++ b/server.go
@@ -278,7 +278,7 @@ func (s *server) channelUpdateStatusWrapper(handler ChannelHandler, handlerFunc 
 		if err != nil {
 			return err
 		}
-		url := fmt.Sprintf("%s://%s%s", s.Config().Scheme, r.URL.Host, r.URL.RequestURI())
+		url := fmt.Sprintf("https://%s%s", r.URL.Host, r.URL.RequestURI())
 
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		ww.Tee(response)
@@ -326,7 +326,7 @@ func (s *server) channelReceiveMsgWrapper(handler ChannelHandler, handlerFunc Ch
 		if err != nil {
 			return err
 		}
-		url := fmt.Sprintf("%s://%s%s", s.Config().Scheme, r.URL.Host, r.URL.RequestURI())
+		url := fmt.Sprintf("https://%s%s", r.URL.Host, r.URL.RequestURI())
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
 		ww.Tee(response)

--- a/test.go
+++ b/test.go
@@ -288,6 +288,15 @@ func (c *MockChannel) SetConfig(key string, value interface{}) {
 	c.config[key] = value
 }
 
+// CallbackDomain returns the callback domain to use for this channel
+func (c *MockChannel) CallbackDomain(fallbackDomain string) string {
+	value, found := c.config[ConfigCallbackDomain]
+	if !found {
+		return fallbackDomain
+	}
+	return value.(string)
+}
+
 // ConfigForKey returns the config value for the passed in key
 func (c *MockChannel) ConfigForKey(key string, defaultValue interface{}) interface{} {
 	value, found := c.config[key]


### PR DESCRIPTION
Removed `Scheme` as a config as:
 1) I'm fine forcing https for callbacks (SSL everywhere!)
 2) and I thought it was a bit confusing as a config option as it felt like it was implying that we were serving via https (when really we are listening on a high port and SSL is handled upstream)