### PR TITLE
Add session status from mailroom to MT message sent to external channel API CGI parameters

### DIFF
--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -504,7 +504,7 @@ type DBMsg struct {
 	SessionID_            SessionID  `json:"session_id,omitempty"`
 	SessionTimeout_       int        `json:"session_timeout,omitempty"`
 	SessionWaitStartedOn_ *time.Time `json:"session_wait_started_on,omitempty"`
-	SessionStatus_ string `json:"session_status,omitempty"`
+	SessionStatus_        string     `json:"session_status,omitempty"`
 
 	channel        *DBChannel
 	workerToken    queue.WorkerToken
@@ -528,7 +528,7 @@ func (m *DBMsg) ResponseToID() courier.MsgID  { return m.ResponseToID_ }
 func (m *DBMsg) ResponseToExternalID() string { return m.ResponseToExternalID_ }
 
 func (m *DBMsg) Channel() courier.Channel { return m.channel }
-func (m *DBMsg) SessionStatus() string {return m.SessionStatus_ }
+func (m *DBMsg) SessionStatus() string    { return m.SessionStatus_ }
 
 func (m *DBMsg) QuickReplies() []string {
 	if m.quickReplies != nil {

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -504,6 +504,7 @@ type DBMsg struct {
 	SessionID_            SessionID  `json:"session_id,omitempty"`
 	SessionTimeout_       int        `json:"session_timeout,omitempty"`
 	SessionWaitStartedOn_ *time.Time `json:"session_wait_started_on,omitempty"`
+	SessionStatus_ string `json:"session_status,omitempty"`
 
 	channel        *DBChannel
 	workerToken    queue.WorkerToken
@@ -527,6 +528,7 @@ func (m *DBMsg) ResponseToID() courier.MsgID  { return m.ResponseToID_ }
 func (m *DBMsg) ResponseToExternalID() string { return m.ResponseToExternalID_ }
 
 func (m *DBMsg) Channel() courier.Channel { return m.channel }
+func (m *DBMsg) SessionStatus() string {return m.SessionStatus_ }
 
 func (m *DBMsg) QuickReplies() []string {
 	if m.quickReplies != nil {

--- a/handlers/external/external.go
+++ b/handlers/external/external.go
@@ -290,14 +290,14 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 	for i, part := range parts {
 		// build our request
 		form := map[string]string{
-			"id":           msg.ID().String(),
-			"text":         part,
-			"to":           msg.URN().Path(),
-			"to_no_plus":   strings.TrimPrefix(msg.URN().Path(), "+"),
-			"from":         msg.Channel().Address(),
-			"from_no_plus": strings.TrimPrefix(msg.Channel().Address(), "+"),
-			"channel":      msg.Channel().UUID().String(),
-			"session_status":	msg.SessionStatus(),
+			"id":             msg.ID().String(),
+			"text":           part,
+			"to":             msg.URN().Path(),
+			"to_no_plus":     strings.TrimPrefix(msg.URN().Path(), "+"),
+			"from":           msg.Channel().Address(),
+			"from_no_plus":   strings.TrimPrefix(msg.Channel().Address(), "+"),
+			"channel":        msg.Channel().UUID().String(),
+			"session_status": msg.SessionStatus(),
 		}
 
 		useNationalStr := msg.Channel().ConfigForKey(courier.ConfigUseNational, false)

--- a/handlers/external/external.go
+++ b/handlers/external/external.go
@@ -297,6 +297,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 			"from":         msg.Channel().Address(),
 			"from_no_plus": strings.TrimPrefix(msg.Channel().Address(), "+"),
 			"channel":      msg.Channel().UUID().String(),
+			"session_status":	msg.SessionStatus(),
 		}
 
 		useNationalStr := msg.Channel().ConfigForKey(courier.ConfigUseNational, false)

--- a/msg.go
+++ b/msg.go
@@ -115,4 +115,5 @@ type Msg interface {
 	WithMetadata(metadata json.RawMessage) Msg
 
 	EventID() int64
+	SessionStatus() string
 }

--- a/test.go
+++ b/test.go
@@ -543,7 +543,7 @@ type mockMsg struct {
 	wiredOn    *time.Time
 }
 
-func (m *mockMsg) SessionStatus() string {return ""}
+func (m *mockMsg) SessionStatus() string { return "" }
 
 func (m *mockMsg) Channel() Channel             { return m.channel }
 func (m *mockMsg) ID() MsgID                    { return m.id }

--- a/test.go
+++ b/test.go
@@ -543,6 +543,8 @@ type mockMsg struct {
 	wiredOn    *time.Time
 }
 
+func (m *mockMsg) SessionStatus() string {return ""}
+
 func (m *mockMsg) Channel() Channel             { return m.channel }
 func (m *mockMsg) ID() MsgID                    { return m.id }
 func (m *mockMsg) EventID() int64               { return int64(m.id) }


### PR DESCRIPTION
Mailroom passes the session status to courier. We would like to pass that on in the external API URL call.

 Relates to https://github.com/rapidpro/rapidpro/issues/1298