### PR TITLE
Retry WhatsApp messaging after contact verification with returned WhatsApp ID

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -576,48 +576,21 @@ func (ts *BackendTestSuite) TestMsgStatus() {
 	ts.Equal(m.Status_, courier.MsgFailed)
 	ts.Equal(m.ErrorCount_, 3)
 
-	// don't update URN for different URN schemes
-	status = ts.b.NewMsgStatusForID(channel, courier.NewMsgID(10000), courier.MsgSent)
-	oldURN, _ := urns.NewTelURNForCountry("12065551518", "US")
-	newURN, _ := urns.NewWhatsAppURN("12065551518")
-	status.SetUpdatedURN(oldURN, newURN)
-
-	ts.Error(ts.b.WriteMsgStatus(ctx, status))
-
-	// don't update URN for equal status URNs
-	tx, _ := ts.b.db.BeginTxx(ctx, nil)
-	oldURN, _ = urns.NewTelURNForCountry("12065551520", "US")
-	_ = insertContactURN(tx, newDBContactURN(channel.OrgID_, channel.ID_, NilContactID, oldURN, ""))
-
-	ts.NoError(tx.Commit())
-
-	status = ts.b.NewMsgStatusForID(channel, courier.MsgID(10000), courier.MsgSent)
-	status.SetUpdatedURN(oldURN, oldURN)
-
-	ts.NoError(ts.b.WriteMsgStatus(ctx, status))
-
-	tx, _ = ts.b.db.BeginTxx(ctx, nil)
-	contactURN, err := selectContactURN(tx, channel.OrgID_, oldURN)
-
-	ts.NoError(err)
-	ts.Equal(contactURN.Identity, oldURN.Identity().String())
-	ts.NoError(tx.Commit())
-
 	// update URN when the new doesn't exist
-	tx, _ = ts.b.db.BeginTxx(ctx, nil)
-	oldURN, _ = urns.NewWhatsAppURN("55988776655")
+	tx, _ := ts.b.db.BeginTxx(ctx, nil)
+	oldURN, _ := urns.NewWhatsAppURN("55988776655")
 	_ = insertContactURN(tx, newDBContactURN(channel.OrgID_, channel.ID_, NilContactID, oldURN, ""))
 
 	ts.NoError(tx.Commit())
 
-	newURN, _ = urns.NewWhatsAppURN("5588776655")
+	newURN, _ := urns.NewWhatsAppURN("5588776655")
 	status = ts.b.NewMsgStatusForID(channel, courier.MsgID(10000), courier.MsgSent)
 	status.SetUpdatedURN(oldURN, newURN)
 
 	ts.NoError(ts.b.WriteMsgStatus(ctx, status))
 
 	tx, _ = ts.b.db.BeginTxx(ctx, nil)
-	contactURN, err = selectContactURN(tx, channel.OrgID_, newURN)
+	contactURN, err := selectContactURN(tx, channel.OrgID_, newURN)
 
 	ts.NoError(err)
 	ts.Equal(contactURN.Identity, newURN.Identity().String())

--- a/backends/rapidpro/status.go
+++ b/backends/rapidpro/status.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/nyaruka/gocommon/urns"
 	"log"
 	"os"
 	"strconv"
@@ -22,6 +23,8 @@ func newMsgStatus(channel courier.Channel, id courier.MsgID, externalID string, 
 		ChannelUUID_: channel.UUID(),
 		ChannelID_:   dbChannel.ID(),
 		ID_:          id,
+		OldURN_:      urns.NilURN,
+		NewURN_:      urns.NilURN,
 		ExternalID_:  externalID,
 		Status_:      status,
 		ModifiedOn_:  time.Now().In(time.UTC),
@@ -296,6 +299,8 @@ type DBMsgStatus struct {
 	ChannelUUID_ courier.ChannelUUID    `json:"channel_uuid"             db:"channel_uuid"`
 	ChannelID_   courier.ChannelID      `json:"channel_id"               db:"channel_id"`
 	ID_          courier.MsgID          `json:"msg_id,omitempty"         db:"msg_id"`
+	OldURN_      urns.URN               `json:"old_urn"                  db:"old_urn"`
+	NewURN_      urns.URN               `json:"new_urn"                  db:"new_urn"`
 	ExternalID_  string                 `json:"external_id,omitempty"    db:"external_id"`
 	Status_      courier.MsgStatusValue `json:"status"                   db:"status"`
 	ModifiedOn_  time.Time              `json:"modified_on"              db:"modified_on"`
@@ -316,6 +321,11 @@ func (s *DBMsgStatus) RowID() string {
 	}
 	return ""
 }
+
+func (s *DBMsgStatus) OldURN() urns.URN       { return s.OldURN_ }
+func (s *DBMsgStatus) SetOldURN(urn urns.URN) { s.OldURN_ = urn }
+func (s *DBMsgStatus) NewURN() urns.URN       { return s.NewURN_ }
+func (s *DBMsgStatus) SetNewURN(urn urns.URN) { s.NewURN_ = urn }
 
 func (s *DBMsgStatus) ExternalID() string      { return s.ExternalID_ }
 func (s *DBMsgStatus) SetExternalID(id string) { s.ExternalID_ = id }

--- a/backends/rapidpro/status.go
+++ b/backends/rapidpro/status.go
@@ -322,10 +322,13 @@ func (s *DBMsgStatus) RowID() string {
 	return ""
 }
 
-func (s *DBMsgStatus) OldURN() urns.URN       { return s.OldURN_ }
-func (s *DBMsgStatus) SetOldURN(urn urns.URN) { s.OldURN_ = urn }
-func (s *DBMsgStatus) NewURN() urns.URN       { return s.NewURN_ }
-func (s *DBMsgStatus) SetNewURN(urn urns.URN) { s.NewURN_ = urn }
+func (s *DBMsgStatus) SetUpdatedURN(old, new urns.URN) {
+	s.OldURN_ = old
+	s.NewURN_ = new
+}
+func (s *DBMsgStatus) UpdatedURN() (urns.URN, urns.URN) {
+	return s.OldURN_, s.NewURN_
+}
 
 func (s *DBMsgStatus) ExternalID() string      { return s.ExternalID_ }
 func (s *DBMsgStatus) SetExternalID(id string) { s.ExternalID_ = id }

--- a/backends/rapidpro/urn.go
+++ b/backends/rapidpro/urn.go
@@ -181,6 +181,17 @@ ORDER BY
 LIMIT 1
 `
 
+// selectContactURN returns the ContactURN for the passed in org and URN
+func selectContactURN(db *sqlx.Tx, org OrgID, urn urns.URN) (*DBContactURN, error) {
+	contactURN := newDBContactURN(org, courier.NilChannelID, NilContactID, urn, "")
+	err := db.Get(contactURN, selectOrgURN, org, urn.Identity())
+
+	if err != nil {
+		return nil, err
+	}
+	return contactURN, nil
+}
+
 // contactURNForURN returns the ContactURN for the passed in org and URN, creating and associating
 // it with the passed in contact if necessary
 func contactURNForURN(db *sqlx.Tx, org OrgID, channelID courier.ChannelID, contactID ContactID, urn urns.URN, auth string) (*DBContactURN, error) {
@@ -248,6 +259,8 @@ UPDATE
 SET 
 	channel_id = :channel_id, 
 	contact_id = :contact_id, 
+	identity = :identity, 
+	path = :path, 
 	display = :display, 
 	auth = :auth, 
 	priority = :priority

--- a/backends/rapidpro/urn.go
+++ b/backends/rapidpro/urn.go
@@ -259,6 +259,18 @@ UPDATE
 SET 
 	channel_id = :channel_id, 
 	contact_id = :contact_id, 
+	display = :display, 
+	auth = :auth, 
+	priority = :priority
+WHERE 
+	id = :id
+`
+const fullyUpdateURN = `
+UPDATE 
+	contacts_contacturn
+SET 
+	channel_id = :channel_id, 
+	contact_id = :contact_id, 
 	identity = :identity, 
 	path = :path, 
 	display = :display, 
@@ -271,6 +283,21 @@ WHERE
 // UpdateContactURN updates the Channel and Contact on an existing URN
 func updateContactURN(db *sqlx.Tx, urn *DBContactURN) error {
 	rows, err := db.NamedQuery(updateURN, urn)
+	if err != nil {
+		logrus.WithError(err).WithField("urn_id", urn.ID).Error("error updating contact urn")
+		return err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		err = rows.Scan(&urn.ID)
+	}
+	return err
+}
+
+// FullyUpdateContactURN updates the Identity, Channel and Contact on an existing URN
+func fullyUpdateContactURN(db *sqlx.Tx, urn *DBContactURN) error {
+	rows, err := db.NamedQuery(fullyUpdateURN, urn)
 	if err != nil {
 		logrus.WithError(err).WithField("urn_id", urn.ID).Error("error updating contact urn")
 		return err

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -408,7 +408,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 					Type: "audio",
 				}
 				payload.Audio = &mediaObject{Link: s3url}
-				wppID, externalID, logs, err = h.sendWhatsAppMsg(ctx, msg, sendPath, token, payload)
+				wppID, externalID, logs, err = sendWhatsAppMsg(msg, sendPath, token, payload)
 
 			} else if strings.HasPrefix(mimeType, "application") {
 				payload := mtDocumentPayload{
@@ -421,7 +421,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 				} else {
 					payload.Document = &mediaObject{Link: s3url}
 				}
-				wppID, externalID, logs, err = h.sendWhatsAppMsg(ctx, msg, sendPath, token, payload)
+				wppID, externalID, logs, err = sendWhatsAppMsg(msg, sendPath, token, payload)
 
 			} else if strings.HasPrefix(mimeType, "image") {
 				payload := mtImagePayload{
@@ -433,7 +433,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 				} else {
 					payload.Image = &mediaObject{Link: s3url}
 				}
-				wppID, externalID, logs, err = h.sendWhatsAppMsg(ctx, msg, sendPath, token, payload)
+				wppID, externalID, logs, err = sendWhatsAppMsg(msg, sendPath, token, payload)
 			} else if strings.HasPrefix(mimeType, "video") {
 				payload := mtVideoPayload{
 					To:   msg.URN().Path(),
@@ -444,7 +444,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 				} else {
 					payload.Video = &mediaObject{Link: s3url}
 				}
-				wppID, externalID, logs, err = h.sendWhatsAppMsg(ctx, msg, sendPath, token, payload)
+				wppID, externalID, logs, err = sendWhatsAppMsg(msg, sendPath, token, payload)
 			} else {
 				duration := time.Since(start)
 				err = fmt.Errorf("unknown attachment mime type: %s", mimeType)
@@ -494,7 +494,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			}
 
 			externalID := ""
-			wppID, externalID, logs, err = h.sendWhatsAppMsg(ctx, msg, sendPath, token, payload)
+			wppID, externalID, logs, err = sendWhatsAppMsg(msg, sendPath, token, payload)
 
 			// add logs to our status
 			for _, log := range logs {
@@ -513,7 +513,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 					Type: "text",
 				}
 				payload.Text.Body = part
-				wppID, externalID, logs, err = h.sendWhatsAppMsg(ctx, msg, sendPath, token, payload)
+				wppID, externalID, logs, err = sendWhatsAppMsg(msg, sendPath, token, payload)
 
 				// add logs to our status
 				for _, log := range logs {
@@ -534,16 +534,15 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 	// we are wired it there were no errors
 	if err == nil {
 		if wppID != "" {
-			status.SetOldURN(msg.URN())
-			toURN, _ := urns.NewWhatsAppURN(wppID)
-			status.SetNewURN(toURN)
+			newURN, _ := urns.NewWhatsAppURN(wppID)
+			status.SetUpdatedURN(msg.URN(), newURN)
 		}
 		status.SetStatus(courier.MsgWired)
 	}
 	return status, nil
 }
 
-func (h *handler) sendWhatsAppMsg(ctx context.Context, msg courier.Msg, sendPath *url.URL, token string, payload interface{}) (string, string, []*courier.ChannelLog, error) {
+func sendWhatsAppMsg(msg courier.Msg, sendPath *url.URL, token string, payload interface{}) (string, string, []*courier.ChannelLog, error) {
 	start := time.Now()
 	jsonBody, err := json.Marshal(payload)
 

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -481,7 +481,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 				return nil, errors.Errorf("cannot send template message without Facebook namespace for channel: %s", msg.Channel().UUID())
 			}
 
-			payload := &hsmPayload{
+			payload := hsmPayload{
 				To:   msg.URN().Path(),
 				Type: "hsm",
 			}

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -508,7 +508,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 
 			externalID := ""
 			if msg.Channel().BoolConfigForKey(configHSMSupport, false) {
-				payload := &hsmPayload{
+				payload := hsmPayload{
 					To:   msg.URN().Path(),
 					Type: "hsm",
 				}
@@ -522,7 +522,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 				wppID, externalID, logs, err = sendWhatsAppMsg(msg, sendPath, token, payload)
 			} else {
 
-				payload := &templatePayload{
+				payload := templatePayload{
 					To:   msg.URN().Path(),
 					Type: "template",
 				}
@@ -652,6 +652,9 @@ func sendWhatsAppMsg(msg courier.Msg, sendPath *url.URL, token string, payload i
 			} else if document, ok := payload.(mtDocumentPayload); ok {
 				document.To = wppID
 				updatedPayload = document
+			} else if template, ok := payload.(templatePayload); ok {
+				template.To = wppID
+				updatedPayload = template
 			} else if hsm, ok := payload.(hsmPayload); ok {
 				hsm.To = wppID
 				updatedPayload = hsm

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -535,7 +535,13 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 	if err == nil {
 		if wppID != "" {
 			newURN, _ := urns.NewWhatsAppURN(wppID)
-			status.SetUpdatedURN(msg.URN(), newURN)
+			err = status.SetUpdatedURN(msg.URN(), newURN)
+
+			if err != nil {
+				elapsed := time.Now().Sub(start)
+				log := courier.NewChannelLogFromError("unable to update contact URN", msg.Channel(), msg.ID(), elapsed, err)
+				status.AddLog(log)
+			}
 		}
 		status.SetStatus(courier.MsgWired)
 	}

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -637,27 +637,28 @@ func sendWhatsAppMsg(msg courier.Msg, sendPath *url.URL, token string, payload i
 			var updatedPayload interface{}
 
 			// handle msg type casting
-			if text, ok := payload.(mtTextPayload); ok {
-				text.To = wppID
-				updatedPayload = text
-			} else if image, ok := payload.(mtImagePayload); ok {
-				image.To = wppID
-				updatedPayload = image
-			} else if video, ok := payload.(mtVideoPayload); ok {
-				video.To = wppID
-				updatedPayload = video
-			} else if audio, ok := payload.(mtAudioPayload); ok {
-				audio.To = wppID
-				updatedPayload = audio
-			} else if document, ok := payload.(mtDocumentPayload); ok {
-				document.To = wppID
-				updatedPayload = document
-			} else if template, ok := payload.(templatePayload); ok {
-				template.To = wppID
-				updatedPayload = template
-			} else if hsm, ok := payload.(hsmPayload); ok {
-				hsm.To = wppID
-				updatedPayload = hsm
+			switch v := payload.(type) {
+			case mtTextPayload:
+				v.To = wppID
+				updatedPayload = v
+			case mtImagePayload:
+				v.To = wppID
+				updatedPayload = v
+			case mtVideoPayload:
+				v.To = wppID
+				updatedPayload = v
+			case mtAudioPayload:
+				v.To = wppID
+				updatedPayload = v
+			case mtDocumentPayload:
+				v.To = wppID
+				updatedPayload = v
+			case templatePayload:
+				v.To = wppID
+				updatedPayload = v
+			case hsmPayload:
+				v.To = wppID
+				updatedPayload = v
 			}
 			// marshal updated payload
 			if updatedPayload != nil {

--- a/handlers/whatsapp/whatsapp_test.go
+++ b/handlers/whatsapp/whatsapp_test.go
@@ -436,6 +436,38 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		},
 		SendPrep: setSendURL,
 	},
+	{Label: "Try Messaging Again After WhatsApp Contact Check With Returned WhatsApp ID",
+		Text: "try again", URN: "whatsapp:5582999887766",
+		Status: "W", ExternalID: "157b5e14568e8",
+		Responses: map[MockedRequest]MockedResponse{
+			MockedRequest{
+				Method: "POST",
+				Path:   "/v1/messages",
+				Body:   `{"to":"5582999887766","type":"text","text":{"body":"try again"}}`,
+			}: MockedResponse{
+				Status: 404,
+				Body:   `{"errors": [{"code": 1006, "title": "Resource not found", "details": "unknown contact"}]}`,
+			},
+			MockedRequest{
+				Method: "POST",
+				Path:   "/v1/contacts",
+				Body:   `{"blocking":"wait","contacts":["+5582999887766"],"force_check":true}`,
+			}: MockedResponse{
+				Status: 200,
+				Body:   `{"contacts": [{"input": "+5582999887766", "status": "valid", "wa_id": "558299887766"}]}`,
+			},
+			MockedRequest{
+				Method:   "POST",
+				Path:     "/v1/messages",
+				RawQuery: "retry=1",
+				Body:     `{"to":"558299887766","type":"text","text":{"body":"try again"}}`,
+			}: MockedResponse{
+				Status: 201,
+				Body:   `{"messages": [{"id": "157b5e14568e8"}]}`,
+			},
+		},
+		SendPrep: setSendURL,
+	},
 }
 
 func TestSending(t *testing.T) {

--- a/status.go
+++ b/status.go
@@ -1,5 +1,7 @@
 package courier
 
+import "github.com/nyaruka/gocommon/urns"
+
 // MsgStatusValue is the status of a message
 type MsgStatusValue string
 
@@ -25,6 +27,11 @@ type MsgStatus interface {
 
 	ChannelUUID() ChannelUUID
 	ID() MsgID
+
+	OldURN() urns.URN
+	SetOldURN(urns.URN)
+	NewURN() urns.URN
+	SetNewURN(urns.URN)
 
 	ExternalID() string
 	SetExternalID(string)

--- a/status.go
+++ b/status.go
@@ -28,10 +28,8 @@ type MsgStatus interface {
 	ChannelUUID() ChannelUUID
 	ID() MsgID
 
-	OldURN() urns.URN
-	SetOldURN(urns.URN)
-	NewURN() urns.URN
-	SetNewURN(urns.URN)
+	SetUpdatedURN(old, new urns.URN)
+	UpdatedURN() (old, new urns.URN)
 
 	ExternalID() string
 	SetExternalID(string)

--- a/status.go
+++ b/status.go
@@ -28,8 +28,9 @@ type MsgStatus interface {
 	ChannelUUID() ChannelUUID
 	ID() MsgID
 
-	SetUpdatedURN(old, new urns.URN)
+	SetUpdatedURN(old, new urns.URN) error
 	UpdatedURN() (old, new urns.URN)
+	HasUpdatedURN() bool
 
 	ExternalID() string
 	SetExternalID(string)

--- a/test.go
+++ b/test.go
@@ -577,10 +577,13 @@ func (m *mockMsgStatus) ChannelUUID() ChannelUUID { return m.channel.UUID() }
 func (m *mockMsgStatus) ID() MsgID                { return m.id }
 func (m *mockMsgStatus) EventID() int64           { return int64(m.id) }
 
-func (m *mockMsgStatus) OldURN() urns.URN       { return m.oldURN }
-func (m *mockMsgStatus) SetOldURN(urn urns.URN) { m.oldURN = urn }
-func (m *mockMsgStatus) NewURN() urns.URN       { return m.newURN }
-func (m *mockMsgStatus) SetNewURN(urn urns.URN) { m.newURN = urn }
+func (m *mockMsgStatus) SetUpdatedURN(old, new urns.URN) {
+	m.oldURN = old
+	m.newURN = new
+}
+func (m *mockMsgStatus) UpdatedURN() (urns.URN, urns.URN) {
+	return m.oldURN, m.newURN
+}
 
 func (m *mockMsgStatus) ExternalID() string      { return m.externalID }
 func (m *mockMsgStatus) SetExternalID(id string) { m.externalID = id }

--- a/test.go
+++ b/test.go
@@ -577,12 +577,19 @@ func (m *mockMsgStatus) ChannelUUID() ChannelUUID { return m.channel.UUID() }
 func (m *mockMsgStatus) ID() MsgID                { return m.id }
 func (m *mockMsgStatus) EventID() int64           { return int64(m.id) }
 
-func (m *mockMsgStatus) SetUpdatedURN(old, new urns.URN) {
+func (m *mockMsgStatus) SetUpdatedURN(old, new urns.URN) error {
 	m.oldURN = old
 	m.newURN = new
+	return nil
 }
 func (m *mockMsgStatus) UpdatedURN() (urns.URN, urns.URN) {
 	return m.oldURN, m.newURN
+}
+func (m *mockMsgStatus) HasUpdatedURN() bool {
+	if m.oldURN != urns.NilURN && m.newURN != urns.NilURN {
+		return true
+	}
+	return false
 }
 
 func (m *mockMsgStatus) ExternalID() string      { return m.externalID }

--- a/test.go
+++ b/test.go
@@ -564,6 +564,8 @@ func (m *mockMsg) WithMetadata(metadata json.RawMessage) Msg { m.metadata = meta
 type mockMsgStatus struct {
 	channel    Channel
 	id         MsgID
+	oldURN     urns.URN
+	newURN     urns.URN
 	externalID string
 	status     MsgStatusValue
 	createdOn  time.Time
@@ -574,6 +576,11 @@ type mockMsgStatus struct {
 func (m *mockMsgStatus) ChannelUUID() ChannelUUID { return m.channel.UUID() }
 func (m *mockMsgStatus) ID() MsgID                { return m.id }
 func (m *mockMsgStatus) EventID() int64           { return int64(m.id) }
+
+func (m *mockMsgStatus) OldURN() urns.URN       { return m.oldURN }
+func (m *mockMsgStatus) SetOldURN(urn urns.URN) { m.oldURN = urn }
+func (m *mockMsgStatus) NewURN() urns.URN       { return m.newURN }
+func (m *mockMsgStatus) SetNewURN(urn urns.URN) { m.newURN = urn }
 
 func (m *mockMsgStatus) ExternalID() string      { return m.externalID }
 func (m *mockMsgStatus) SetExternalID(id string) { m.externalID = id }


### PR DESCRIPTION
PR https://github.com/nyaruka/courier/pull/286 makes contact verification by `POST /v1/contacts`, validating the phone number before a new retry to `POST /v1/messages`, when the first try fails with error `"unknown contact"`. Response body format for contact verification:
```json
{
  "contacts": [{"input": "16315551000", "status": "valid", "wa_id": "16315551000"}]
}
```
This PR adjusts the retry request to use the `"wa_id"` returned from contact verification instead of the URN, because we may have inconsistencies in the format of phone numbers in some country when they are registered via API or manually.

In our case, in Brazil, a 9th digit has been incorporated into phone numbers in recent years, but not in WhatsApp, there are regions with 8-digit phone numbers while they are registered in the 9-digit pattern on RP, for example, "+55 98877-6655" is the current phone number pattern, while in WhatsApp it is "+55 8877-6655", causing problems with the new attempt to send message. Contact verification with "+55 98877-6655" or "+55 98877-6655" would return the same `"wa_id"`, which is "5588776655".

So, this PR makes messaging more reliable in these cases of phone number inconsistencies with WhatsApp.