### PR TITLE
Add response and log method for ignoring status messages for messages…

### DIFF
--- a/handlers/facebook/facebook.go
+++ b/handlers/facebook/facebook.go
@@ -333,7 +333,7 @@ func (h *handler) Receive(ctx context.Context, channel courier.Channel, w http.R
 
 				// we don't know about this message, just tell them we ignored it
 				if err == courier.ErrMsgNotFound {
-					data = append(data, courier.NewInfoData("unknown message, ignoring"))
+					data = append(data, courier.NewInfoData("message not found, ignored"))
 					continue
 				}
 

--- a/handlers/nexmo/nexmo.go
+++ b/handlers/nexmo/nexmo.go
@@ -98,7 +98,7 @@ func (h *handler) StatusMessage(ctx context.Context, channel courier.Channel, w 
 
 	// nexmo can return more than one message id when doing multipart, so ignore status updates which might be for one of those parts
 	if err == courier.ErrMsgNotFound {
-		return nil, courier.WriteAndLogRequestIgnored(ctx, w, r, channel, "message not found, ignored")
+		return nil, courier.WriteAndLogStatusMsgNotFound(ctx, w, r, channel)
 	}
 
 	if err != nil {

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -170,6 +170,12 @@ func (h *handler) UpdateStatus(ctx context.Context, channel courier.Channel, w h
 
 	// write our status
 	err = h.Backend().WriteMsgStatus(ctx, status)
+
+	// we can receive read statuses for msgs we didn't trigger
+	if err == courier.ErrMsgNotFound {
+		return nil, courier.WriteAndLogStatusMsgNotFound(ctx, w, r, channel)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/responses.go
+++ b/responses.go
@@ -12,6 +12,8 @@ import (
 	validator "gopkg.in/go-playground/validator.v9"
 )
 
+const statusMsgNotFoundDetail = "message not found, ignored"
+
 // WriteError writes a JSON response for the passed in error
 func WriteError(ctx context.Context, w http.ResponseWriter, r *http.Request, err error) error {
 	errors := []interface{}{NewErrorData(err.Error())}
@@ -35,6 +37,12 @@ func WriteAndLogRequestError(ctx context.Context, w http.ResponseWriter, r *http
 func WriteAndLogRequestIgnored(ctx context.Context, w http.ResponseWriter, r *http.Request, c Channel, details string) error {
 	LogRequestIgnored(r, c, details)
 	return WriteDataResponse(ctx, w, http.StatusOK, "Ignored", []interface{}{NewInfoData(details)})
+}
+
+// WriteAndLogStatusMsgNotFound writes a JSON response for the passed in message and logs an info message
+func WriteAndLogStatusMsgNotFound(ctx context.Context, w http.ResponseWriter, r *http.Request, c Channel) error {
+	LogRequestIgnored(r, c, statusMsgNotFoundDetail)
+	return WriteDataResponse(ctx, w, http.StatusOK, "Ignored", []interface{}{NewInfoData(statusMsgNotFoundDetail)})
 }
 
 // WriteChannelEventSuccess writes a JSON response for the passed in event indicating we handled it


### PR DESCRIPTION
… we don't know about.

Just standardizing these.. we were filling up sentry with errors on the Nexmo side due to them splitting message ids and giving us status for each segment. This just changes us to have a shared method to call for the response and message.