### PR TITLE
Do not verify the SSL certificate for Bongo Live

### DIFF
--- a/handlers/bongolive/bongolive.go
+++ b/handlers/bongolive/bongolive.go
@@ -164,7 +164,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		}
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-		rr, err := utils.MakeHTTPRequest(req)
+		rr, err := utils.MakeInsecureHTTPRequest(req)
 
 		// record our status and log
 		log := courier.NewChannelLogFromRR("Message Sent", msg.Channel(), msg.ID(), rr).WithError("Send Error", err)


### PR DESCRIPTION
BongoLive now Beem Africa have a self signed certificate and that is failing to validate.
I tried to clarify that to team so that they can fix that but if they do not we can ignore the verification so messages are sent.