### PR TITLE
always report stops as stop channel events

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -66,9 +66,6 @@ type Backend interface {
 	// used to determine any sort of deduping of msg sends
 	MarkOutgoingMsgComplete(context.Context, Msg, MsgStatus)
 
-	// StopMsgContact marks the contact for the passed in msg as stopped
-	StopMsgContact(context.Context, Msg)
-
 	// Health returns a string describing any health problems the backend has, or empty string if all is well
 	Health() string
 

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -168,15 +168,6 @@ func (b *backend) MarkOutgoingMsgComplete(ctx context.Context, msg courier.Msg, 
 	}
 }
 
-// StopMsgContact marks the contact for the passed in msg as stopped, that is they no longer want to receive messages
-func (b *backend) StopMsgContact(ctx context.Context, m courier.Msg) {
-	rc := b.redisPool.Get()
-	defer rc.Close()
-
-	dbMsg := m.(*DBMsg)
-	queueStopContact(rc, dbMsg.OrgID_, dbMsg.ContactID_)
-}
-
 // WriteMsg writes the passed in message to our store
 func (b *backend) WriteMsg(ctx context.Context, m courier.Msg) error {
 	timeout, cancel := context.WithTimeout(ctx, backendTimeout)

--- a/backends/rapidpro/task.go
+++ b/backends/rapidpro/task.go
@@ -45,15 +45,6 @@ func queueMsgHandling(rc redis.Conn, orgID OrgID, contactID ContactID, msgID cou
 	return queueTask(rc, "handler", "handle_event_task", orgID, fmt.Sprintf("ch:%d", contactID.Int64), body)
 }
 
-func queueStopContact(rc redis.Conn, orgID OrgID, contactID ContactID) error {
-	body := map[string]interface{}{
-		"type":       "stop_contact",
-		"contact_id": contactID.Int64,
-	}
-
-	return queueTask(rc, "handler", "handle_event_task", orgID, "", body)
-}
-
 func queueChannelEvent(rc redis.Conn, orgID OrgID, contactID ContactID, eventID ChannelEventID) error {
 	body := map[string]interface{}{
 		"type":       "channel_event",

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -282,7 +282,9 @@ func RunChannelSendTestCases(t *testing.T, channel courier.Channel, handler cour
 			}
 
 			if testCase.Stopped {
-				require.Equal(msg, mb.GetLastStoppedMsgContact())
+				evt, err := mb.GetLastChannelEvent()
+				require.NoError(err)
+				require.Equal(courier.StopContact, evt.EventType())
 			}
 		})
 	}

--- a/handlers/twilio/twilio.go
+++ b/handlers/twilio/twilio.go
@@ -237,7 +237,13 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			if errorCode != 0 {
 				if errorCode == errorStopped {
 					status.SetStatus(courier.MsgFailed)
-					h.Backend().StopMsgContact(ctx, msg)
+
+					// create a stop channel event
+					channelEvent := h.Backend().NewChannelEvent(msg.Channel(), courier.StopContact, msg.URN())
+					err = h.Backend().WriteChannelEvent(ctx, channelEvent)
+					if err != nil {
+						return nil, err
+					}
 				}
 				log.WithError("Message Send Error", errors.Errorf("received error code from twilio '%d'", errorCode))
 				return status, nil

--- a/handlers/yo/yo.go
+++ b/handlers/yo/yo.go
@@ -142,7 +142,14 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			createMessage, _ := responseQS["ybs_autocreate_message"]
 			if len(createMessage) > 0 && strings.Contains(createMessage[0], "BLACKLISTED") {
 				status.SetStatus(courier.MsgFailed)
-				h.Backend().StopMsgContact(ctx, msg)
+
+				// create a stop channel event
+				channelEvent := h.Backend().NewChannelEvent(msg.Channel(), courier.StopContact, msg.URN())
+				err = h.Backend().WriteChannelEvent(ctx, channelEvent)
+				if err != nil {
+					return nil, err
+				}
+
 				return status, nil
 			}
 

--- a/test.go
+++ b/test.go
@@ -34,9 +34,8 @@ type MockBackend struct {
 	channelEvents   []ChannelEvent
 	lastContactName string
 
-	stoppedMsgContacts []Msg
-	sentMsgs           map[MsgID]bool
-	redisPool          *redis.Pool
+	sentMsgs  map[MsgID]bool
+	redisPool *redis.Pool
 }
 
 // NewMockBackend returns a new mock backend suitable for testing
@@ -143,19 +142,6 @@ func (mb *MockBackend) WasMsgSent(ctx context.Context, msg Msg) (bool, error) {
 	defer mb.mutex.Unlock()
 
 	return mb.sentMsgs[msg.ID()], nil
-}
-
-// StopMsgContact stops the contact for the passed in msg
-func (mb *MockBackend) StopMsgContact(ctx context.Context, msg Msg) {
-	mb.stoppedMsgContacts = append(mb.stoppedMsgContacts, msg)
-}
-
-// GetLastStoppedMsgContact returns the last msg contact
-func (mb *MockBackend) GetLastStoppedMsgContact() Msg {
-	if len(mb.stoppedMsgContacts) > 0 {
-		return mb.stoppedMsgContacts[len(mb.stoppedMsgContacts)-1]
-	}
-	return nil
 }
 
 // MarkOutgoingMsgComplete marks the passed msg as having been dealt with


### PR DESCRIPTION
We had two ways to do it before, a custom stop event and a channel event with type stop, this just unifies the two.