### PR TITLE
Add SignalWire handler

### DIFF
--- a/backends/rapidpro/channel.go
+++ b/backends/rapidpro/channel.go
@@ -241,6 +241,16 @@ func (c *DBChannel) StringConfigForKey(key string, defaultValue string) string {
 	return str
 }
 
+// BoolConfigForKey returns the config value for the passed in key, or defaultValue if it isn't found
+func (c *DBChannel) BoolConfigForKey(key string, defaultValue bool) bool {
+	val := c.ConfigForKey(key, defaultValue)
+	b, isBool := val.(bool)
+	if !isBool {
+		return defaultValue
+	}
+	return b
+}
+
 // IntConfigForKey returns the config value for the passed in key
 func (c *DBChannel) IntConfigForKey(key string, defaultValue int) int {
 	val := c.ConfigForKey(key, defaultValue)

--- a/channel.go
+++ b/channel.go
@@ -136,6 +136,7 @@ type Channel interface {
 
 	ConfigForKey(key string, defaultValue interface{}) interface{}
 	StringConfigForKey(key string, defaultValue string) string
+	BoolConfigForKey(key string, defaultValue bool) bool
 	IntConfigForKey(key string, defaultValue int) int
 	OrgConfigForKey(key string, defaultValue interface{}) interface{}
 }

--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -49,7 +49,7 @@ import (
 	_ "github.com/nyaruka/courier/handlers/smscentral"
 	_ "github.com/nyaruka/courier/handlers/start"
 	_ "github.com/nyaruka/courier/handlers/telegram"
-	_ "github.com/nyaruka/courier/handlers/twilio"
+	_ "github.com/nyaruka/courier/handlers/twiml"
 	_ "github.com/nyaruka/courier/handlers/twitter"
 	_ "github.com/nyaruka/courier/handlers/viber"
 	_ "github.com/nyaruka/courier/handlers/wavy"

--- a/config.go
+++ b/config.go
@@ -4,30 +4,29 @@ import "github.com/nyaruka/ezconf"
 
 // Config is our top level configuration object
 type Config struct {
-	Backend               string `help:"the backend that will be used by courier (currently only rapidpro is supported)"`
-	SentryDSN             string `help:"the DSN used for logging errors to Sentry"`
-	Domain                string `help:"the domain courier is exposed on"`
-	Address               string `help:"the network interface address courier will bind to"`
-	Port                  int    `help:"the port courier will listen on"`
-	DB                    string `help:"URL describing how to connect to the RapidPro database"`
-	Redis                 string `help:"URL describing how to connect to Redis"`
-	SpoolDir              string `help:"the local directory where courier will write statuses or msgs that need to be retried (needs to be writable)"`
-	S3Endpoint            string `help:"the S3 endpoint we will write attachments to"`
-	S3Region              string `help:"the S3 region we will write attachments to"`
-	S3MediaBucket         string `help:"the S3 bucket we will write attachments to"`
-	S3MediaPrefix         string `help:"the prefix that will be added to attachment filenames"`
-	S3DisableSSL          bool   `help:"whether we disable SSL when accessing S3. Should always be set to False unless you're hosting an S3 compatible service within a secure internal network"`
-	S3ForcePathStyle      bool   `help:"whether we force S3 path style. Should generally need to default to False unless you're hosting an S3 compatible service"`
-	AWSAccessKeyID        string `help:"the access key id to use when authenticating S3"`
-	AWSSecretAccessKey    string `help:"the secret access key id to use when authenticating S3"`
-	MaxWorkers            int    `help:"the maximum number of go routines that will be used for sending (set to 0 to disable sending)"`
-	LibratoUsername       string `help:"the username that will be used to authenticate to Librato"`
-	LibratoToken          string `help:"the token that will be used to authenticate to Librato"`
-	StatusUsername        string `help:"the username that is needed to authenticate against the /status endpoint"`
-	StatusPassword        string `help:"the password that is needed to authenticate against the /status endpoint"`
-	LogLevel              string `help:"the logging level courier should use"`
-	IgnoreDeliveryReports bool   `help:"whether we ignore delivered status reports (errors will still be handled)"`
-	Version               string `help:"the version that will be used in request and response headers"`
+	Backend            string `help:"the backend that will be used by courier (currently only rapidpro is supported)"`
+	SentryDSN          string `help:"the DSN used for logging errors to Sentry"`
+	Domain             string `help:"the domain courier is exposed on"`
+	Address            string `help:"the network interface address courier will bind to"`
+	Port               int    `help:"the port courier will listen on"`
+	DB                 string `help:"URL describing how to connect to the RapidPro database"`
+	Redis              string `help:"URL describing how to connect to Redis"`
+	SpoolDir           string `help:"the local directory where courier will write statuses or msgs that need to be retried (needs to be writable)"`
+	S3Endpoint         string `help:"the S3 endpoint we will write attachments to"`
+	S3Region           string `help:"the S3 region we will write attachments to"`
+	S3MediaBucket      string `help:"the S3 bucket we will write attachments to"`
+	S3MediaPrefix      string `help:"the prefix that will be added to attachment filenames"`
+	S3DisableSSL       bool   `help:"whether we disable SSL when accessing S3. Should always be set to False unless you're hosting an S3 compatible service within a secure internal network"`
+	S3ForcePathStyle   bool   `help:"whether we force S3 path style. Should generally need to default to False unless you're hosting an S3 compatible service"`
+	AWSAccessKeyID     string `help:"the access key id to use when authenticating S3"`
+	AWSSecretAccessKey string `help:"the secret access key id to use when authenticating S3"`
+	MaxWorkers         int    `help:"the maximum number of go routines that will be used for sending (set to 0 to disable sending)"`
+	LibratoUsername    string `help:"the username that will be used to authenticate to Librato"`
+	LibratoToken       string `help:"the token that will be used to authenticate to Librato"`
+	StatusUsername     string `help:"the username that is needed to authenticate against the /status endpoint"`
+	StatusPassword     string `help:"the password that is needed to authenticate against the /status endpoint"`
+	LogLevel           string `help:"the logging level courier should use"`
+	Version            string `help:"the version that will be used in request and response headers"`
 
 	// IncludeChannels is the list of channels to enable, empty means include all
 	IncludeChannels []string

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -249,7 +249,7 @@ func RunChannelSendTestCases(t *testing.T, channel courier.Channel, handler cour
 			}
 
 			if testCase.Path != "" {
-				require.NotNil(testRequest)
+				require.NotNil(testRequest, "path should not be nil")
 				require.Equal(testCase.Path, testRequest.URL.Path)
 			}
 
@@ -262,7 +262,7 @@ func RunChannelSendTestCases(t *testing.T, channel courier.Channel, handler cour
 			}
 
 			if testCase.PostParams != nil {
-				require.NotNil(testRequest)
+				require.NotNil(testRequest, "post body should not be nil")
 				for k, v := range testCase.PostParams {
 					value := testRequest.PostFormValue(k)
 					require.Equal(v, value)
@@ -270,7 +270,7 @@ func RunChannelSendTestCases(t *testing.T, channel courier.Channel, handler cour
 			}
 
 			if testCase.RequestBody != "" {
-				require.NotNil(testRequest)
+				require.NotNil(testRequest, "request body should not be nil")
 				value, _ := ioutil.ReadAll(testRequest.Body)
 				require.Equal(testCase.RequestBody, strings.Trim(string(value), "\n"))
 			}
@@ -280,7 +280,7 @@ func RunChannelSendTestCases(t *testing.T, channel courier.Channel, handler cour
 			}
 
 			if testCase.Headers != nil {
-				require.NotNil(testRequest)
+				require.NotNil(testRequest, "headers should not be nil")
 				for k, v := range testCase.Headers {
 					value := testRequest.Header.Get(k)
 					require.Equal(v, value)
@@ -292,7 +292,7 @@ func RunChannelSendTestCases(t *testing.T, channel courier.Channel, handler cour
 			}
 
 			if testCase.Status != "" {
-				require.NotNil(status)
+				require.NotNil(status, "status should not be nil")
 				require.Equal(testCase.Status, string(status.Status()))
 			}
 

--- a/handlers/twiml/twiml.go
+++ b/handlers/twiml/twiml.go
@@ -225,6 +225,11 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		}
 
 		// build our URL
+		baseURL := h.baseURL(channel)
+		if baseURL == "" {
+			return nil, fmt.Errorf("missing base URL for %s channel", h.ChannelName())
+		}
+
 		sendURL, err := utils.AddURLPath(h.baseURL(channel), "2010-04-01", "Accounts", accountSID, "Messages.json")
 		if err != nil {
 			return nil, err
@@ -283,7 +288,12 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 }
 
 func (h *handler) baseURL(c courier.Channel) string {
-	return c.StringConfigForKey(configSendURL, c.StringConfigForKey(configBaseURL, twilioBaseURL))
+	// Twilio channels use the Twili base URL
+	if c.ChannelType() == "T" || c.ChannelType() == "TMS" {
+		return twilioBaseURL
+	}
+
+	return c.StringConfigForKey(configSendURL, c.StringConfigForKey(configBaseURL, ""))
 }
 
 // see https://www.twilio.com/docs/api/security

--- a/handlers/twiml/twiml.go
+++ b/handlers/twiml/twiml.go
@@ -222,7 +222,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			return nil, fmt.Errorf("missing base URL for %s channel", h.ChannelName())
 		}
 
-		sendURL, err := utils.AddURLPath(h.baseURL(channel), "2010-04-01", "Accounts", accountSID, "Messages.json")
+		sendURL, err := utils.AddURLPath(baseURL, "2010-04-01", "Accounts", accountSID, "Messages.json")
 		if err != nil {
 			return nil, err
 		}

--- a/handlers/twiml/twiml.go
+++ b/handlers/twiml/twiml.go
@@ -27,14 +27,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Flavor defines the methods a flavor needs to implement for a TWIML channel
-type Flavor interface {
-	Name() string
-	ChannelType() courier.ChannelType
-	BaseURL() string
-	ValidateSignature(courier.Channel, *http.Request) error
-}
-
 const (
 	configAccountSID          = "account_sid"
 	configMessagingServiceSID = "messaging_service_sid"

--- a/handlers/twiml/twiml_test.go
+++ b/handlers/twiml/twiml_test.go
@@ -23,6 +23,10 @@ var twTestChannels = []courier.Channel{
 	courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "TW", "2020", "US", map[string]interface{}{"auth_token": "6789"}),
 }
 
+var swTestChannels = []courier.Channel{
+	courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "SW", "2020", "US", map[string]interface{}{"auth_token": "6789"}),
+}
+
 var (
 	receiveURL         = "/c/t/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive"
 	statusURL          = "/c/t/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status"
@@ -38,6 +42,11 @@ var (
 	twStatusURL          = "/c/tw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status"
 	twStatusIDURL        = "/c/tw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=12345"
 	twStatusInvalidIDURL = "/c/tw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=asdf"
+
+	swReceiveURL         = "/c/sw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive"
+	swStatusURL          = "/c/sw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status"
+	swStatusIDURL        = "/c/sw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=12345"
+	swStatusInvalidIDURL = "/c/sw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=asdf"
 
 	receiveValid        = "ToCountry=US&ToState=District+Of+Columbia&SmsMessageSid=SMe287d7109a5a925f182f0e07fe5b223b&NumMedia=0&ToCity=&FromZip=01022&SmsSid=SMe287d7109a5a925f182f0e07fe5b223b&FromState=MA&SmsStatus=received&FromCity=CHICOPEE&Body=Msg&FromCountry=US&To=%2B12028831111&ToZip=&NumSegments=1&MessageSid=SMe287d7109a5a925f182f0e07fe5b223b&AccountSid=acctid&From=%2B14133881111&ApiVersion=2010-04-01"
 	receiveMedia        = "ToCountry=US&ToState=District+Of+Columbia&SmsMessageSid=SMe287d7109a5a925f182f0e07fe5b223b&NumMedia=2&ToCity=&FromZip=01022&SmsSid=SMe287d7109a5a925f182f0e07fe5b223b&FromState=MA&SmsStatus=received&FromCity=CHICOPEE&FromCountry=US&To=%2B12028831111&ToZip=&NumSegments=1&MessageSid=SMe287d7109a5a925f182f0e07fe5b223b&AccountSid=acctid&From=%2B14133881111&ApiVersion=2010-04-01&MediaUrl0=cat.jpg&MediaUrl1=dog.jpg"
@@ -151,6 +160,23 @@ var twTestCases = []ChannelHandleTestCase{
 		PrepRequest: addValidSignature},
 }
 
+var swTestCases = []ChannelHandleTestCase{
+	{Label: "Receive Valid", URL: swReceiveURL, Data: receiveValid, Status: 200, Response: "<Response/>",
+		Text: Sp("Msg"), URN: Sp("tel:+14133881111"), ExternalID: Sp("SMe287d7109a5a925f182f0e07fe5b223b")},
+	{Label: "Receive No Params", URL: swReceiveURL, Data: " ", Status: 400, Response: "field 'messagesid' required"},
+	{Label: "Receive Media", URL: swReceiveURL, Data: receiveMedia, Status: 200, Response: "<Response/>",
+		URN: Sp("tel:+14133881111"), ExternalID: Sp("SMe287d7109a5a925f182f0e07fe5b223b"), Attachments: []string{"cat.jpg", "dog.jpg"}},
+	{Label: "Receive Media With Msg", URL: swReceiveURL, Data: receiveMediaWithMsg, Status: 200, Response: "<Response/>",
+		Text: Sp("Msg"), URN: Sp("tel:+14133881111"), ExternalID: Sp("SMe287d7109a5a925f182f0e07fe5b223b"), Attachments: []string{"cat.jpg", "dog.jpg"}},
+	{Label: "Receive Base64", URL: swReceiveURL, Data: receiveBase64, Status: 200, Response: "<Response/>",
+		Text: Sp("Bannon Explains The World ...\n“The Camp of the Saints"), URN: Sp("tel:+14133881111"), ExternalID: Sp("SMe287d7109a5a925f182f0e07fe5b223b")},
+	{Label: "Status No Params", URL: swStatusURL, Data: " ", Status: 200, Response: "no msg status, ignoring"},
+	{Label: "Status Invalid Status", URL: swStatusURL, Data: statusInvalid, Status: 400, Response: "unknown status 'huh'"},
+	{Label: "Status Valid", URL: swStatusURL, Data: statusValid, Status: 200, Response: `"status":"D"`, ExternalID: Sp("SMe287d7109a5a925f182f0e07fe5b223b")},
+	{Label: "Status ID Valid", URL: swStatusIDURL, Data: statusValid, Status: 200, Response: `"status":"D"`, ID: 12345},
+	{Label: "Status ID Invalid", URL: swStatusInvalidIDURL, Data: statusValid, Status: 200, Response: `"status":"D"`, ExternalID: Sp("SMe287d7109a5a925f182f0e07fe5b223b")},
+}
+
 func addValidSignature(r *http.Request) {
 	r.ParseForm()
 	sig, _ := twCalculateSignature(fmt.Sprintf("%s://%s%s", r.URL.Scheme, r.Host, r.URL.RequestURI()), r.PostForm, "6789")
@@ -172,6 +198,7 @@ func TestHandler(t *testing.T) {
 	RunChannelTestCases(t, testChannels, newTWIMLHandler("T", "Twilio", true), testCases)
 	RunChannelTestCases(t, tmsTestChannels, newTWIMLHandler("TMS", "Twilio Messaging Service", true), tmsTestCases)
 	RunChannelTestCases(t, twTestChannels, newTWIMLHandler("TW", "TwiML API", true), twTestCases)
+	RunChannelTestCases(t, swTestChannels, newTWIMLHandler("SW", "SignalWire", false), swTestCases)
 }
 
 func BenchmarkHandler(b *testing.B) {
@@ -182,8 +209,7 @@ func BenchmarkHandler(b *testing.B) {
 
 // setSendURL takes care of setting the send_url to our test server host
 func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
-
-	if c.ChannelType().String() == "TW" {
+	if c.ChannelType().String() == "TW" || c.ChannelType().String() == "SW" {
 		c.(*courier.MockChannel).SetConfig("send_url", s.URL)
 	} else {
 		twilioBaseURL = s.URL
@@ -343,6 +369,57 @@ var twDefaultSendTestCases = []ChannelSendTestCase{
 		SendPrep:   setSendURL},
 }
 
+var swSendTestCases = []ChannelSendTestCase{
+	{Label: "Plain Send",
+		Text: "Simple Message ☺", URN: "tel:+250788383383",
+		Status: "W", ExternalID: "1002",
+		ResponseBody: `{ "sid": "1002" }`, ResponseStatus: 200,
+		PostParams: map[string]string{"Body": "Simple Message ☺", "To": "+250788383383", "From": "2020", "StatusCallback": "https://localhost/c/sw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&action=callback"},
+		Path:       "/2010-04-01/Accounts/accountSID/Messages.json",
+		Headers:    map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
+		SendPrep:   setSendURL},
+	{Label: "Long Send",
+		Text:   "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, I need to keep adding more things to make it work",
+		URN:    "tel:+250788383383",
+		Status: "W", ExternalID: "1002",
+		ResponseBody: `{ "sid": "1002" }`, ResponseStatus: 200,
+		PostParams: map[string]string{"Body": "I need to keep adding more things to make it work", "To": "+250788383383", "From": "2020", "StatusCallback": "https://localhost/c/sw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&action=callback"},
+		Path:       "/2010-04-01/Accounts/accountSID/Messages.json",
+		Headers:    map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
+		SendPrep:   setSendURL},
+	{Label: "Error Sending",
+		Text: "Error Message", URN: "tel:+250788383383",
+		Status:       "E",
+		ResponseBody: `{ "error": "out of credits" }`, ResponseStatus: 401,
+		PostParams: map[string]string{"Body": "Error Message", "To": "+250788383383", "From": "2020", "StatusCallback": "https://localhost/c/sw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&action=callback"},
+		SendPrep:   setSendURL},
+	{Label: "Error Code",
+		Text: "Error Code", URN: "tel:+250788383383",
+		Status:       "E",
+		ResponseBody: `{ "code": 1001 }`, ResponseStatus: 200,
+		PostParams: map[string]string{"Body": "Error Code", "To": "+250788383383", "From": "2020", "StatusCallback": "https://localhost/c/sw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&action=callback"},
+		SendPrep:   setSendURL},
+	{Label: "Stopped Contact Code",
+		Text: "Stopped Contact", URN: "tel:+250788383383",
+		Status:       "F",
+		ResponseBody: `{ "code": 21610 }`, ResponseStatus: 400,
+		PostParams: map[string]string{"Body": "Stopped Contact", "To": "+250788383383", "From": "2020", "StatusCallback": "https://localhost/c/sw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&action=callback"},
+		SendPrep:   setSendURL,
+		Stopped:    true},
+	{Label: "No SID",
+		Text: "No SID", URN: "tel:+250788383383",
+		Status:       "E",
+		ResponseBody: `{ }`, ResponseStatus: 200,
+		PostParams: map[string]string{"Body": "No SID", "To": "+250788383383", "From": "2020", "StatusCallback": "https://localhost/c/sw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&action=callback"},
+		SendPrep:   setSendURL},
+	{Label: "Send Attachment",
+		Text: "My pic!", URN: "tel:+250788383383", Attachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
+		Status:       "W",
+		ResponseBody: `{ "sid": "1002" }`, ResponseStatus: 200,
+		PostParams: map[string]string{"Body": "My pic!", "To": "+250788383383", "MediaUrl": "https://foo.bar/image.jpg", "From": "2020", "StatusCallback": "https://localhost/c/sw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&action=callback"},
+		SendPrep:   setSendURL},
+}
+
 func TestSending(t *testing.T) {
 	maxMsgLength = 160
 	var defaultChannel = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "T", "2020", "US",
@@ -363,7 +440,15 @@ func TestSending(t *testing.T) {
 			configSendURL:           "SEND_URL",
 		})
 
+	var swChannel = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "SW", "2020", "US",
+	map[string]interface{}{
+			configAccountSID:        "accountSID",
+			courier.ConfigAuthToken: "authToken",
+			configSendURL:           "BASE_URL",
+		})
+
 	RunChannelSendTestCases(t, defaultChannel, newTWIMLHandler("T", "Twilio", true), defaultSendTestCases, nil)
 	RunChannelSendTestCases(t, tmsDefaultChannel, newTWIMLHandler("TMS", "Twilio Messaging Service", true), tmsDefaultSendTestCases, nil)
 	RunChannelSendTestCases(t, twDefaultChannel, newTWIMLHandler("TW", "TwiML", true), twDefaultSendTestCases, nil)
+	RunChannelSendTestCases(t, swChannel, newTWIMLHandler("SW", "SignalWire", false), swSendTestCases, nil)
 }

--- a/handlers/twiml/twiml_test.go
+++ b/handlers/twiml/twiml_test.go
@@ -1,4 +1,4 @@
-package twilio
+package twiml
 
 import (
 	"net/http"
@@ -169,24 +169,24 @@ func addInvalidSignature(r *http.Request) {
 }
 
 func TestHandler(t *testing.T) {
-	RunChannelTestCases(t, testChannels, newHandler("T", "Twilio"), testCases)
-	RunChannelTestCases(t, tmsTestChannels, newHandler("TMS", "Twilio Messaging Service"), tmsTestCases)
-	RunChannelTestCases(t, twTestChannels, newHandler("TW", "TwiML API"), twTestCases)
+	RunChannelTestCases(t, testChannels, newTWIMLHandler("T", "Twilio", true), testCases)
+	RunChannelTestCases(t, tmsTestChannels, newTWIMLHandler("TMS", "Twilio Messaging Service", true), tmsTestCases)
+	RunChannelTestCases(t, twTestChannels, newTWIMLHandler("TW", "TwiML API", true), twTestCases)
 }
 
 func BenchmarkHandler(b *testing.B) {
-	RunChannelBenchmarks(b, testChannels, newHandler("T", "Twilio"), testCases)
-	RunChannelBenchmarks(b, tmsTestChannels, newHandler("TMS", "Twilio Messaging Service"), tmsTestCases)
-	RunChannelBenchmarks(b, twTestChannels, newHandler("TW", "TwiML API"), twTestCases)
+	RunChannelBenchmarks(b, testChannels, newTWIMLHandler("T", "Twilio", true), testCases)
+	RunChannelBenchmarks(b, tmsTestChannels, newTWIMLHandler("TMS", "Twilio Messaging Service", true), tmsTestCases)
+	RunChannelBenchmarks(b, twTestChannels, newTWIMLHandler("TW", "TwiML API", true), twTestCases)
 }
 
 // setSendURL takes care of setting the send_url to our test server host
 func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
 
 	if c.ChannelType().String() == "TW" {
-		c.(*courier.MockChannel).SetConfig("send_url", s.URL+"/Account/")
+		c.(*courier.MockChannel).SetConfig("send_url", s.URL)
 	} else {
-		sendURL = s.URL + "/Account/"
+		twilioBaseURL = s.URL
 	}
 }
 
@@ -196,7 +196,7 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		Status: "W", ExternalID: "1002",
 		ResponseBody: `{ "sid": "1002" }`, ResponseStatus: 200,
 		PostParams: map[string]string{"Body": "Simple Message ☺", "To": "+250788383383", "From": "2020", "StatusCallback": "https://localhost/c/t/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&action=callback"},
-		Path:       "/Account/accountSID/Messages.json",
+		Path:       "/2010-04-01/Accounts/accountSID/Messages.json",
 		Headers:    map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
 		SendPrep:   setSendURL},
 	{Label: "Long Send",
@@ -205,7 +205,7 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		Status: "W", ExternalID: "1002",
 		ResponseBody: `{ "sid": "1002" }`, ResponseStatus: 200,
 		PostParams: map[string]string{"Body": "I need to keep adding more things to make it work", "To": "+250788383383", "From": "2020", "StatusCallback": "https://localhost/c/t/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&action=callback"},
-		Path:       "/Account/accountSID/Messages.json",
+		Path:       "/2010-04-01/Accounts/accountSID/Messages.json",
 		Headers:    map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
 		SendPrep:   setSendURL},
 	{Label: "Error Sending",
@@ -247,7 +247,7 @@ var tmsDefaultSendTestCases = []ChannelSendTestCase{
 		Status: "W", ExternalID: "1002",
 		ResponseBody: `{ "sid": "1002" }`, ResponseStatus: 200,
 		PostParams: map[string]string{"Body": "Simple Message ☺", "To": "+250788383383", "MessagingServiceSid": "messageServiceSID", "StatusCallback": "https://localhost/c/tms/8eb23e93-5ecb-45ba-b726-3b064e0c56cd/status?id=10&action=callback"},
-		Path:       "/Account/accountSID/Messages.json",
+		Path:       "/2010-04-01/Accounts/accountSID/Messages.json",
 		Headers:    map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
 		SendPrep:   setSendURL},
 	{Label: "Long Send",
@@ -256,7 +256,7 @@ var tmsDefaultSendTestCases = []ChannelSendTestCase{
 		Status: "W", ExternalID: "1002",
 		ResponseBody: `{ "sid": "1002" }`, ResponseStatus: 200,
 		PostParams: map[string]string{"Body": "I need to keep adding more things to make it work", "To": "+250788383383", "MessagingServiceSid": "messageServiceSID", "StatusCallback": "https://localhost/c/tms/8eb23e93-5ecb-45ba-b726-3b064e0c56cd/status?id=10&action=callback"},
-		Path:       "/Account/accountSID/Messages.json",
+		Path:       "/2010-04-01/Accounts/accountSID/Messages.json",
 		Headers:    map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
 		SendPrep:   setSendURL},
 	{Label: "Error Sending",
@@ -298,7 +298,7 @@ var twDefaultSendTestCases = []ChannelSendTestCase{
 		Status: "W", ExternalID: "1002",
 		ResponseBody: `{ "sid": "1002" }`, ResponseStatus: 200,
 		PostParams: map[string]string{"Body": "Simple Message ☺", "To": "+250788383383", "From": "2020", "StatusCallback": "https://localhost/c/tw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&action=callback"},
-		Path:       "/Account/accountSID/Messages.json",
+		Path:       "/2010-04-01/Accounts/accountSID/Messages.json",
 		Headers:    map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
 		SendPrep:   setSendURL},
 	{Label: "Long Send",
@@ -307,7 +307,7 @@ var twDefaultSendTestCases = []ChannelSendTestCase{
 		Status: "W", ExternalID: "1002",
 		ResponseBody: `{ "sid": "1002" }`, ResponseStatus: 200,
 		PostParams: map[string]string{"Body": "I need to keep adding more things to make it work", "To": "+250788383383", "From": "2020", "StatusCallback": "https://localhost/c/tw/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&action=callback"},
-		Path:       "/Account/accountSID/Messages.json",
+		Path:       "/2010-04-01/Accounts/accountSID/Messages.json",
 		Headers:    map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
 		SendPrep:   setSendURL},
 	{Label: "Error Sending",
@@ -363,7 +363,7 @@ func TestSending(t *testing.T) {
 			configSendURL:           "SEND_URL",
 		})
 
-	RunChannelSendTestCases(t, defaultChannel, newHandler("T", "Twilio"), defaultSendTestCases, nil)
-	RunChannelSendTestCases(t, tmsDefaultChannel, newHandler("TMS", "Twilio Messaging Service"), tmsDefaultSendTestCases, nil)
-	RunChannelSendTestCases(t, twDefaultChannel, newHandler("TW", "TwiML"), twDefaultSendTestCases, nil)
+	RunChannelSendTestCases(t, defaultChannel, newTWIMLHandler("T", "Twilio", true), defaultSendTestCases, nil)
+	RunChannelSendTestCases(t, tmsDefaultChannel, newTWIMLHandler("TMS", "Twilio Messaging Service", true), tmsDefaultSendTestCases, nil)
+	RunChannelSendTestCases(t, twDefaultChannel, newTWIMLHandler("TW", "TwiML", true), twDefaultSendTestCases, nil)
 }

--- a/test.go
+++ b/test.go
@@ -411,6 +411,16 @@ func (c *MockChannel) StringConfigForKey(key string, defaultValue string) string
 	return str
 }
 
+// BoolConfigForKey returns the config value for the passed in key
+func (c *MockChannel) BoolConfigForKey(key string, defaultValue bool) bool {
+	val := c.ConfigForKey(key, defaultValue)
+	b, isBool := val.(bool)
+	if !isBool {
+		return defaultValue
+	}
+	return b
+}
+
 // IntConfigForKey returns the config value for the passed in key
 func (c *MockChannel) IntConfigForKey(key string, defaultValue int) int {
 	val := c.ConfigForKey(key, defaultValue)


### PR DESCRIPTION
https://signalwire.com/

Mostly the same API as Twilio except they don't sign.

Renamed `twilio` handler to `twiml` since that's more accurate now.

Also removed global 'ignore_delivery_reports' setting which was only used by Resist. That's now a channel config. 

@chris-erickson, I set `ignore_dlrs` to `true` on the config for the main ResistBot Twilio channel so this doesn't change anything for you. (that global config option was only for resist)