### PR TITLE
Don't save duplicate messages sent by the WA business API

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -50,6 +50,9 @@ type Backend interface {
 	// WriteMsgStatus writes the passed in status update to our backend
 	WriteMsgStatus(context.Context, MsgStatus) error
 
+	// CheckMsgExternalIDExistsInDB checks if a message exists with the given external ID
+	CheckMsgExternalIDExistsInDB(string) (int, error)
+
 	// NewChannelEvent creates a new channel event for the given channel and event type
 	NewChannelEvent(Channel, ChannelEventType, urns.URN) ChannelEvent
 

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -269,6 +269,11 @@ func (b *backend) WriteMsgStatus(ctx context.Context, status courier.MsgStatus) 
 	return nil
 }
 
+// CheckMsgExternalIDExistsInDB checks if a message exists with the given external ID
+func (b *backend) CheckMsgExternalIDExistsInDB(externalID string) (int, error) {
+	return checkMsgExternalIDExistsInDB(b, externalID)
+}
+
 // NewChannelEvent creates a new channel event with the passed in parameters
 func (b *backend) NewChannelEvent(channel courier.Channel, eventType courier.ChannelEventType, urn urns.URN) courier.ChannelEvent {
 	return newChannelEvent(channel, eventType, urn)

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -117,7 +117,7 @@ func newMsg(direction MsgDirection, channel courier.Channel, urn urns.URN, text 
 }
 
 const insertMsgSQL = `
-INSERT INTO 
+INSERT INTO
 	msgs_msg(org_id, uuid, direction, text, attachments, msg_count, error_count, high_priority, status,
              visibility, external_id, channel_id, contact_id, contact_urn_id, created_on, modified_on, next_attempt, queued_on, sent_on)
     VALUES(:org_id, :uuid, :direction, :text, :attachments, :msg_count, :error_count, :high_priority, :status,
@@ -165,28 +165,28 @@ func writeMsgToDB(ctx context.Context, b *backend, m *DBMsg) error {
 }
 
 const selectMsgSQL = `
-SELECT 
-	org_id, 
-	direction, 
-	text, 
-	attachments, 
-	msg_count, 
-	error_count, 
-	high_priority, 
+SELECT
+	org_id,
+	direction,
+	text,
+	attachments,
+	msg_count,
+	error_count,
+	high_priority,
 	status,
-	visibility, 
-	external_id, 
-	channel_id, 
-	contact_id, 
-	contact_urn_id, 
-	created_on, 
-	modified_on, 
-	next_attempt, 
-	queued_on, 
+	visibility,
+	external_id,
+	channel_id,
+	contact_id,
+	contact_urn_id,
+	created_on,
+	modified_on,
+	next_attempt,
+	queued_on,
 	sent_on
-FROM 
+FROM
 	msgs_msg
-WHERE 
+WHERE
 	id = $1
 `
 
@@ -197,6 +197,21 @@ func readMsgFromDB(b *backend, id courier.MsgID) (*DBMsg, error) {
 	}
 	err := b.db.Get(m, selectMsgSQL, id)
 	return m, err
+}
+
+const checkExternalIDExistsSQL = `
+SELECT
+	count(*)
+FROM
+	msgs_msg
+WHERE
+    external_id = $1
+`
+
+func checkMsgExternalIDExistsInDB(b *backend, externalID string) (int, error) {
+	count := 0
+	err := b.db.Get(&count, checkExternalIDExistsSQL, null.StringFrom(externalID))
+	return count, err
 }
 
 //-----------------------------------------------------------------------------

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -134,6 +134,12 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 	// first deal with any received messages
 	for _, msg := range payload.Messages {
 
+		// check if we have this message already
+		count, err := h.Backend().CheckMsgExternalIDExistsInDB(msg.ID)
+		if count > 0 {
+			continue
+		}
+
 		// create our date from the timestamp
 		ts, err := strconv.ParseInt(msg.Timestamp, 10, 64)
 		if err != nil {

--- a/handlers/whatsapp/whatsapp_test.go
+++ b/handlers/whatsapp/whatsapp_test.go
@@ -39,6 +39,26 @@ var helloMsg = `{
   }]
 }`
 
+var duplicateMsg = `{
+	"messages": [{
+	  "from": "250788123123",
+	  "id": "41",
+	  "timestamp": "1454119029",
+	  "text": {
+		"body": "hello world"
+	  },
+	  "type": "text"
+	}, {
+	  "from": "250788123123",
+	  "id": "41",
+	  "timestamp": "1454119029",
+	  "text": {
+		"body": "hello world"
+	  },
+	  "type": "text"
+	}]
+  }`
+
 var audioMsg = `{
 	"messages": [{
 		"from": "250788123123",
@@ -186,6 +206,8 @@ var invalidStatus = `
 `
 var testCases = []ChannelHandleTestCase{
 	{Label: "Receive Valid Message", URL: "/c/wa/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: helloMsg, Status: 200, Response: `"type":"msg"`,
+		Text: Sp("hello world"), URN: Sp("whatsapp:250788123123"), ExternalID: Sp("41"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC))},
+	{Label: "Receive Duplicate Valid Message", URL: "/c/wa/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: duplicateMsg, Status: 200, Response: `"type":"msg"`,
 		Text: Sp("hello world"), URN: Sp("whatsapp:250788123123"), ExternalID: Sp("41"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC))},
 	{Label: "Receive Valid Audio Message", URL: "/c/wa/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: audioMsg, Status: 200, Response: `"type":"msg"`,
 		Text: Sp(""), Attachment: Sp("https://foo.bar/v1/media/41"), URN: Sp("whatsapp:250788123123"), ExternalID: Sp("41"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC))},

--- a/test.go
+++ b/test.go
@@ -201,6 +201,11 @@ func (mb *MockBackend) WriteMsgStatus(ctx context.Context, status MsgStatus) err
 	return nil
 }
 
+// CheckMsgExternalIDExistsInDB returns the length of the queue
+func (mb *MockBackend) CheckMsgExternalIDExistsInDB(externalID string) (int, error) {
+	return mb.LenQueuedMsgs(), nil
+}
+
 // NewChannelEvent creates a new channel event with the passed in parameters
 func (mb *MockBackend) NewChannelEvent(channel Channel, eventType ChannelEventType, urn urns.URN) ChannelEvent {
 	return &mockChannelEvent{


### PR DESCRIPTION
We've had a few cases where the WA business API sends us the same message more than once.

The flows in Rapidpro responds to both messages which is not a desirable outcome for us.

This PR will check if the message was already saved and ignore it if it was.