### PR TITLE
FCM Channel fixes

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -103,14 +103,15 @@ func (ts *BackendTestSuite) TestMsgUnmarshal() {
 		"queued_on": null, 
 		"text": "Test message 21", 
 		"contact_id": 30, 
-		"contact_urn_id": 14, 
+		"contact_urn_id": 14,
 		"error_count": 0, 
 		"modified_on": "2017-07-21T19:22:23.254133Z", 
 		"id": 204,
 		"channel_uuid": "f3ad3eb6-d00d-4dc3-92e9-9f34f32940ba", 
 		"uuid": "54c893b9-b026-44fc-a490-50aed0361c3f", 
 		"next_attempt": "2017-07-21T19:22:23.254182Z", 
-		"urn": "telegram:3527065", 
+		"urn": "telegram:3527065",
+		"contact_urn_auth": "5ApPVsFDcFt:RZdK9ne7LgfvBYdtCYg7tv99hC9P2",
 		"org_id": 1, 
 		"created_on": "2017-07-21T19:22:23.242757Z", 
 		"sent_on": null, 
@@ -126,6 +127,7 @@ func (ts *BackendTestSuite) TestMsgUnmarshal() {
 	ts.NoError(err)
 	ts.Equal(msg.ChannelUUID_.String(), "f3ad3eb6-d00d-4dc3-92e9-9f34f32940ba")
 	ts.Equal(msg.ChannelID_, courier.NewChannelID(11))
+	ts.Equal(msg.URNAuth_, "5ApPVsFDcFt:RZdK9ne7LgfvBYdtCYg7tv99hC9P2")
 	ts.Equal([]string{"https://foo.bar/image.jpg"}, msg.Attachments())
 	ts.Equal(msg.ExternalID(), "")
 	ts.Equal([]string{"Yes", "No"}, msg.QuickReplies())

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -111,7 +111,7 @@ func (ts *BackendTestSuite) TestMsgUnmarshal() {
 		"uuid": "54c893b9-b026-44fc-a490-50aed0361c3f", 
 		"next_attempt": "2017-07-21T19:22:23.254182Z", 
 		"urn": "telegram:3527065",
-		"contact_urn_auth": "5ApPVsFDcFt:RZdK9ne7LgfvBYdtCYg7tv99hC9P2",
+		"urn_auth": "5ApPVsFDcFt:RZdK9ne7LgfvBYdtCYg7tv99hC9P2",
 		"org_id": 1, 
 		"created_on": "2017-07-21T19:22:23.242757Z", 
 		"sent_on": null, 

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -235,6 +235,13 @@ func (ts *BackendTestSuite) TestContactURN() {
 	tx, err := ts.b.db.Beginx()
 	ts.NoError(err)
 
+	contact, err = contactForURN(ctx, ts.b, twChannel.OrgID_, twChannel, urn, "chestnut", "")
+	ts.NoError(err)
+
+	contactURNs, err := contactURNsForContact(tx, contact.ID_)
+	ts.NoError(err)
+	ts.Equal("chestnut", contactURNs[0].Auth.String)
+
 	// first build a URN for our number with the kannel channel
 	knURN, err := contactURNForURN(tx, knChannel.OrgID_, knChannel.ID_, contact.ID_, urn, "sesame")
 	ts.NoError(err)

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -83,6 +83,8 @@ func contactForURN(ctx context.Context, b *backend, org OrgID, channel *DBChanne
 			tx.Rollback()
 			return nil, err
 		}
+		// update urn auth if necessary
+		contactURNForURN(tx, org, channel.ID(), contact.ID_, urn, auth)
 		return contact, tx.Commit()
 	}
 

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -84,7 +84,9 @@ func contactForURN(ctx context.Context, b *backend, org OrgID, channel *DBChanne
 			return nil, err
 		}
 		// update urn auth if necessary
-		contactURNForURN(tx, org, channel.ID(), contact.ID_, urn, auth)
+		if auth != "" {
+			contactURNForURN(tx, org, channel.ID(), contact.ID_, urn, auth)
+		}
 		return contact, tx.Commit()
 	}
 

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -374,7 +374,7 @@ type DBMsg struct {
 	Visibility_   MsgVisibility          `json:"visibility"      db:"visibility"`
 	HighPriority_ null.Bool              `json:"high_priority"   db:"high_priority"`
 	URN_          urns.URN               `json:"urn"`
-	URNAuth_      string                 `json:"contact_urn_auth"`
+	URNAuth_      string                 `json:"urn_auth"`
 	Text_         string                 `json:"text"            db:"text"`
 	Attachments_  pq.StringArray         `json:"attachments"     db:"attachments"`
 	ExternalID_   null.String            `json:"external_id"     db:"external_id"`

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -374,7 +374,7 @@ type DBMsg struct {
 	Visibility_   MsgVisibility          `json:"visibility"      db:"visibility"`
 	HighPriority_ null.Bool              `json:"high_priority"   db:"high_priority"`
 	URN_          urns.URN               `json:"urn"`
-	URNAuth_      string                 `json:"urn_auth"`
+	URNAuth_      string                 `json:"contact_urn_auth"`
 	Text_         string                 `json:"text"            db:"text"`
 	Attachments_  pq.StringArray         `json:"attachments"     db:"attachments"`
 	ExternalID_   null.String            `json:"external_id"     db:"external_id"`


### PR DESCRIPTION
This PR includes:

- Fixes contact urn auth when unmarshalling json message from rapidpro backend;
- Updates URN with auth for existing contacts in all the channels, not only for FCM, so please tell me if you have any concern about that. I used this approach after checking some tests (especially [this](https://github.com/nyaruka/courier/blob/master/backends/rapidpro/backend_test.go#L224) one) that the function `contactURNForURN` is called after the update of existing contacts;