### PR TITLE
Add video support for WhatsApp

### DIFF
--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -288,8 +288,8 @@ var waIgnoreStatuses = map[string]bool{
 //     "id": "the-image-id"
 //     "caption": "the optional image caption"
 // 	 }
-//   "video": {
-//	   "id": "the-video-id",
+//	 "video": {
+//     "id": "the-video-id"
 //     "caption": "the optional video caption"
 //   }
 // }

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -288,6 +288,10 @@ var waIgnoreStatuses = map[string]bool{
 //     "id": "the-image-id"
 //     "caption": "the optional image caption"
 // 	 }
+//   "video": {
+//	   "id": "the-video-id",
+//     "caption": "the optional video caption"
+//   }
 // }
 
 type mtTextPayload struct {
@@ -341,6 +345,12 @@ type mtImagePayload struct {
 	To    string                `json:"to"    validate:"required"`
 	Type  string                `json:"type"  validate:"required"`
 	Image *captionedMediaObject `json:"image"`
+}
+
+type mtVideoPayload struct {
+	To    string                `json:"to" validate: "required"`
+	Type  string                `json:"type" validate: "required"`
+	Video *captionedMediaObject `json:"video"`
 }
 
 // whatsapp only allows messages up to 4096 chars
@@ -415,7 +425,17 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 					payload.Image = &captionedMediaObject{ID: mediaID}
 				}
 				externalID, log, err = sendWhatsAppMsg(msg, sendURL, token, payload)
-
+			} else if strings.HasPrefix(mimeType, "video") {
+				payload := mtVideoPayload{
+					To:   msg.URN().Path(),
+					Type: "video",
+				}
+				if attachmentCount == 0 {
+					payload.Video = &captionedMediaObject{ID: mediaID, Caption: msg.Text()}
+				} else {
+					payload.Video = &captionedMediaObject{ID: mediaID}
+				}
+				externalID, log, err = sendWhatsAppMsg(msg, sendURL, token, payload)
 			} else {
 				duration := time.Since(start)
 				err = fmt.Errorf("unknown attachment mime type: %s", mimeType)

--- a/handlers/whatsapp/whatsapp_test.go
+++ b/handlers/whatsapp/whatsapp_test.go
@@ -389,6 +389,31 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		},
 		SendPrep: setSendURL,
 	},
+	{Label: "Video Send",
+		Text:   "video caption",
+		URN:    "whatsapp:250788123123",
+		Status: "W", ExternalID: "157b5e14568e8",
+		Attachments: []string{"video/mp4:https://foo.bar/video.mp4"},
+		Responses: map[MockedRequest]MockedResponse{
+			MockedRequest{
+				Method: "POST",
+				Path:   "/v1/media",
+				Body:   "media body",
+			}: MockedResponse{
+				Status: 201,
+				Body:   `{"media": [{"id": "media-id"}]}`,
+			},
+			MockedRequest{
+				Method: "POST",
+				Path:   "/v1/messages",
+				Body:   `{"to":"250788123123","type":"video","video":{"id":"media-id","caption":"video caption"}}`,
+			}: MockedResponse{
+				Status: 201,
+				Body:   `{ "messages": [{"id": "157b5e14568e8"}] }`,
+			},
+		},
+		SendPrep: setSendURL,
+	},
 	{Label: "Template Send",
 		Text:   "templated message",
 		URN:    "whatsapp:250788123123",


### PR DESCRIPTION
Version 2.23.4 of the WhatsApp Business API allows for sending of mp4 videos. This PR adds support for that.