### PR TITLE
add whatsapp scheme to twiml channels

### DIFF
--- a/backends/rapidpro/channel.go
+++ b/backends/rapidpro/channel.go
@@ -188,6 +188,11 @@ func (c *DBChannel) Address() string { return c.Address_.String }
 // Country returns the country code for this channel if any
 func (c *DBChannel) Country() string { return c.Country_.String }
 
+// IsScheme returns whether this channel serves only the passed in scheme
+func (c *DBChannel) IsScheme(scheme string) bool {
+	return len(c.Schemes_) == 1 && c.Schemes_[0] == scheme
+}
+
 // ConfigForKey returns the config value for the passed in key, or defaultValue if it isn't found
 func (c *DBChannel) ConfigForKey(key string, defaultValue interface{}) interface{} {
 	// no value, return our default value

--- a/channel.go
+++ b/channel.go
@@ -131,6 +131,9 @@ type Channel interface {
 	Country() string
 	Address() string
 
+	// is this channel for the passed in scheme (and only that scheme)
+	IsScheme(string) bool
+
 	// CallbackDomain returns the domain that should be used for any callbacks the channel registers
 	CallbackDomain(fallbackDomain string) string
 

--- a/test.go
+++ b/test.go
@@ -369,8 +369,16 @@ func (c *MockChannel) Name() string { return fmt.Sprintf("Channel: %s", c.uuid.S
 // ChannelType returns the type of this channel
 func (c *MockChannel) ChannelType() ChannelType { return c.channelType }
 
+// SetScheme sets the scheme for this channel
+func (c *MockChannel) SetScheme(scheme string) { c.schemes = []string{scheme} }
+
 // Schemes returns the schemes for this channel
 func (c *MockChannel) Schemes() []string { return c.schemes }
+
+// IsScheme returns whether the passed in scheme is the scheme for this channel
+func (c *MockChannel) IsScheme(scheme string) bool {
+	return len(c.schemes) == 1 && c.schemes[0] == scheme
+}
 
 // Address returns the address of this channel
 func (c *MockChannel) Address() string { return c.address }
@@ -457,7 +465,7 @@ func (c *MockChannel) OrgConfigForKey(key string, defaultValue interface{}) inte
 }
 
 // NewMockChannel creates a new mock channel for the passed in type, address, country and config
-func NewMockChannel(uuid string, channelType string, address string, country string, config map[string]interface{}) Channel {
+func NewMockChannel(uuid string, channelType string, address string, country string, config map[string]interface{}) *MockChannel {
 	cUUID, _ := NewChannelUUID(uuid)
 
 	channel := &MockChannel{


### PR DESCRIPTION
Not positive this is the right approach, we may want to add a `WAT` type for "WhatsApp Twilio" but this lets us test this out with a customer to start, we can switch them over once we add a new channel type. (also want to limit changes due to v5 push)

We have a customer with a Twiliio WA number so this addresses that.