### PR TITLE
tweaks to smscentral before shipping, simplify form parsing

### DIFF
--- a/handlers/base.go
+++ b/handlers/base.go
@@ -94,7 +94,7 @@ func Validate(form interface{}) error {
 }
 
 // DecodeAndValidateForm takes the passed in form and attempts to parse and validate it from the
-// POST parameters of the passed in request
+// URL query parameters as well as any POST parameters of the passed in request
 func DecodeAndValidateForm(form interface{}, r *http.Request) error {
 	err := r.ParseForm()
 	if err != nil {
@@ -102,23 +102,6 @@ func DecodeAndValidateForm(form interface{}, r *http.Request) error {
 	}
 
 	err = decoder.Decode(form, r.Form)
-	if err != nil {
-		return err
-	}
-
-	// check our input is valid
-	err = validate.Struct(form)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DecodeAndValidateQueryParams takes the passed in form and attempts to parse and validate it from the
-// GET parameters of the passed in request
-func DecodeAndValidateQueryParams(form interface{}, r *http.Request) error {
-	err := decoder.Decode(form, r.URL.Query())
 	if err != nil {
 		return err
 	}

--- a/handlers/external/external.go
+++ b/handlers/external/external.go
@@ -61,12 +61,7 @@ func (h *handler) Initialize(s courier.Server) error {
 // ReceiveMessage is our HTTP handler function for incoming messages
 func (h *handler) ReceiveMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	externalMessage := &externalMessage{}
-	handlers.DecodeAndValidateQueryParams(externalMessage, r)
-
-	// if this is a post, also try to parse the form body
-	if r.Method == http.MethodPost {
-		handlers.DecodeAndValidateForm(externalMessage, r)
-	}
+	handlers.DecodeAndValidateForm(externalMessage, r)
 
 	// validate whether our required fields are present
 	err := handlers.Validate(externalMessage)

--- a/handlers/external/external.go
+++ b/handlers/external/external.go
@@ -61,10 +61,7 @@ func (h *handler) Initialize(s courier.Server) error {
 // ReceiveMessage is our HTTP handler function for incoming messages
 func (h *handler) ReceiveMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	externalMessage := &externalMessage{}
-	handlers.DecodeAndValidateForm(externalMessage, r)
-
-	// validate whether our required fields are present
-	err := handlers.Validate(externalMessage)
+	err := handlers.DecodeAndValidateForm(externalMessage, r)
 	if err != nil {
 		return nil, err
 	}
@@ -125,15 +122,7 @@ func (h *handler) buildStatusHandler(status string) courier.ChannelHandleFunc {
 // StatusMessage is our HTTP handler function for status updates
 func (h *handler) StatusMessage(ctx context.Context, statusString string, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	statusForm := &statusForm{}
-	handlers.DecodeAndValidateQueryParams(statusForm, r)
-
-	// if this is a post, also try to parse the form body
-	if r.Method == http.MethodPost {
-		handlers.DecodeAndValidateForm(statusForm, r)
-	}
-
-	// validate whether our required fields are present
-	err := handlers.Validate(statusForm)
+	err := handlers.DecodeAndValidateForm(statusForm, r)
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/jiochat/jiochat.go
+++ b/handlers/jiochat/jiochat.go
@@ -73,7 +73,7 @@ type verifyRequest struct {
 // VerifyURL is our HTTP handler function for Jiochat config URL verification callbacks
 func (h *handler) VerifyURL(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	jcVerify := &verifyRequest{}
-	err := handlers.DecodeAndValidateQueryParams(jcVerify, r)
+	err := handlers.DecodeAndValidateForm(jcVerify, r)
 	if err != nil {
 		return nil, courier.WriteAndLogRequestError(ctx, w, r, channel, err)
 	}

--- a/handlers/kannel/kannel.go
+++ b/handlers/kannel/kannel.go
@@ -51,7 +51,7 @@ func (h *handler) Initialize(s courier.Server) error {
 func (h *handler) ReceiveMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	// get our params
 	kannelMsg := &kannelMessage{}
-	err := handlers.DecodeAndValidateQueryParams(kannelMsg, r)
+	err := handlers.DecodeAndValidateForm(kannelMsg, r)
 	if err != nil {
 		return nil, courier.WriteAndLogRequestError(ctx, w, r, channel, err)
 	}
@@ -93,7 +93,7 @@ var kannelStatusMapping = map[int]courier.MsgStatusValue{
 func (h *handler) StatusMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	// get our params
 	kannelStatus := &kannelStatus{}
-	err := handlers.DecodeAndValidateQueryParams(kannelStatus, r)
+	err := handlers.DecodeAndValidateForm(kannelStatus, r)
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/kannel/kannel.go
+++ b/handlers/kannel/kannel.go
@@ -95,12 +95,12 @@ func (h *handler) StatusMessage(ctx context.Context, channel courier.Channel, w 
 	kannelStatus := &kannelStatus{}
 	err := handlers.DecodeAndValidateForm(kannelStatus, r)
 	if err != nil {
-		return nil, err
+		return nil, courier.WriteAndLogRequestError(ctx, w, r, channel, err)
 	}
 
 	msgStatus, found := kannelStatusMapping[kannelStatus.Status]
 	if !found {
-		return nil, fmt.Errorf("unknown status '%d', must be one of 1,2,4,8,16", kannelStatus.Status)
+		return nil, courier.WriteAndLogRequestError(ctx, w, r, channel, fmt.Errorf("unknown status '%d', must be one of 1,2,4,8,16", kannelStatus.Status))
 	}
 
 	// write our status

--- a/handlers/nexmo/nexmo.go
+++ b/handlers/nexmo/nexmo.go
@@ -119,11 +119,6 @@ func (h *handler) ReceiveMessage(ctx context.Context, channel courier.Channel, w
 	nexmoIncomingMessage := &nexmoIncomingMessage{}
 	handlers.DecodeAndValidateForm(nexmoIncomingMessage, r)
 
-	// if this is a post, also try to parse the form body
-	if r.Method == http.MethodPost {
-		handlers.DecodeAndValidateForm(nexmoIncomingMessage, r)
-	}
-
 	if nexmoIncomingMessage.To == "" {
 		return nil, courier.WriteAndLogRequestIgnored(ctx, w, r, channel, "no to parameter, ignored")
 	}

--- a/handlers/nexmo/nexmo.go
+++ b/handlers/nexmo/nexmo.go
@@ -79,7 +79,7 @@ var statusMappings = map[string]courier.MsgStatusValue{
 // StatusMessage is our HTTP handler function for status updates
 func (h *handler) StatusMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	nexmoDeliveryReport := &nexmoDeliveryReport{}
-	handlers.DecodeAndValidateQueryParams(nexmoDeliveryReport, r)
+	handlers.DecodeAndValidateForm(nexmoDeliveryReport, r)
 
 	if nexmoDeliveryReport.MessageID == "" {
 		return nil, courier.WriteAndLogRequestIgnored(ctx, w, r, channel, "no messageId parameter, ignored")
@@ -117,7 +117,7 @@ type nexmoIncomingMessage struct {
 // ReceiveMessage is our HTTP handler function for incoming messages
 func (h *handler) ReceiveMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	nexmoIncomingMessage := &nexmoIncomingMessage{}
-	handlers.DecodeAndValidateQueryParams(nexmoIncomingMessage, r)
+	handlers.DecodeAndValidateForm(nexmoIncomingMessage, r)
 
 	// if this is a post, also try to parse the form body
 	if r.Method == http.MethodPost {

--- a/handlers/shaqodoon/shaqodoon.go
+++ b/handlers/shaqodoon/shaqodoon.go
@@ -42,12 +42,7 @@ func (h *handler) Initialize(s courier.Server) error {
 // ReceiveMessage is our HTTP handler function for incoming messages
 func (h *handler) ReceiveMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	shaqodoonMessage := &shaqodoonMessage{}
-	handlers.DecodeAndValidateQueryParams(shaqodoonMessage, r)
-
-	// if this is a post, also try to parse the form body
-	if r.Method == http.MethodPost {
-		handlers.DecodeAndValidateForm(shaqodoonMessage, r)
-	}
+	handlers.DecodeAndValidateForm(shaqodoonMessage, r)
 
 	// validate whether our required fields are present
 	err := handlers.Validate(shaqodoonMessage)
@@ -110,12 +105,7 @@ func (h *handler) buildStatusHandler(status string) courier.ChannelHandleFunc {
 // StatusMessage is our HTTP handler function for status updates
 func (h *handler) StatusMessage(ctx context.Context, statusString string, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	statusForm := &statusForm{}
-	handlers.DecodeAndValidateQueryParams(statusForm, r)
-
-	// if this is a post, also try to parse the form body
-	if r.Method == http.MethodPost {
-		handlers.DecodeAndValidateForm(statusForm, r)
-	}
+	handlers.DecodeAndValidateForm(statusForm, r)
 
 	// validate whether our required fields are present
 	err := handlers.Validate(statusForm)

--- a/handlers/shaqodoon/shaqodoon.go
+++ b/handlers/shaqodoon/shaqodoon.go
@@ -42,10 +42,7 @@ func (h *handler) Initialize(s courier.Server) error {
 // ReceiveMessage is our HTTP handler function for incoming messages
 func (h *handler) ReceiveMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	shaqodoonMessage := &shaqodoonMessage{}
-	handlers.DecodeAndValidateForm(shaqodoonMessage, r)
-
-	// validate whether our required fields are present
-	err := handlers.Validate(shaqodoonMessage)
+	err := handlers.DecodeAndValidateForm(shaqodoonMessage, r)
 	if err != nil {
 		return nil, courier.WriteAndLogRequestError(ctx, w, r, channel, err)
 	}
@@ -105,10 +102,7 @@ func (h *handler) buildStatusHandler(status string) courier.ChannelHandleFunc {
 // StatusMessage is our HTTP handler function for status updates
 func (h *handler) StatusMessage(ctx context.Context, statusString string, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	statusForm := &statusForm{}
-	handlers.DecodeAndValidateForm(statusForm, r)
-
-	// validate whether our required fields are present
-	err := handlers.Validate(statusForm)
+	err := handlers.DecodeAndValidateForm(statusForm, r)
 	if err != nil {
 		return nil, courier.WriteAndLogRequestError(ctx, w, r, channel, err)
 	}

--- a/handlers/smscentral/smscentral.go
+++ b/handlers/smscentral/smscentral.go
@@ -45,22 +45,14 @@ func (h *handler) Initialize(s courier.Server) error {
 }
 
 type smsCentralMessage struct {
-	Message string `validate:"required" name:"message"`
-	Mobile  string `validate:"required" name:"mobile"`
+	Message string `name:"message"`
+	Mobile  string `name:"mobile" validate:"required" `
 }
 
 // ReceiveMessage is our HTTP handler function for incoming messages
 func (h *handler) ReceiveMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	smsCentralMessage := &smsCentralMessage{}
-	handlers.DecodeAndValidateQueryParams(smsCentralMessage, r)
-
-	// if this is a post, also try to parse the form body
-	if r.Method == http.MethodPost {
-		handlers.DecodeAndValidateForm(smsCentralMessage, r)
-	}
-
-	// validate whether our required fields are present
-	err := handlers.Validate(smsCentralMessage)
+	err := handlers.DecodeAndValidateForm(smsCentralMessage, r)
 	if err != nil {
 		return nil, courier.WriteAndLogRequestError(ctx, w, r, channel, err)
 	}

--- a/handlers/smscentral/smscentral_test.go
+++ b/handlers/smscentral/smscentral_test.go
@@ -9,10 +9,11 @@ import (
 )
 
 var (
-	receiveValidMessage = "/c/sc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?mobile=%2B2349067554729&message=Join"
-	receiveNoParams     = "/c/sc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-	receiveNoSender     = "/c/sc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?message=Join"
-	receiveNoMessage    = "/c/sc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?mobile=%2B2349067554729"
+	receiveURL          = "/c/sc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive"
+	receiveValidMessage = "mobile=%2B2349067554729&message=Join"
+	receiveNoMessage    = "mobile=%2B2349067554729"
+	receiveNoParams     = "none"
+	receiveNoSender     = "message=Join"
 )
 
 var testChannels = []courier.Channel{
@@ -20,11 +21,12 @@ var testChannels = []courier.Channel{
 }
 
 var handleTestCases = []ChannelHandleTestCase{
-	{Label: "Receive Valid Message", URL: receiveValidMessage, Data: "empty", Status: 200, Response: "Accepted",
+	{Label: "Receive Valid Message", URL: receiveURL, Data: receiveValidMessage, Status: 200, Response: "Accepted",
 		Text: Sp("Join"), URN: Sp("tel:+2349067554729")},
-	{Label: "Receive No Params", URL: receiveNoParams, Data: "empty", Status: 400, Response: "field 'message' required"},
-	{Label: "Receive No Sender", URL: receiveNoSender, Data: "empty", Status: 400, Response: "field 'mobile' required"},
-	{Label: "Receive No Message", URL: receiveNoMessage, Data: "empty", Status: 400, Response: "field 'message' required"},
+	{Label: "Receive No Message", URL: receiveURL, Data: receiveNoMessage, Status: 200, Response: "Accepted",
+		Text: Sp(""), URN: Sp("tel:+2349067554729")},
+	{Label: "Receive No Params", URL: receiveURL, Data: receiveNoParams, Status: 400, Response: "field 'mobile' required"},
+	{Label: "Receive No Sender", URL: receiveURL, Data: receiveNoSender, Status: 400, Response: "field 'mobile' required"},
 }
 
 func TestHandler(t *testing.T) {

--- a/handlers/yo/yo.go
+++ b/handlers/yo/yo.go
@@ -55,7 +55,7 @@ type moMsg struct {
 // ReceiveMessage is our HTTP handler function for incoming messages
 func (h *handler) ReceiveMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	msg := &moMsg{}
-	err := handlers.DecodeAndValidateQueryParams(msg, r)
+	err := handlers.DecodeAndValidateForm(msg, r)
 	if err != nil {
 		return nil, courier.WriteAndLogRequestError(ctx, w, r, channel, err)
 	}


### PR DESCRIPTION
Removed the QueryParams function as the Form version takes care of both URL parameters and POST parameters (in the case of POST).