### PR TITLE
add is_resend to Msg payload to allow for resending messages manually

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -68,7 +68,11 @@ type Backend interface {
 
 	// WasMsgSent returns whether the backend thinks the passed in message was already sent. This can be used in cases where
 	// a backend wants to implement a failsafe against double sending messages (say if they were double queued)
-	WasMsgSent(context.Context, Msg) (bool, error)
+	WasMsgSent(context.Context, MsgID) (bool, error)
+
+	// ClearMsgSent clears any internal status that a message was previously sent. This can be used in the case where
+	// a message is being forced in being resent by a user
+	ClearMsgSent(context.Context, MsgID) error
 
 	// IsMsgLoop returns whether the passed in message is part of a message loop, possibly with another bot. Backends should
 	// implement their own logic to implement this.

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -183,13 +183,29 @@ var luaSent = redis.NewScript(3,
 `)
 
 // WasMsgSent returns whether the passed in message has already been sent
-func (b *backend) WasMsgSent(ctx context.Context, msg courier.Msg) (bool, error) {
+func (b *backend) WasMsgSent(ctx context.Context, id courier.MsgID) (bool, error) {
 	rc := b.redisPool.Get()
 	defer rc.Close()
 
 	todayKey := fmt.Sprintf(sentSetName, time.Now().UTC().Format("2006_01_02"))
 	yesterdayKey := fmt.Sprintf(sentSetName, time.Now().Add(time.Hour*-24).UTC().Format("2006_01_02"))
-	return redis.Bool(luaSent.Do(rc, todayKey, yesterdayKey, msg.ID().String()))
+	return redis.Bool(luaSent.Do(rc, todayKey, yesterdayKey, id.String()))
+}
+
+var luaClearSent = redis.NewScript(3,
+	`-- KEYS: [TodayKey, YesterdayKey, MsgID]
+	 redis.call("srem", KEYS[1], KEYS[3])
+     redis.call("srem", KEYS[2], KEYS[3])
+`)
+
+func (b *backend) ClearMsgSent(ctx context.Context, id courier.MsgID) error {
+	rc := b.redisPool.Get()
+	defer rc.Close()
+
+	todayKey := fmt.Sprintf(sentSetName, time.Now().UTC().Format("2006_01_02"))
+	yesterdayKey := fmt.Sprintf(sentSetName, time.Now().Add(time.Hour*-24).UTC().Format("2006_01_02"))
+	_, err := luaClearSent.Do(rc, todayKey, yesterdayKey, id.String())
+	return err
 }
 
 var luaMsgLoop = redis.NewScript(3, `-- KEYS: [key, contact_id, text]
@@ -330,16 +346,7 @@ func (b *backend) WriteMsgStatus(ctx context.Context, status courier.MsgStatus) 
 
 	// if we have an id and are marking an outgoing msg as errored, then clear our sent flag
 	if status.ID() != courier.NilMsgID && status.Status() == courier.MsgErrored {
-		rc := b.redisPool.Get()
-		defer rc.Close()
-
-		dateKey := fmt.Sprintf(sentSetName, time.Now().UTC().Format("2006_01_02"))
-		prevDateKey := fmt.Sprintf(sentSetName, time.Now().Add(time.Hour*-24).UTC().Format("2006_01_02"))
-
-		// we pipeline the removals because we don't care about the return value
-		rc.Send("srem", dateKey, status.ID().String())
-		rc.Send("srem", prevDateKey, status.ID().String())
-		_, err := rc.Do("")
+		err := b.ClearMsgSent(ctx, status.ID())
 		if err != nil {
 			logrus.WithError(err).WithField("msg", status.ID().String()).Error("error clearing sent flags")
 		}

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -123,6 +123,7 @@ func (ts *BackendTestSuite) TestMsgUnmarshal() {
 		"response_to_id": 15,
 		"response_to_external_id": "external-id",
 		"external_id": null,
+		"is_resend": true,
 		"metadata": {"quick_replies": ["Yes", "No"], "topic": "event"}
 	}`
 
@@ -139,6 +140,7 @@ func (ts *BackendTestSuite) TestMsgUnmarshal() {
 	ts.Equal(courier.NewMsgID(15), msg.ResponseToID())
 	ts.Equal("external-id", msg.ResponseToExternalID())
 	ts.True(msg.HighPriority())
+	ts.True(msg.IsResend())
 
 	msgJSONNoQR := `{
 		"status": "P",
@@ -173,6 +175,7 @@ func (ts *BackendTestSuite) TestMsgUnmarshal() {
 	ts.Equal("", msg.Topic())
 	ts.Equal(courier.NilMsgID, msg.ResponseToID())
 	ts.Equal("", msg.ResponseToExternalID())
+	ts.False(msg.IsResend())
 }
 
 func (ts *BackendTestSuite) TestCheckMsgExists() {
@@ -801,7 +804,7 @@ func (ts *BackendTestSuite) TestOutgoingQueue() {
 	ts.b.MarkOutgoingMsgComplete(ctx, msg, ts.b.NewMsgStatusForID(msg.Channel(), msg.ID(), courier.MsgWired))
 
 	// this message should now be marked as sent
-	sent, err := ts.b.WasMsgSent(ctx, msg)
+	sent, err := ts.b.WasMsgSent(ctx, msg.ID())
 	ts.NoError(err)
 	ts.True(sent)
 
@@ -813,7 +816,7 @@ func (ts *BackendTestSuite) TestOutgoingQueue() {
 	// checking another message should show unsent
 	msg3, err := readMsgFromDB(ts.b, courier.NewMsgID(10001))
 	ts.NoError(err)
-	sent, err = ts.b.WasMsgSent(ctx, msg3)
+	sent, err = ts.b.WasMsgSent(ctx, msg3.ID())
 	ts.NoError(err)
 	ts.False(sent)
 
@@ -822,7 +825,7 @@ func (ts *BackendTestSuite) TestOutgoingQueue() {
 	ts.NoError(err)
 
 	// message should no longer be considered sent
-	sent, err = ts.b.WasMsgSent(ctx, msg)
+	sent, err = ts.b.WasMsgSent(ctx, msg.ID())
 	ts.NoError(err)
 	ts.False(sent)
 }

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -505,6 +505,7 @@ type DBMsg struct {
 	ExternalID_           null.String            `json:"external_id"     db:"external_id"`
 	ResponseToID_         courier.MsgID          `json:"response_to_id"  db:"response_to_id"`
 	ResponseToExternalID_ string                 `json:"response_to_external_id"`
+	IsResend_             bool                   `json:"is_resend,omitempty"`
 	Metadata_             json.RawMessage        `json:"metadata"        db:"metadata"`
 
 	ChannelID_    courier.ChannelID `json:"channel_id"      db:"channel_id"`
@@ -523,8 +524,7 @@ type DBMsg struct {
 	QueuedOn_    time.Time `json:"queued_on"     db:"queued_on"`
 	SentOn_      time.Time `json:"sent_on"       db:"sent_on"`
 
-	// fields used only for mailroom enabled orgs.. these allow courier to update a session's timeout when
-	// a message is sent for correct and efficient timeout behavior
+	// fields used to allow courier to update a session's timeout when a message is sent for efficient timeout behavior
 	SessionID_            SessionID  `json:"session_id,omitempty"`
 	SessionTimeout_       int        `json:"session_timeout,omitempty"`
 	SessionWaitStartedOn_ *time.Time `json:"session_wait_started_on,omitempty"`
@@ -550,6 +550,7 @@ func (m *DBMsg) ReceivedOn() *time.Time       { return &m.SentOn_ }
 func (m *DBMsg) SentOn() *time.Time           { return &m.SentOn_ }
 func (m *DBMsg) ResponseToID() courier.MsgID  { return m.ResponseToID_ }
 func (m *DBMsg) ResponseToExternalID() string { return m.ResponseToExternalID_ }
+func (m *DBMsg) IsResend() bool               { return m.IsResend_ }
 
 func (m *DBMsg) Channel() courier.Channel { return m.channel }
 func (m *DBMsg) SessionStatus() string    { return m.SessionStatus_ }

--- a/msg.go
+++ b/msg.go
@@ -97,6 +97,7 @@ type Msg interface {
 	Metadata() json.RawMessage
 	ResponseToID() MsgID
 	ResponseToExternalID() string
+	IsResend() bool
 
 	Channel() Channel
 

--- a/sender.go
+++ b/sender.go
@@ -172,8 +172,17 @@ func (w *Sender) sendMessage(msg Msg) {
 
 	start := time.Now()
 
+	// if this is a resend, clear our sent status
+	if msg.IsResend() {
+		err := backend.ClearMsgSent(sendCTX, msg.ID())
+		if err != nil {
+			log.WithError(err).Error("error clearing sent status for msg")
+		}
+
+	}
+
 	// was this msg already sent? (from a double queue?)
-	sent, err := backend.WasMsgSent(sendCTX, msg)
+	sent, err := backend.WasMsgSent(sendCTX, msg.ID())
 
 	// failing on a lookup isn't a halting problem but we should log it
 	if err != nil {

--- a/test.go
+++ b/test.go
@@ -151,11 +151,19 @@ func (mb *MockBackend) PopNextOutgoingMsg(ctx context.Context) (Msg, error) {
 }
 
 // WasMsgSent returns whether the passed in msg was already sent
-func (mb *MockBackend) WasMsgSent(ctx context.Context, msg Msg) (bool, error) {
+func (mb *MockBackend) WasMsgSent(ctx context.Context, id MsgID) (bool, error) {
 	mb.mutex.Lock()
 	defer mb.mutex.Unlock()
 
-	return mb.sentMsgs[msg.ID()], nil
+	return mb.sentMsgs[id], nil
+}
+
+func (mb *MockBackend) ClearMsgSent(ctx context.Context, id MsgID) error {
+	mb.mutex.Lock()
+	defer mb.mutex.Unlock()
+
+	delete(mb.sentMsgs, id)
+	return nil
 }
 
 // IsMsgLoop returns whether the passed in msg is a loop
@@ -564,6 +572,7 @@ type mockMsg struct {
 	responseToExternalID string
 	metadata             json.RawMessage
 	alreadyWritten       bool
+	isResend             bool
 
 	receivedOn *time.Time
 	sentOn     *time.Time
@@ -588,6 +597,7 @@ func (m *mockMsg) Topic() string                { return m.topic }
 func (m *mockMsg) ResponseToID() MsgID          { return m.responseToID }
 func (m *mockMsg) ResponseToExternalID() string { return m.responseToExternalID }
 func (m *mockMsg) Metadata() json.RawMessage    { return m.metadata }
+func (m *mockMsg) IsResend() bool               { return m.isResend }
 
 func (m *mockMsg) ReceivedOn() *time.Time { return m.receivedOn }
 func (m *mockMsg) SentOn() *time.Time     { return m.sentOn }


### PR DESCRIPTION
The sender orchestration doesn't have a super nice unit test (it's tested as an integration test with all the various handlers) so need to figure out a better testing strategy for this