### PR TITLE
Changed Zenvia API endpoint

### DIFF
--- a/handlers/zenvia/zenvia.go
+++ b/handlers/zenvia/zenvia.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	maxMsgLength = 1152
-	sendURL      = "https://api-rest.zenvia360.com.br/services/send-sms"
+	sendURL      = "https://api-rest.zenvia.com/services/send-sms"
 )
 
 func init() {


### PR DESCRIPTION
Recently Zenvia changed your API endpoint.

Zenvia doc: https://zenviasmsenus.docs.apiary.io/#reference/api-services/sending-a-single-sms/sending-a-single-sms
New endpoint: https://api-rest.zenvia.com/services

Now only HTTPS (TLS v1.2) protocol is allowed.