### PR TITLE
Fix # of workers when there is error, fix int config reading

### DIFF
--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -99,11 +99,13 @@ func (b *backend) PopNextOutgoingMsg(ctx context.Context) (courier.Msg, error) {
 		dbMsg := &DBMsg{}
 		err = json.Unmarshal([]byte(msgJSON), dbMsg)
 		if err != nil {
+			queue.MarkComplete(rc, msgQueueName, token)
 			return nil, fmt.Errorf("unable to unmarshal message '%s': %s", msgJSON, err)
 		}
 		// populate the channel on our db msg
 		channel, err := b.GetChannel(ctx, courier.AnyChannelType, dbMsg.ChannelUUID_)
 		if err != nil {
+			queue.MarkComplete(rc, msgQueueName, token)
 			return nil, err
 		}
 		dbMsg.channel = channel.(*DBChannel)
@@ -428,9 +430,9 @@ func (b *backend) Start() error {
 
 	// create our s3 client
 	s3Session, err := session.NewSession(&aws.Config{
-		Credentials: credentials.NewStaticCredentials(b.config.AWSAccessKeyID, b.config.AWSSecretAccessKey, ""),
-		Endpoint:    aws.String(b.config.S3Endpoint),
-		Region:      aws.String(b.config.S3Region),
+		Credentials:      credentials.NewStaticCredentials(b.config.AWSAccessKeyID, b.config.AWSSecretAccessKey, ""),
+		Endpoint:         aws.String(b.config.S3Endpoint),
+		Region:           aws.String(b.config.S3Region),
 		DisableSSL:       aws.Bool(b.config.S3DisableSSL),
 		S3ForcePathStyle: aws.Bool(b.config.S3ForcePathStyle),
 	})

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -549,6 +549,21 @@ func (ts *BackendTestSuite) TestChannel() {
 	val = knChannel.ConfigForKey("encoding", "default")
 	ts.Equal("smart", val)
 
+	val = knChannel.StringConfigForKey("encoding", "default")
+	ts.Equal("smart", val)
+
+	val = knChannel.StringConfigForKey("encoding_missing", "default")
+	ts.Equal("default", val)
+
+	val = knChannel.IntConfigForKey("max_length_int", -1)
+	ts.Equal(320, val)
+
+	val = knChannel.IntConfigForKey("max_length_str", -1)
+	ts.Equal(320, val)
+
+	val = knChannel.IntConfigForKey("max_length_missing", -1)
+	ts.Equal(-1, val)
+
 	// missing value
 	val = knChannel.ConfigForKey("missing", "missingValue")
 	ts.Equal("missingValue", val)

--- a/backends/rapidpro/channel.go
+++ b/backends/rapidpro/channel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -218,6 +219,26 @@ func (c *DBChannel) StringConfigForKey(key string, defaultValue string) string {
 		return defaultValue
 	}
 	return str
+}
+
+// IntConfigForKey returns the config value for the passed in key
+func (c *DBChannel) IntConfigForKey(key string, defaultValue int) int {
+	val := c.ConfigForKey(key, defaultValue)
+
+	// golang unmarshals number literals in JSON into float64s by default
+	i, isFloat := val.(float64)
+	if isFloat {
+		return int(i)
+	}
+
+	str, isStr := val.(string)
+	if isStr {
+		i, err := strconv.Atoi(str)
+		if err == nil {
+			return i
+		}
+	}
+	return defaultValue
 }
 
 // supportsScheme returns whether the passed in channel supports the passed in scheme

--- a/backends/rapidpro/testdata.sql
+++ b/backends/rapidpro/testdata.sql
@@ -6,7 +6,7 @@ INSERT INTO orgs_org("id", "name", "language", "is_anon", "config")
 /* Channel with id 10, 11, 12 */
 DELETE FROM channels_channel;
 INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "config")
-                      VALUES('10', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c95d', 'KN', '2500', 1, 'RW', '{ "encoding": "smart", "use_national": true }');
+                      VALUES('10', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c95d', 'KN', '2500', 1, 'RW', '{ "encoding": "smart", "use_national": true, "max_length_int": 320, "max_length_str": "320" }');
 
 INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "config")
                       VALUES('11', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c96a', 'TW', '4500', 1, 'US', NULL);

--- a/channel.go
+++ b/channel.go
@@ -117,5 +117,6 @@ type Channel interface {
 
 	ConfigForKey(key string, defaultValue interface{}) interface{}
 	StringConfigForKey(key string, defaultValue string) string
+	IntConfigForKey(key string, defaultValue int) int
 	OrgConfigForKey(key string, defaultValue interface{}) interface{}
 }

--- a/handlers/external/external.go
+++ b/handlers/external/external.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"time"
 
 	"strings"
@@ -164,12 +163,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 	sendBody := msg.Channel().StringConfigForKey(courier.ConfigSendBody, "")
 	contentType := msg.Channel().StringConfigForKey(courier.ConfigContentType, contentURLEncoded)
 
-	maxLengthStr := msg.Channel().StringConfigForKey(courier.ConfigMaxLength, "160")
-	maxLength, err := strconv.Atoi(maxLengthStr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid value for max length on EX channel %s: %s", msg.Channel().UUID(), maxLengthStr)
-	}
-
+	maxLength := msg.Channel().IntConfigForKey(courier.ConfigMaxLength, 160)
 	status := h.Backend().NewMsgStatusForID(msg.Channel(), msg.ID(), courier.MsgErrored)
 	parts := handlers.SplitMsg(handlers.GetTextAndAttachments(msg), maxLength)
 	for _, part := range parts {

--- a/handlers/external/external_test.go
+++ b/handlers/external/external_test.go
@@ -75,6 +75,15 @@ func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel,
 	c.(*courier.MockChannel).SetConfig(courier.ConfigSendURL, sendURL)
 }
 
+var longSendTestCases = []ChannelSendTestCase{
+	{Label: "Long Send",
+		Text: "This is a long message that will be longer than 30....... characters", URN: "tel:+250788383383",
+		Status:       "W",
+		ResponseBody: "0: Accepted for delivery", ResponseStatus: 200,
+		URLParams: map[string]string{"text": "characters", "to": "+250788383383", "from": "2020"},
+		SendPrep:  setSendURL},
+}
+
 var getSendTestCases = []ChannelSendTestCase{
 	{Label: "Plain Send",
 		Text: "Simple Message", URN: "tel:+250788383383",
@@ -220,4 +229,19 @@ func TestSending(t *testing.T) {
 	RunChannelSendTestCases(t, postChannel, newHandler(), postSendTestCases, nil)
 	RunChannelSendTestCases(t, jsonChannel, newHandler(), jsonSendTestCases, nil)
 	RunChannelSendTestCases(t, xmlChannel, newHandler(), xmlSendTestCases, nil)
+
+	var getChannel30IntLength = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "KN", "2020", "US",
+		map[string]interface{}{
+			"max_length":             30,
+			"send_path":              "?to={{to}}&text={{text}}&from={{from}}",
+			courier.ConfigSendMethod: http.MethodGet})
+
+	var getChannel30StrLength = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "KN", "2020", "US",
+		map[string]interface{}{
+			"max_length":             "30",
+			"send_path":              "?to={{to}}&text={{text}}&from={{from}}",
+			courier.ConfigSendMethod: http.MethodGet})
+
+	RunChannelSendTestCases(t, getChannel30IntLength, newHandler(), longSendTestCases, nil)
+	RunChannelSendTestCases(t, getChannel30StrLength, newHandler(), longSendTestCases, nil)
 }

--- a/test.go
+++ b/test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	"github.com/satori/go.uuid"
@@ -365,6 +366,24 @@ func (c *MockChannel) StringConfigForKey(key string, defaultValue string) string
 		return defaultValue
 	}
 	return str
+}
+
+// IntConfigForKey returns the config value for the passed in key
+func (c *MockChannel) IntConfigForKey(key string, defaultValue int) int {
+	val := c.ConfigForKey(key, defaultValue)
+	i, isInt := val.(int)
+	if isInt {
+		return i
+	}
+
+	str, isStr := val.(string)
+	if isStr {
+		i, err := strconv.Atoi(str)
+		if err == nil {
+			return i
+		}
+	}
+	return defaultValue
 }
 
 // OrgConfigForKey returns the org config value for the passed in key

--- a/test.go
+++ b/test.go
@@ -371,9 +371,11 @@ func (c *MockChannel) StringConfigForKey(key string, defaultValue string) string
 // IntConfigForKey returns the config value for the passed in key
 func (c *MockChannel) IntConfigForKey(key string, defaultValue int) int {
 	val := c.ConfigForKey(key, defaultValue)
-	i, isInt := val.(int)
-	if isInt {
-		return i
+
+	// golang unmarshals number literals in JSON into float64s by default
+	i, isFloat := val.(float64)
+	if isFloat {
+		return int(i)
 	}
 
 	str, isStr := val.(string)


### PR DESCRIPTION
Two little issues:
 1) if we fail to grab a channel when popping a message off to send, we weren't marking that task as complete, this was horking our status dashboard for how many workers we had assigned to that channel

 2) we weren't dealing with int config values properly so were ignoring max length for external channels. Added a `GetIntConfig` that makes that easier for callers. 