### PR TITLE
Add handling for whatsapp quickreply responses

### DIFF
--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -103,6 +103,10 @@ type eventPayload struct {
 			MimeType string `json:"mime_type" validate:"required"`
 			Sha256   string `json:"sha256"    validate:"required"`
 		} `json:"audio"`
+		Button *struct {
+			Payload string `json:"payload"`
+			Text    string `json:"text"    validate:"required"`
+		} `json:"button"`
 		Document *struct {
 			File     string `json:"file"      validate:"required"`
 			ID       string `json:"id"        validate:"required"`
@@ -190,6 +194,8 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 			text = msg.Text.Body
 		} else if msg.Type == "audio" && msg.Audio != nil {
 			mediaURL, err = resolveMediaURL(channel, msg.Audio.ID)
+		} else if msg.Type == "button" && msg.Button != nil {
+			text = msg.Button.Text
 		} else if msg.Type == "document" && msg.Document != nil {
 			text = msg.Document.Caption
 			mediaURL, err = resolveMediaURL(channel, msg.Document.ID)

--- a/handlers/whatsapp/whatsapp_test.go
+++ b/handlers/whatsapp/whatsapp_test.go
@@ -98,6 +98,19 @@ var audioMsg = `{
 	}]
 }`
 
+var buttonMsg = `{
+	"messages": [{
+		"from": "250788123123",
+		"id": "41",
+		"timestamp": "1454119029",
+		"type": "button",
+		"button": {
+			"payload": null,
+			"text": "BUTTON1"
+		}
+	}]
+}`
+
 var documentMsg = `{
 	"messages": [{
 		"from": "250788123123",
@@ -250,6 +263,8 @@ var waTestCases = []ChannelHandleTestCase{
 		Text: Sp("hello world"), URN: Sp("whatsapp:250788123123"), ExternalID: Sp("41"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC))},
 	{Label: "Receive Valid Audio Message", URL: waReceiveURL, Data: audioMsg, Status: 200, Response: `"type":"msg"`,
 		Text: Sp(""), Attachment: Sp("https://foo.bar/v1/media/41"), URN: Sp("whatsapp:250788123123"), ExternalID: Sp("41"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC))},
+	{Label: "Receive Valid Button Message", URL: waReceiveURL, Data: buttonMsg, Status: 200, Response: `"type":"msg"`,
+		Text: Sp("BUTTON1"), URN: Sp("whatsapp:250788123123"), ExternalID: Sp("41"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC))},
 	{Label: "Receive Valid Document Message", URL: waReceiveURL, Data: documentMsg, Status: 200, Response: `"type":"msg"`,
 		Text: Sp("the caption"), Attachment: Sp("https://foo.bar/v1/media/41"), URN: Sp("whatsapp:250788123123"), ExternalID: Sp("41"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC))},
 	{Label: "Receive Valid Image Message", URL: waReceiveURL, Data: imageMsg, Status: 200, Response: `"type":"msg"`,


### PR DESCRIPTION
This allows RapidPro to handle quickreply responses / button messages, by interpreting the button text as the message text.

More details in https://github.com/rapidpro/rapidpro/issues/1430