### PR TITLE
No err new request

### DIFF
--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -205,13 +205,11 @@ func downloadMediaToS3(ctx context.Context, b *backend, channel courier.Channel,
 	}
 
 	if req == nil {
-
 		// first fetch our media
-		req, err = http.NewRequest("GET", mediaURL, nil)
+		req, err = http.NewRequest(http.MethodGet, mediaURL, nil)
 		if err != nil {
 			return "", err
 		}
-
 	}
 
 	resp, err := utils.GetHTTPClient().Do(req)

--- a/chatbase/chatbase.go
+++ b/chatbase/chatbase.go
@@ -42,10 +42,7 @@ func SendChatbaseMessage(apiKey string, apiVersion string, messageType string, u
 		return err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, chatbaseAPIURL, bytes.NewReader(jsonBody))
-	if err != nil {
-		return err
-	}
+	req, _ := http.NewRequest(http.MethodPost, chatbaseAPIURL, bytes.NewReader(jsonBody))
 	req.Header.Set("Content-Type", "application/json")
 
 	_, err = utils.MakeHTTPRequest(req)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	"github.com/nyaruka/gocommon/urns" v0.1.0
 	"github.com/satori/go.uuid" v1.2.0
 	"github.com/sirupsen/logrus" v1.0.4
+	"github.com/stretchr/testify" v1.2.1
 	"golang.org/x/crypto" v0.0.0-20180222182404-49796115aa4b
 	"golang.org/x/sys" v0.0.0-20180222210305-c1138c84af3a
 	"gopkg.in/go-playground/validator.v9" v1.11.0-gopkgin-v9.11.0

--- a/handlers/africastalking/africastalking.go
+++ b/handlers/africastalking/africastalking.go
@@ -145,7 +145,7 @@ func (h *handler) SendMsg(_ context.Context, msg courier.Msg) (courier.MsgStatus
 		form["from"] = []string{msg.Channel().Address()}
 	}
 
-	req, err := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
+	req, _ := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("apikey", apiKey)

--- a/handlers/arabiacell/arabiacell.go
+++ b/handlers/arabiacell/arabiacell.go
@@ -87,7 +87,7 @@ func (h *handler) SendMsg(_ context.Context, msg courier.Msg) (courier.MsgStatus
 			"chargingLevel": []string{chargingLevel},
 		}
 
-		req, err := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
+		req, _ := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Set("Accept", "application/xml")
 		rr, err := utils.MakeHTTPRequest(req)

--- a/handlers/blackmyna/blackmyna.go
+++ b/handlers/blackmyna/blackmyna.go
@@ -130,7 +130,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		"message":       []string{handlers.GetTextAndAttachments(msg)},
 	}
 
-	req, err := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
+	req, _ := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(username, password)
 	rr, err := utils.MakeHTTPRequest(req)

--- a/handlers/clickatell/clickatell.go
+++ b/handlers/clickatell/clickatell.go
@@ -202,7 +202,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		partSendURL, _ := url.Parse(sendURL)
 		partSendURL.RawQuery = form.Encode()
 
-		req, err := http.NewRequest(http.MethodGet, partSendURL.String(), nil)
+		req, _ := http.NewRequest(http.MethodGet, partSendURL.String(), nil)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Set("Accept", "application/json")
 		rr, err := utils.MakeHTTPRequest(req)

--- a/handlers/dart/dart.go
+++ b/handlers/dart/dart.go
@@ -175,7 +175,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		partSendURL, _ := url.Parse(h.sendURL)
 		partSendURL.RawQuery = form.Encode()
 
-		req, err := http.NewRequest(http.MethodGet, partSendURL.String(), nil)
+		req, _ := http.NewRequest(http.MethodGet, partSendURL.String(), nil)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		rr, err := utils.MakeHTTPRequest(req)
 

--- a/handlers/dmark/dmark.go
+++ b/handlers/dmark/dmark.go
@@ -138,7 +138,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			"dlr_url":  []string{dlrURL},
 		}
 
-		req, err := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
+		req, _ := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("Authorization", fmt.Sprintf("Token %s", auth))

--- a/handlers/facebook/facebook.go
+++ b/handlers/facebook/facebook.go
@@ -474,7 +474,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			return status, err
 		}
 
-		req, err := http.NewRequest(http.MethodPost, msgURL.String(), bytes.NewReader(jsonBody))
+		req, _ := http.NewRequest(http.MethodPost, msgURL.String(), bytes.NewReader(jsonBody))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 		rr, err := utils.MakeHTTPRequest(req)

--- a/handlers/firebase/firebase.go
+++ b/handlers/firebase/firebase.go
@@ -189,7 +189,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			return nil, err
 		}
 
-		req, err := http.NewRequest(http.MethodPost, sendURL, bytes.NewReader(jsonPayload))
+		req, _ := http.NewRequest(http.MethodPost, sendURL, bytes.NewReader(jsonPayload))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("Authorization", fmt.Sprintf("key=%s", fcmKey))

--- a/handlers/globe/globe.go
+++ b/handlers/globe/globe.go
@@ -161,12 +161,9 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		json.NewEncoder(requestBody).Encode(payload)
 
 		// build our request
-		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf(sendURL, msg.Channel().Address()), requestBody)
+		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf(sendURL, msg.Channel().Address()), requestBody)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
-		if err != nil {
-			return nil, err
-		}
 
 		rr, err := utils.MakeHTTPRequest(req)
 		log := courier.NewChannelLogFromRR("Message Sent", msg.Channel(), msg.ID(), rr).WithError("Message Send Error", err)

--- a/handlers/infobip/infobip.go
+++ b/handlers/infobip/infobip.go
@@ -219,7 +219,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 	}
 
 	// build our request
-	req, err := http.NewRequest(http.MethodPost, sendURL, requestBody)
+	req, _ := http.NewRequest(http.MethodPost, sendURL, requestBody)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.SetBasicAuth(username, password)

--- a/handlers/jiochat/jiochat.go
+++ b/handlers/jiochat/jiochat.go
@@ -190,7 +190,7 @@ func (h *handler) fetchAccessToken(channel courier.Channel) error {
 		return err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, tokenURL.String(), bytes.NewReader(jsonBody))
+	req, _ := http.NewRequest(http.MethodPost, tokenURL.String(), bytes.NewReader(jsonBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	rr, err := utils.MakeHTTPRequest(req)
@@ -255,13 +255,11 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		json.NewEncoder(requestBody).Encode(jcMsg)
 
 		// build our request
-		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/%s", sendURL, "custom/custom_send.action"), requestBody)
+		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/%s", sendURL, "custom/custom_send.action"), requestBody)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 		if err != nil {
-			return nil, err
-		}
 
 		rr, err := utils.MakeHTTPRequest(req)
 
@@ -294,11 +292,8 @@ func (h *handler) DescribeURN(ctx context.Context, channel courier.Channel, urn 
 	reqURL, _ := url.Parse(fmt.Sprintf("%s/%s", sendURL, "user/info.action"))
 	reqURL.RawQuery = form.Encode()
 
-	req, err := http.NewRequest(http.MethodGet, reqURL.String(), nil)
+	req, _ := http.NewRequest(http.MethodGet, reqURL.String(), nil)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
-	if err != nil {
-		return nil, err
-	}
 
 	rr, err := utils.MakeHTTPRequest(req)
 	if err != nil {
@@ -325,11 +320,7 @@ func (h *handler) BuildDownloadMediaRequest(ctx context.Context, b courier.Backe
 	}
 
 	// first fetch our media
-	req, err := http.NewRequest(http.MethodGet, parsedURL.String(), nil)
+	req, _ := http.NewRequest(http.MethodGet, parsedURL.String(), nil)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
-	if err != nil {
-		return nil, err
-	}
-
 	return req, nil
 }

--- a/handlers/jiochat/jiochat.go
+++ b/handlers/jiochat/jiochat.go
@@ -259,8 +259,6 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
-		if err != nil {
-
 		rr, err := utils.MakeHTTPRequest(req)
 
 		// record our status and log

--- a/handlers/junebug/junebug.go
+++ b/handlers/junebug/junebug.go
@@ -202,7 +202,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			return status, err
 		}
 
-		req, err := http.NewRequest(http.MethodPost, sendURL, bytes.NewReader(jsonBody))
+		req, _ := http.NewRequest(http.MethodPost, sendURL, bytes.NewReader(jsonBody))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 		req.SetBasicAuth(username, password)

--- a/handlers/kannel/kannel.go
+++ b/handlers/kannel/kannel.go
@@ -200,10 +200,6 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 	verifySSL, _ := verifySSLStr.(bool)
 
 	req, err := http.NewRequest(http.MethodGet, sendURL, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	var rr *utils.RequestResponse
 
 	if verifySSL {

--- a/handlers/line/line.go
+++ b/handlers/line/line.go
@@ -156,13 +156,10 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		json.NewEncoder(requestBody).Encode(payload)
 
 		// build our request
-		req, err := http.NewRequest(http.MethodPost, sendURL, requestBody)
+		req, _ := http.NewRequest(http.MethodPost, sendURL, requestBody)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
-		if err != nil {
-			return nil, err
-		}
 
 		rr, err := utils.MakeHTTPRequest(req)
 		// record our status and log

--- a/handlers/m3tech/m3tech.go
+++ b/handlers/m3tech/m3tech.go
@@ -109,10 +109,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 
 		msgURL, _ := url.Parse(sendURL)
 		msgURL.RawQuery = params.Encode()
-		req, err := http.NewRequest(http.MethodGet, msgURL.String(), nil)
-		if err != nil {
-			return nil, err
-		}
+		req, _ := http.NewRequest(http.MethodGet, msgURL.String(), nil)
 
 		rr, err := utils.MakeHTTPRequest(req)
 		status.AddLog(courier.NewChannelLogFromRR("Message Sent", msg.Channel(), msg.ID(), rr).WithError("Message Send Error", err))

--- a/handlers/mblox/mblox.go
+++ b/handlers/mblox/mblox.go
@@ -147,14 +147,10 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		json.NewEncoder(requestBody).Encode(payload)
 
 		// build our request
-		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/%s/batches", sendURL, username), requestBody)
+		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/%s/batches", sendURL, username), requestBody)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", password))
-
-		if err != nil {
-			return nil, err
-		}
 
 		rr, err := utils.MakeHTTPRequest(req)
 		log := courier.NewChannelLogFromRR("Message Sent", msg.Channel(), msg.ID(), rr).WithError("Message Send Error", err)

--- a/handlers/mtarget/mtarget.go
+++ b/handlers/mtarget/mtarget.go
@@ -179,10 +179,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 
 		msgURL, _ := url.Parse(sendURL)
 		msgURL.RawQuery = params.Encode()
-		req, err := http.NewRequest(http.MethodPost, msgURL.String(), nil)
-		if err != nil {
-			return nil, err
-		}
+		req, _ := http.NewRequest(http.MethodPost, msgURL.String(), nil)
 
 		rr, err := utils.MakeHTTPRequest(req)
 		log := courier.NewChannelLogFromRR("Message Sent", msg.Channel(), msg.ID(), rr).WithError("Message Send Error", err)

--- a/handlers/nexmo/nexmo.go
+++ b/handlers/nexmo/nexmo.go
@@ -173,7 +173,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			"type":              []string{textType},
 		}
 
-		req, err := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
+		req, _ := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		var rr *utils.RequestResponse

--- a/handlers/shaqodoon/shaqodoon.go
+++ b/handlers/shaqodoon/shaqodoon.go
@@ -111,7 +111,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 	encodedForm := form.Encode()
 	sendURL = fmt.Sprintf("%s?%s", sendURL, encodedForm)
 
-	req, err := http.NewRequest(http.MethodGet, sendURL, nil)
+	req, _ := http.NewRequest(http.MethodGet, sendURL, nil)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr, err := utils.MakeInsecureHTTPRequest(req)
 

--- a/handlers/smscentral/smscentral.go
+++ b/handlers/smscentral/smscentral.go
@@ -93,7 +93,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		"content": []string{handlers.GetTextAndAttachments(msg)},
 	}
 
-	req, err := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
+	req, _ := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr, err := utils.MakeHTTPRequest(req)
 

--- a/handlers/start/start.go
+++ b/handlers/start/start.go
@@ -165,7 +165,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		}
 
 		// build our request
-		req, err := http.NewRequest(http.MethodPost, sendURL, requestBody)
+		req, _ := http.NewRequest(http.MethodPost, sendURL, requestBody)
 		req.Header.Set("Content-Type", "application/xml; charset=utf8")
 		req.SetBasicAuth(username, password)
 		rr, err := utils.MakeHTTPRequest(req)

--- a/handlers/telegram/telegram.go
+++ b/handlers/telegram/telegram.go
@@ -142,7 +142,7 @@ func (h *handler) sendMsgPart(msg courier.Msg, token string, path string, form u
 	}
 
 	sendURL := fmt.Sprintf("%s/bot%s/%s", apiURL, token, path)
-	req, err := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
+	req, _ := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	rr, err := utils.MakeHTTPRequest(req)
@@ -286,12 +286,8 @@ func resolveFileID(channel courier.Channel, fileID string) (string, error) {
 	form := url.Values{}
 	form.Set("file_id", fileID)
 
-	req, err := http.NewRequest(http.MethodPost, fileURL, strings.NewReader(form.Encode()))
+	req, _ := http.NewRequest(http.MethodPost, fileURL, strings.NewReader(form.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-	if err != nil {
-		return "", err
-	}
 
 	rr, err := utils.MakeHTTPRequest(req)
 	if err != nil {

--- a/handlers/twilio/twilio.go
+++ b/handlers/twilio/twilio.go
@@ -234,7 +234,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			return nil, err
 		}
 
-		req, err := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
+		req, _ := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
 		req.SetBasicAuth(accountSID, accountToken)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Set("Accept", "application/json")

--- a/handlers/twitter/twitter.go
+++ b/handlers/twitter/twitter.go
@@ -282,7 +282,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			return status, err
 		}
 
-		req, err := http.NewRequest(http.MethodPost, sendURL, bytes.NewReader(jsonBody))
+		req, _ := http.NewRequest(http.MethodPost, sendURL, bytes.NewReader(jsonBody))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 		rr, err := utils.MakeHTTPRequestWithClient(req, client)

--- a/handlers/viber/viber.go
+++ b/handlers/viber/viber.go
@@ -375,7 +375,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		}
 
 		// build our request
-		req, err := http.NewRequest(http.MethodPost, sendURL, requestBody)
+		req, _ := http.NewRequest(http.MethodPost, sendURL, requestBody)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 		rr, err := utils.MakeHTTPRequest(req)

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -224,7 +224,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			return status, err
 		}
 
-		req, err := http.NewRequest(http.MethodPost, sendURL, bytes.NewReader(jsonBody))
+		req, _ := http.NewRequest(http.MethodPost, sendURL, bytes.NewReader(jsonBody))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 		req.SetBasicAuth(username, password)

--- a/handlers/yo/yo.go
+++ b/handlers/yo/yo.go
@@ -127,8 +127,9 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			sendURL, _ := url.Parse(sendURL)
 			sendURL.RawQuery = form.Encode()
 
-			req, err := http.NewRequest(http.MethodGet, sendURL.String(), nil)
+			req, _ := http.NewRequest(http.MethodGet, sendURL.String(), nil)
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 			rr, err := utils.MakeHTTPRequest(req)
 			log := courier.NewChannelLogFromRR("Message Sent", msg.Channel(), msg.ID(), rr).WithError("Message Send Error", err)
 			status.AddLog(log)

--- a/librato/librato.go
+++ b/librato/librato.go
@@ -106,11 +106,7 @@ func (c *Sender) flush(count int) {
 		return
 	}
 
-	req, err := http.NewRequest("POST", libratoEndpoint, bytes.NewReader(encoded))
-	if err != nil {
-		logrus.WithField("comp", "librato").WithError(err).Error("error sending librato metrics")
-		return
-	}
+	req, _ := http.NewRequest("POST", libratoEndpoint, bytes.NewReader(encoded))
 	req.SetBasicAuth(c.username, c.token)
 	req.Header.Set("Content-Type", "application/json")
 	_, err = utils.MakeHTTPRequest(req)


### PR DESCRIPTION
There's no need to check `err` when building a new request which has a URL we know to be valid. We didn't tend to check this consistently anyways and when we did we were doing it after trying to set headers on the request (which was nil and would panic anyways).

So this just removes those checks and consistently ignores `err` for the `http.NewRequest` case.