### PR TITLE
handle deleted message from WhatsApp

### DIFF
--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -255,6 +255,7 @@ var waStatusMapping = map[string]courier.MsgStatusValue{
 	"sent":      courier.MsgSent,
 	"delivered": courier.MsgDelivered,
 	"read":      courier.MsgDelivered,
+	"deleted":   courier.MsgDelivered,
 	"failed":    courier.MsgFailed,
 }
 


### PR DESCRIPTION
WhatsApp sends a message status update when the message is deleted. Currently, this throws the following error `*pq.Error: Incoming messages can only be PENDING or HANDLED`

I've set the message status to `courier.MsgDelivered`. I'm not sure if this is the ideal configuration, as from my understanding, RapidPro doesn't have the concept of a deleted message for status, but that there is for message visibility in [msg.go](https://github.com/nyaruka/courier/blob/master/backends/rapidpro/msg.go#L48). 
Should I be approaching this differently?
