### PR TITLE
Deduplicate WA messages on external ID

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -73,10 +73,10 @@ type Backend interface {
 	MarkOutgoingMsgComplete(context.Context, Msg, MsgStatus)
 
 	// Check if external ID has been seen in a period
-	CheckExternalIDSeen(string) bool
+	CheckExternalIDSeen(Msg) Msg
 
 	// Mark a external ID as seen for a period
-	WriteExternalIDSeen(string)
+	WriteExternalIDSeen(Msg)
 
 	// Health returns a string describing any health problems the backend has, or empty string if all is well
 	Health() string

--- a/backend.go
+++ b/backend.go
@@ -72,6 +72,12 @@ type Backend interface {
 	// used to determine any sort of deduping of msg sends
 	MarkOutgoingMsgComplete(context.Context, Msg, MsgStatus)
 
+	// Check if external ID has been seen in a period
+	CheckExternalIDSeen(string) bool
+
+	// Mark a external ID as seen for a period
+	WriteExternalIDSeen(string)
+
 	// Health returns a string describing any health problems the backend has, or empty string if all is well
 	Health() string
 

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -296,6 +296,16 @@ func (b *backend) WriteChannelLogs(ctx context.Context, logs []*courier.ChannelL
 	return nil
 }
 
+// Check if external ID has been seen in a period
+func (b *backend) CheckExternalIDSeen(externalID string) bool {
+	return checkExternalIDSeen(b, externalID)
+}
+
+// Mark a external ID as seen for a period
+func (b *backend) WriteExternalIDSeen(externalID string) {
+	writeExternalIDSeen(b, externalID)
+}
+
 // Health returns the health of this backend as a string, returning "" if all is well
 func (b *backend) Health() string {
 	// test redis

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -297,13 +297,20 @@ func (b *backend) WriteChannelLogs(ctx context.Context, logs []*courier.ChannelL
 }
 
 // Check if external ID has been seen in a period
-func (b *backend) CheckExternalIDSeen(externalID string) bool {
-	return checkExternalIDSeen(b, externalID)
+func (b *backend) CheckExternalIDSeen(msg courier.Msg) courier.Msg {
+	var prevUUID = checkExternalIDSeen(b, msg)
+	m := msg.(*DBMsg)
+	if prevUUID != courier.NilMsgUUID {
+		// if so, use its UUID and that we've been written
+		m.UUID_ = prevUUID
+		m.alreadyWritten = true
+	}
+	return m
 }
 
 // Mark a external ID as seen for a period
-func (b *backend) WriteExternalIDSeen(externalID string) {
-	writeExternalIDSeen(b, externalID)
+func (b *backend) WriteExternalIDSeen(msg courier.Msg) {
+	writeExternalIDSeen(b, msg)
 }
 
 // Health returns the health of this backend as a string, returning "" if all is well

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -97,27 +97,27 @@ func (ts *BackendTestSuite) getChannel(cType string, cUUID string) *DBChannel {
 
 func (ts *BackendTestSuite) TestMsgUnmarshal() {
 	msgJSON := `{
-		"status": "P", 
-		"direction": "O", 
-		"attachments": ["https://foo.bar/image.jpg"], 
-		"queued_on": null, 
-		"text": "Test message 21", 
-		"contact_id": 30, 
-		"contact_urn_id": 14, 
-		"error_count": 0, 
-		"modified_on": "2017-07-21T19:22:23.254133Z", 
+		"status": "P",
+		"direction": "O",
+		"attachments": ["https://foo.bar/image.jpg"],
+		"queued_on": null,
+		"text": "Test message 21",
+		"contact_id": 30,
+		"contact_urn_id": 14,
+		"error_count": 0,
+		"modified_on": "2017-07-21T19:22:23.254133Z",
 		"id": 204,
-		"channel_uuid": "f3ad3eb6-d00d-4dc3-92e9-9f34f32940ba", 
-		"uuid": "54c893b9-b026-44fc-a490-50aed0361c3f", 
-		"next_attempt": "2017-07-21T19:22:23.254182Z", 
+		"channel_uuid": "f3ad3eb6-d00d-4dc3-92e9-9f34f32940ba",
+		"uuid": "54c893b9-b026-44fc-a490-50aed0361c3f",
+		"next_attempt": "2017-07-21T19:22:23.254182Z",
 		"urn": "telegram:3527065",
 		"urn_auth": "5ApPVsFDcFt:RZdK9ne7LgfvBYdtCYg7tv99hC9P2",
-		"org_id": 1, 
-		"created_on": "2017-07-21T19:22:23.242757Z", 
-		"sent_on": null, 
+		"org_id": 1,
+		"created_on": "2017-07-21T19:22:23.242757Z",
+		"sent_on": null,
 		"high_priority": true,
-		"channel_id": 11, 
-		"response_to_id": 15, 
+		"channel_id": 11,
+		"response_to_id": 15,
 		"response_to_external_id": "external-id",
 		"external_id": null,
 		"metadata": {"quick_replies": ["Yes", "No"]}
@@ -137,26 +137,26 @@ func (ts *BackendTestSuite) TestMsgUnmarshal() {
 	ts.True(msg.HighPriority())
 
 	msgJSONNoQR := `{
-		"status": "P", 
-		"direction": "O", 
-		"attachments": ["https://foo.bar/image.jpg"], 
-		"queued_on": null, 
-		"text": "Test message 21", 
-		"contact_id": 30, 
-		"contact_urn_id": 14, 
-		"error_count": 0, 
-		"modified_on": "2017-07-21T19:22:23.254133Z", 
+		"status": "P",
+		"direction": "O",
+		"attachments": ["https://foo.bar/image.jpg"],
+		"queued_on": null,
+		"text": "Test message 21",
+		"contact_id": 30,
+		"contact_urn_id": 14,
+		"error_count": 0,
+		"modified_on": "2017-07-21T19:22:23.254133Z",
 		"id": 204,
-		"channel_uuid": "f3ad3eb6-d00d-4dc3-92e9-9f34f32940ba", 
-		"uuid": "54c893b9-b026-44fc-a490-50aed0361c3f", 
-		"next_attempt": "2017-07-21T19:22:23.254182Z", 
-		"urn": "telegram:3527065", 
-		"org_id": 1, 
-		"created_on": "2017-07-21T19:22:23.242757Z", 
-		"sent_on": null, 
+		"channel_uuid": "f3ad3eb6-d00d-4dc3-92e9-9f34f32940ba",
+		"uuid": "54c893b9-b026-44fc-a490-50aed0361c3f",
+		"next_attempt": "2017-07-21T19:22:23.254182Z",
+		"urn": "telegram:3527065",
+		"org_id": 1,
+		"created_on": "2017-07-21T19:22:23.242757Z",
+		"sent_on": null,
 		"high_priority": true,
-		"channel_id": 11, 
-		"response_to_id": null, 
+		"channel_id": 11,
+		"response_to_id": null,
 		"response_to_external_id": "",
 		"external_id": null,
 		"metadata": null
@@ -582,6 +582,22 @@ func (ts *BackendTestSuite) TestDupes() {
 	ts.NoError(err)
 
 	ts.NotEqual(uuid2, msg.UUID().String())
+}
+
+func (ts *BackendTestSuite) TestExternalIDDupes() {
+	r := ts.b.redisPool.Get()
+	defer r.Close()
+
+	var seen = ts.b.CheckExternalIDSeen("ext123")
+	ts.False(seen)
+
+	ts.b.WriteExternalIDSeen("ext123")
+
+	seen = ts.b.CheckExternalIDSeen("ext123")
+	ts.True(seen)
+
+	seen = ts.b.CheckExternalIDSeen("ext222")
+	ts.False(seen)
 }
 
 func (ts *BackendTestSuite) TestStatus() {

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -588,16 +588,20 @@ func (ts *BackendTestSuite) TestExternalIDDupes() {
 	r := ts.b.redisPool.Get()
 	defer r.Close()
 
-	var seen = ts.b.CheckExternalIDSeen("ext123")
-	ts.False(seen)
+	knChannel := ts.getChannel("KN", "dbc126ed-66bc-4e28-b67b-81dc3327c95d")
+	urn, _ := urns.NewTelURNForCountry("12065551215", knChannel.Country())
 
-	ts.b.WriteExternalIDSeen("ext123")
+	msg := newMsg(MsgIncoming, knChannel, urn, "ping")
 
-	seen = ts.b.CheckExternalIDSeen("ext123")
-	ts.True(seen)
+	var checkedMsg = ts.b.CheckExternalIDSeen(msg)
+	m := checkedMsg.(*DBMsg)
+	ts.False(m.alreadyWritten)
 
-	seen = ts.b.CheckExternalIDSeen("ext222")
-	ts.False(seen)
+	ts.b.WriteExternalIDSeen(msg)
+
+	checkedMsg = ts.b.CheckExternalIDSeen(msg)
+	m2 := checkedMsg.(*DBMsg)
+	ts.True(m2.alreadyWritten)
 }
 
 func (ts *BackendTestSuite) TestStatus() {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 ignore:
   - "vendor/.*"
+  - "**/*test.go"

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -333,6 +333,7 @@ func RunChannelTestCases(t *testing.T, channels []courier.Channel, handler couri
 			require := require.New(t)
 
 			mb.ClearQueueMsgs()
+			mb.ClearSeenExternalIDs()
 
 			testHandlerRequest(t, s, testCase.URL, testCase.Headers, testCase.Data, testCase.Status, &testCase.Response, testCase.PrepRequest)
 
@@ -437,6 +438,7 @@ func RunChannelBenchmarks(b *testing.B, channels []courier.Channel, handler cour
 
 	for _, testCase := range testCases {
 		mb.ClearQueueMsgs()
+		mb.ClearSeenExternalIDs()
 
 		b.Run(testCase.Label, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -134,6 +134,13 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 	// first deal with any received messages
 	for _, msg := range payload.Messages {
 
+		if msg.ID != "" {
+			seen := h.Backend().CheckExternalIDSeen(msg.ID)
+			if seen {
+				continue
+			}
+		}
+
 		// create our date from the timestamp
 		ts, err := strconv.ParseInt(msg.Timestamp, 10, 64)
 		if err != nil {
@@ -187,6 +194,8 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 		if err != nil {
 			return nil, err
 		}
+
+		h.Backend().WriteExternalIDSeen(msg.ID)
 
 		events = append(events, event)
 		data = append(data, courier.NewMsgReceiveData(event))

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -133,14 +133,6 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 
 	// first deal with any received messages
 	for _, msg := range payload.Messages {
-
-		if msg.ID != "" {
-			seen := h.Backend().CheckExternalIDSeen(msg.ID)
-			if seen {
-				continue
-			}
-		}
-
 		// create our date from the timestamp
 		ts, err := strconv.ParseInt(msg.Timestamp, 10, 64)
 		if err != nil {
@@ -179,7 +171,8 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 		}
 
 		// create our message
-		event := h.Backend().NewIncomingMsg(channel, urn, text).WithReceivedOn(date).WithExternalID(msg.ID)
+		ev := h.Backend().NewIncomingMsg(channel, urn, text).WithReceivedOn(date).WithExternalID(msg.ID)
+		event := h.Backend().CheckExternalIDSeen(ev)
 
 		// we had an error downloading media
 		if err != nil {
@@ -195,7 +188,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 			return nil, err
 		}
 
-		h.Backend().WriteExternalIDSeen(msg.ID)
+		h.Backend().WriteExternalIDSeen(event)
 
 		events = append(events, event)
 		data = append(data, courier.NewMsgReceiveData(event))

--- a/handlers/whatsapp/whatsapp_test.go
+++ b/handlers/whatsapp/whatsapp_test.go
@@ -39,6 +39,26 @@ var helloMsg = `{
   }]
 }`
 
+var duplicateMsg = `{
+	"messages": [{
+	  "from": "250788123123",
+	  "id": "41",
+	  "timestamp": "1454119029",
+	  "text": {
+		"body": "hello world"
+	  },
+	  "type": "text"
+	}, {
+	  "from": "250788123123",
+	  "id": "41",
+	  "timestamp": "1454119029",
+	  "text": {
+		"body": "hello world"
+	  },
+	  "type": "text"
+	}]
+  }`
+
 var audioMsg = `{
 	"messages": [{
 		"from": "250788123123",
@@ -186,6 +206,8 @@ var invalidStatus = `
 `
 var testCases = []ChannelHandleTestCase{
 	{Label: "Receive Valid Message", URL: "/c/wa/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: helloMsg, Status: 200, Response: `"type":"msg"`,
+		Text: Sp("hello world"), URN: Sp("whatsapp:250788123123"), ExternalID: Sp("41"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC))},
+	{Label: "Receive Duplicate Valid Message", URL: "/c/wa/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: duplicateMsg, Status: 200, Response: `"type":"msg"`,
 		Text: Sp("hello world"), URN: Sp("whatsapp:250788123123"), ExternalID: Sp("41"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC))},
 	{Label: "Receive Valid Audio Message", URL: "/c/wa/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive", Data: audioMsg, Status: 200, Response: `"type":"msg"`,
 		Text: Sp(""), Attachment: Sp("https://foo.bar/v1/media/41"), URN: Sp("whatsapp:250788123123"), ExternalID: Sp("41"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC))},

--- a/test.go
+++ b/test.go
@@ -35,6 +35,8 @@ type MockBackend struct {
 
 	sentMsgs  map[MsgID]bool
 	redisPool *redis.Pool
+
+	seenExternalIDs []string
 }
 
 // NewMockBackend returns a new mock backend suitable for testing
@@ -279,9 +281,29 @@ func (mb *MockBackend) ClearQueueMsgs() {
 	mb.queueMsgs = nil
 }
 
+// ClearSeenExternalIDs clears our mock seen external ids
+func (mb *MockBackend) ClearSeenExternalIDs() {
+	mb.seenExternalIDs = nil
+}
+
 // LenQueuedMsgs Get the length of queued msgs
 func (mb *MockBackend) LenQueuedMsgs() int {
 	return len(mb.queueMsgs)
+}
+
+// CheckExternalIDSeen checks if external ID has been seen in a period
+func (mb *MockBackend) CheckExternalIDSeen(external_id string) bool {
+	for _, b := range mb.seenExternalIDs {
+		if b == external_id {
+			return true
+		}
+	}
+	return false
+}
+
+// WriteExternalIDSeen marks a external ID as seen for a period
+func (mb *MockBackend) WriteExternalIDSeen(external_id string) {
+	mb.seenExternalIDs = append(mb.seenExternalIDs, external_id)
 }
 
 // Health gives a string representing our health, empty for our mock


### PR DESCRIPTION
We've had a few cases where the WA business API sends us the same message more than once.

The flows in Rapidpro responds to both messages which is not a desirable outcome for us.

This PR will deduplicate messages based on the external ID on the WA channel.