### PR TITLE
check for auth changes when making sure URN is default

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -109,7 +109,8 @@ func (ts *BackendTestSuite) TestMsgUnmarshal() {
 		"channel_uuid": "f3ad3eb6-d00d-4dc3-92e9-9f34f32940ba", 
 		"uuid": "54c893b9-b026-44fc-a490-50aed0361c3f", 
 		"next_attempt": "2017-07-21T19:22:23.254182Z", 
-		"urn": "telegram:3527065", 
+		"urn": "telegram:3527065",
+		"urn_auth": "5ApPVsFDcFt:RZdK9ne7LgfvBYdtCYg7tv99hC9P2",
 		"org_id": 1, 
 		"created_on": "2017-07-21T19:22:23.242757Z", 
 		"sent_on": null, 
@@ -127,6 +128,7 @@ func (ts *BackendTestSuite) TestMsgUnmarshal() {
 	ts.Equal(msg.ChannelUUID_.String(), "f3ad3eb6-d00d-4dc3-92e9-9f34f32940ba")
 	ts.Equal(msg.ChannelID_, courier.NewChannelID(11))
 	ts.Equal([]string{"https://foo.bar/image.jpg"}, msg.Attachments())
+	ts.Equal(msg.URNAuth_, "5ApPVsFDcFt:RZdK9ne7LgfvBYdtCYg7tv99hC9P2")
 	ts.Equal(msg.ExternalID(), "")
 	ts.Equal([]string{"Yes", "No"}, msg.QuickReplies())
 	ts.Equal(courier.NewMsgID(15), msg.ResponseToID())
@@ -236,6 +238,13 @@ func (ts *BackendTestSuite) TestContactURN() {
 
 	tx, err := ts.b.db.Beginx()
 	ts.NoError(err)
+
+	contact, err = contactForURN(ctx, ts.b, twChannel.OrgID_, twChannel, urn, "chestnut", "")
+	ts.NoError(err)
+
+	contactURNs, err := contactURNsForContact(tx, contact.ID_)
+	ts.NoError(err)
+	ts.Equal("chestnut", contactURNs[0].Auth.String)
 
 	// first build a URN for our number with the kannel channel
 	knURN, err := contactURNForURN(tx, knChannel.OrgID_, knChannel.ID_, contact.ID_, urn, "sesame")

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -77,7 +77,7 @@ func contactForURN(ctx context.Context, b *backend, org OrgID, channel *DBChanne
 			return nil, err
 		}
 
-		err = setDefaultURN(tx, channel.ID(), contact, urn)
+		err = setDefaultURN(tx, channel.ID(), contact, urn, auth)
 		if err != nil {
 			logrus.WithError(err).WithField("urn", urn.Identity()).WithField("org_id", org).Error("error looking up contact")
 			tx.Rollback()

--- a/backends/rapidpro/urn.go
+++ b/backends/rapidpro/urn.go
@@ -70,7 +70,7 @@ func contactURNsForContact(db *sqlx.Tx, contactID ContactID) ([]*DBContactURN, e
 // that the passed in channel is the default one for that URN
 //
 // Note that the URN must be one of the contact's URN before calling this method
-func setDefaultURN(db *sqlx.Tx, channelID courier.ChannelID, contact *DBContact, urn urns.URN) error {
+func setDefaultURN(db *sqlx.Tx, channelID courier.ChannelID, contact *DBContact, urn urns.URN, auth string) error {
 	scheme := urn.Scheme()
 	contactURNs, err := contactURNsForContact(db, contact.ID_)
 	if err != nil {
@@ -87,10 +87,11 @@ func setDefaultURN(db *sqlx.Tx, channelID courier.ChannelID, contact *DBContact,
 	if contactURNs[0].Identity == urn.Identity() {
 		display := utils.NullStringIfEmpty(urn.Display())
 
-		// if display or channel ids changed, update them
-		if contactURNs[0].Display != display || contactURNs[0].ChannelID != channelID {
+		// if display, channel id or auth changed, update them
+		if contactURNs[0].Display != display || contactURNs[0].ChannelID != channelID || contactURNs[0].Auth.String != auth {
 			contactURNs[0].Display = display
 			contactURNs[0].ChannelID = channelID
+			contactURNs[0].Auth = null.StringFrom(auth)
 			return updateContactURN(db, contactURNs[0])
 		}
 		return nil


### PR DESCRIPTION
replaces #137, @johncordeiro I think this is a bit more efficient approach, as it doesn't require an extra query on every message hit. Give it a look.