### PR TITLE
correctly use referral for get started off an m.me link

### DIFF
--- a/handlers/facebook/facebook.go
+++ b/handlers/facebook/facebook.go
@@ -261,21 +261,26 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 			data = append(data, courier.NewEventReceiveData(event))
 
 		} else if msg.Postback != nil {
-			// this is a postback
-			eventType := courier.Referral
-			if msg.Postback.Payload == "get_started" {
-				eventType = courier.NewConversation
+			// by default postbacks are treated as new conversations, unless we have referral information
+			eventType := courier.NewConversation
+			if msg.Postback.Referral.Ref != "" {
+				eventType = courier.Referral
 			}
 			event := h.Backend().NewChannelEvent(channel, eventType, urn).WithOccurredOn(date)
 
 			// build our extra
 			extra := map[string]interface{}{
-				titleKey:      msg.Postback.Title,
-				payloadKey:    msg.Postback.Payload,
-				referrerIDKey: msg.Postback.Referral.Ref,
-				sourceKey:     msg.Postback.Referral.Source,
-				typeKey:       msg.Postback.Referral.Type,
+				titleKey:   msg.Postback.Title,
+				payloadKey: msg.Postback.Payload,
 			}
+
+			// add in referral information if we have it
+			if eventType == courier.Referral {
+				extra[referrerIDKey] = msg.Postback.Referral.Ref
+				extra[sourceKey] = msg.Postback.Referral.Source
+				extra[typeKey] = msg.Postback.Referral.Type
+			}
+
 			event = event.WithExtra(extra)
 
 			err := h.Backend().WriteChannelEvent(ctx, event)

--- a/handlers/facebook/facebook_test.go
+++ b/handlers/facebook/facebook_test.go
@@ -175,7 +175,7 @@ var postback = `{
 	}]
 }`
 
-var postbackGetStarted = `{
+var postbackReferral = `{
 	"object":"page",
 	"entry": [{
 	  "id": "208685479508187",
@@ -188,6 +188,27 @@ var postbackGetStarted = `{
 			  "source": "postback source",
 			  "type": "postback type"
 			}
+		},
+		"recipient": {
+		  "id": "1234"
+		},
+		"sender": {
+		  "id": "5678"
+		},
+		"timestamp": 1459991487970
+	  }],
+	  "time": 1459991487970
+	}]
+}`
+
+var postbackGetStarted = `{
+	"object":"page",
+	"entry": [{
+	  "id": "208685479508187",
+	  "messaging": [{
+		"postback": {
+			"title": "postback title",  
+			"payload": "get_started"
 		},
 		"recipient": {
 		  "id": "1234"
@@ -294,11 +315,14 @@ var testCases = []ChannelHandleTestCase{
 		URN: Sp("facebook:5678"), Date: Tp(time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC)),
 		ChannelEvent: Sp(courier.Referral), ChannelEventExtra: map[string]interface{}{"referrer_id": "optin_ref"}},
 
-	{Label: "Receive Postback", URL: "/c/fb/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: postback, Status: 200, Response: "Handled",
+	{Label: "Receive Get Started", URL: "/c/fb/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: postbackGetStarted, Status: 200, Response: "Handled",
+		URN: Sp("facebook:5678"), Date: Tp(time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC)), ChannelEvent: Sp(courier.NewConversation),
+		ChannelEventExtra: map[string]interface{}{"title": "postback title", "payload": "get_started"}},
+	{Label: "Receive Referral Postback", URL: "/c/fb/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: postback, Status: 200, Response: "Handled",
 		URN: Sp("facebook:5678"), Date: Tp(time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC)), ChannelEvent: Sp(courier.Referral),
 		ChannelEventExtra: map[string]interface{}{"title": "postback title", "payload": "postback payload", "referrer_id": "postback ref", "source": "postback source", "type": "postback type"}},
-	{Label: "Receive Postback Get Started", URL: "/c/fb/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: postbackGetStarted, Status: 200, Response: "Handled",
-		URN: Sp("facebook:5678"), Date: Tp(time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC)), ChannelEvent: Sp(courier.NewConversation),
+	{Label: "Receive Referral", URL: "/c/fb/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: postbackReferral, Status: 200, Response: "Handled",
+		URN: Sp("facebook:5678"), Date: Tp(time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC)), ChannelEvent: Sp(courier.Referral),
 		ChannelEventExtra: map[string]interface{}{"title": "postback title", "payload": "get_started", "referrer_id": "postback ref", "source": "postback source", "type": "postback type"}},
 
 	{Label: "Receive Referral", URL: "/c/fb/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: referral, Status: 200, Response: "Handled",


### PR DESCRIPTION
This deals with the case @ycleptkellan  brought up, namely we really have three types of events we have to deal with:

1) "Get Started" postbacks that come in without an referral, this should trigger a `NewConversation` event
2) "Get Started" postbacks that come in with a referral, say if someone clicks a m.me link then "Get Started".. this should be a "Referral" event
3) A straight Referral, these are unchanged and create  "Referral" event

We are basically changing 2 to be a Referral event while before it was a NewConversation