### PR TITLE
Fix quick replies variable replacement on external channel long msg

### DIFF
--- a/handlers/external/external.go
+++ b/handlers/external/external.go
@@ -314,7 +314,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		if i == len(parts) - 1 {
 			formEncoded["quick_replies"] = buildQuickRepliesResponse(msg.QuickReplies(), sendMethod, contentURLEncoded)
 		} else {
-			formEncoded["quick_replies"] = buildQuickRepliesResponse([]string{}, sendMethod, contentType)
+			formEncoded["quick_replies"] = buildQuickRepliesResponse([]string{}, sendMethod, contentURLEncoded)
 		}
 		url := replaceVariables(sendURL, formEncoded)
 

--- a/handlers/external/external.go
+++ b/handlers/external/external.go
@@ -313,6 +313,8 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		// put quick replies on last message part
 		if i == len(parts) - 1 {
 			formEncoded["quick_replies"] = buildQuickRepliesResponse(msg.QuickReplies(), sendMethod, contentURLEncoded)
+		} else {
+			formEncoded["quick_replies"] = buildQuickRepliesResponse([]string{}, sendMethod, contentType)
 		}
 		url := replaceVariables(sendURL, formEncoded)
 
@@ -322,6 +324,8 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 
 			if i == len(parts) - 1 {
 				formEncoded["quick_replies"] = buildQuickRepliesResponse(msg.QuickReplies(), sendMethod, contentType)
+			} else {
+				formEncoded["quick_replies"] = buildQuickRepliesResponse([]string{}, sendMethod, contentType)
 			}
 			body = strings.NewReader(replaceVariables(sendBody, formEncoded))
 		}

--- a/handlers/external/external_test.go
+++ b/handlers/external/external_test.go
@@ -267,7 +267,7 @@ var jsonSendTestCases = []ChannelSendTestCase{
 }
 
 var jsonLongSendTestCases = []ChannelSendTestCase{
-	{Label: "Long Send",
+	{Label: "Send Quick Replies",
 		Text: "This is a long message that will be longer than 30....... characters", URN: "tel:+250788383383",
 		QuickReplies: []string{"One", "Two", "Three"},
 		Status:       "W",

--- a/handlers/external/external_test.go
+++ b/handlers/external/external_test.go
@@ -129,9 +129,10 @@ func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel,
 var longSendTestCases = []ChannelSendTestCase{
 	{Label: "Long Send",
 		Text: "This is a long message that will be longer than 30....... characters", URN: "tel:+250788383383",
+		QuickReplies: []string{"One"},
 		Status:       "W",
 		ResponseBody: "0: Accepted for delivery", ResponseStatus: 200,
-		URLParams: map[string]string{"text": "characters", "to": "+250788383383", "from": "2020"},
+		URLParams: map[string]string{"text": "characters", "to": "+250788383383", "from": "2020", "quick_reply": "One"},
 		SendPrep:  setSendURL},
 }
 
@@ -447,13 +448,13 @@ func TestSending(t *testing.T) {
 	var getChannel30IntLength = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
 		map[string]interface{}{
 			"max_length":             30,
-			"send_path":              "?to={{to}}&text={{text}}&from={{from}}",
+			"send_path":              "?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
 			courier.ConfigSendMethod: http.MethodGet})
 
 	var getChannel30StrLength = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
 		map[string]interface{}{
 			"max_length":             "30",
-			"send_path":              "?to={{to}}&text={{text}}&from={{from}}",
+			"send_path":              "?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
 			courier.ConfigSendMethod: http.MethodGet})
 
 	var jsonChannel30IntLength = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",

--- a/handlers/external/external_test.go
+++ b/handlers/external/external_test.go
@@ -265,6 +265,17 @@ var jsonSendTestCases = []ChannelSendTestCase{
 		SendPrep:    setSendURL},
 }
 
+var jsonLongSendTestCases = []ChannelSendTestCase{
+	{Label: "Long Send",
+		Text: "This is a long message that will be longer than 30....... characters", URN: "tel:+250788383383",
+		QuickReplies: []string{"One", "Two", "Three"},
+		Status:       "W",
+		ResponseBody: "0: Accepted for delivery", ResponseStatus: 200,
+		RequestBody: `{ "to":"+250788383383", "text":"characters", "from":"2020", "quick_replies":["One","Two","Three"] }`,
+		Headers:     map[string]string{"Authorization": "Token ABCDEF", "Content-Type": "application/json"},
+		SendPrep:  setSendURL},
+}
+
 var xmlSendTestCases = []ChannelSendTestCase{
 	{Label: "Plain Send",
 		Text: "Simple Message", URN: "tel:+250788383383",
@@ -301,6 +312,18 @@ var xmlSendTestCases = []ChannelSendTestCase{
 		ResponseBody: "0: Accepted for delivery", ResponseStatus: 200,
 		RequestBody: "<msg><to>+250788383383</to><text>Some message</text><from>2020</from>" +
 					"<quick_replies><item>One</item><item>Two</item><item>Three</item></quick_replies></msg>",
+		Headers:     map[string]string{"Content-Type": "text/xml; charset=utf-8"},
+		SendPrep:    setSendURL},
+}
+
+var xmlLongSendTestCases = []ChannelSendTestCase{
+	{Label: "Send Quick Replies",
+		Text: "This is a long message that will be longer than 30....... characters", URN: "tel:+250788383383",
+		QuickReplies: []string{"One", "Two", "Three"},
+		Status:       "W",
+		ResponseBody: "0: Accepted for delivery", ResponseStatus: 200,
+		RequestBody: "<msg><to>+250788383383</to><text>characters</text><from>2020</from>" +
+			"<quick_replies><item>One</item><item>Two</item><item>Three</item></quick_replies></msg>",
 		Headers:     map[string]string{"Content-Type": "text/xml; charset=utf-8"},
 		SendPrep:    setSendURL},
 }
@@ -433,6 +456,28 @@ func TestSending(t *testing.T) {
 			"send_path":              "?to={{to}}&text={{text}}&from={{from}}",
 			courier.ConfigSendMethod: http.MethodGet})
 
+	var jsonChannel30IntLength = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
+		map[string]interface{}{
+			"send_path":                     "",
+			"max_length":                    30,
+			courier.ConfigSendBody:          `{ "to":{{to}}, "text":{{text}}, "from":{{from}}, "quick_replies":{{quick_replies}} }`,
+			courier.ConfigContentType:       contentJSON,
+			courier.ConfigSendMethod:        http.MethodPost,
+			courier.ConfigSendAuthorization: "Token ABCDEF",
+		})
+
+	var xmlChannel30IntLength = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
+		map[string]interface{}{
+			"send_path":                     "",
+			"max_length":                    30,
+			courier.ConfigSendBody:          `<msg><to>{{to}}</to><text>{{text}}</text><from>{{from}}</from><quick_replies>{{quick_replies}}</quick_replies></msg>`,
+			courier.ConfigContentType:       contentXML,
+			courier.ConfigSendMethod:        http.MethodPost,
+			courier.ConfigSendAuthorization: "Token ABCDEF",
+		})
+
 	RunChannelSendTestCases(t, getChannel30IntLength, newHandler(), longSendTestCases, nil)
 	RunChannelSendTestCases(t, getChannel30StrLength, newHandler(), longSendTestCases, nil)
+	RunChannelSendTestCases(t, jsonChannel30IntLength, newHandler(), jsonLongSendTestCases, nil)
+	RunChannelSendTestCases(t, xmlChannel30IntLength, newHandler(), xmlLongSendTestCases, nil)
 }


### PR DESCRIPTION
This is a hotfix related to PR #275 that replace the `{{quick_replies}}` variable in all message part requests. The current implementation keeps the "{{quick_replies}}" string in send URL/body of parts before the last one, breaking the request format. Therefore, replacing that variable by it's list zero value according send method and content type.