### PR TITLE
add test for fb sigs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/go-playground/assert.v1 v1.2.1
+	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.11.0
 	gopkg.in/h2non/filetype.v1 v1.0.5
 )

--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/nyaruka/courier/handlers"
 	. "github.com/nyaruka/courier/handlers"
 	"github.com/nyaruka/gocommon/urns"
-	"gopkg.in/go-playground/assert.v1"
+	"github.com/stretchr/testify/assert"
 )
 
 var testChannels = []courier.Channel{
@@ -625,4 +625,26 @@ func TestSending(t *testing.T) {
 	maxMsgLength = 100
 	var defaultChannel = courier.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "FBA", "2020", "US", map[string]interface{}{courier.ConfigAuthToken: "access_token"})
 	RunChannelSendTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, nil)
+}
+
+func TestSigning(t *testing.T) {
+	tcs := []struct {
+		Body      string
+		Signature string
+	}{
+		{
+			"hello world",
+			"308de7627fe19e92294c4572a7f831bc1002809d",
+		},
+		{
+			"hello world2",
+			"ab6f902b58b9944032d4a960f470d7a8ebfd12b7",
+		},
+	}
+
+	for i, tc := range tcs {
+		sig, err := fbCalculateSignature("sesame", []byte(tc.Body))
+		assert.NoError(t, err)
+		assert.Equal(t, tc.Signature, sig, "%d: mismatched signature", i)
+	}
 }


### PR DESCRIPTION
We do get the body already escaped and that's what we calculate against so things work fine with unicode. this just tests that we aren't stripping leading `a`s from the sig.