### PR TITLE
Give S3 storage test new context

### DIFF
--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -700,7 +700,9 @@ func (b *backend) Start() error {
 	}
 
 	// test our storage
+	ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
 	err = b.storage.Test(ctx)
+	cancel()
 	if err != nil {
 		log.WithError(err).Error(b.storage.Name() + " storage not available")
 	} else {


### PR DESCRIPTION
Update to latest gocommon adds context param to Storage.Test(..)

Noticed pushing to staging we got an error saying "S3 storage not available" but it was working fine https://sentry.io/organizations/nyaruka/issues/2525368566/?project=181813&query=is%3Aunresolved