### PR TITLE
Smarter organization of quick replies into rows and columns for telegram keyboards

### DIFF
--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -1,0 +1,32 @@
+package telegram
+
+import "github.com/nyaruka/courier/utils"
+
+// KeyboardButton is button on a keyboard, see https://core.telegram.org/bots/api/#keyboardbutton
+type KeyboardButton struct {
+	Text            string `json:"text"`
+	RequestContact  bool   `json:"request_contact,omitempty"`
+	RequestLocation bool   `json:"request_location,omitempty"`
+}
+
+// ReplyKeyboardMarkup models a keyboard, see https://core.telegram.org/bots/api/#replykeyboardmarkup
+type ReplyKeyboardMarkup struct {
+	Keyboard        [][]KeyboardButton `json:"keyboard"`
+	ResizeKeyboard  bool               `json:"resize_keyboard"`
+	OneTimeKeyboard bool               `json:"one_time_keyboard"`
+}
+
+// NewKeyboardFromReplies creates a keyboard from the given quick replies
+func NewKeyboardFromReplies(replies []string) *ReplyKeyboardMarkup {
+	rows := utils.StringsToRows(replies, 25, 5)
+	keyboard := make([][]KeyboardButton, len(rows))
+
+	for i := range rows {
+		keyboard[i] = make([]KeyboardButton, len(rows[i]))
+		for j := range rows[i] {
+			keyboard[i][j].Text = rows[i][j]
+		}
+	}
+
+	return &ReplyKeyboardMarkup{Keyboard: keyboard, ResizeKeyboard: true, OneTimeKeyboard: true}
+}

--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -18,7 +18,7 @@ type ReplyKeyboardMarkup struct {
 
 // NewKeyboardFromReplies creates a keyboard from the given quick replies
 func NewKeyboardFromReplies(replies []string) *ReplyKeyboardMarkup {
-	rows := utils.StringsToRows(replies, 25, 5)
+	rows := utils.StringsToRows(replies, 5, 30, 2)
 	keyboard := make([][]KeyboardButton, len(rows))
 
 	for i := range rows {

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -1,0 +1,51 @@
+package telegram_test
+
+import (
+	"testing"
+
+	"github.com/nyaruka/courier/handlers/telegram"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyboardFromReplies(t *testing.T) {
+	tcs := []struct {
+		replies  []string
+		expected *telegram.ReplyKeyboardMarkup
+	}{
+		{
+
+			[]string{"OK"},
+			&telegram.ReplyKeyboardMarkup{
+				[][]telegram.KeyboardButton{
+					{{Text: "OK"}},
+				},
+				true, true,
+			},
+		},
+		{
+			[]string{"Yes", "No", "Maybe"},
+			&telegram.ReplyKeyboardMarkup{
+				[][]telegram.KeyboardButton{
+					{{Text: "Yes"}, {Text: "No"}, {Text: "Maybe"}},
+				},
+				true, true,
+			},
+		},
+		{
+			[]string{"Vanilla", "Chocolate", "Mint", "Lemon Sorbet", "Papaya", "Strawberry"},
+			&telegram.ReplyKeyboardMarkup{
+				[][]telegram.KeyboardButton{
+					{{Text: "Vanilla"}, {Text: "Chocolate"}, {Text: "Mint"}},
+					{{Text: "Lemon Sorbet"}, {Text: "Papaya"}},
+					{{Text: "Strawberry"}},
+				},
+				true, true,
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		kb := telegram.NewKeyboardFromReplies(tc.replies)
+		assert.Equal(t, tc.expected, kb, "keyboard mismatch for replies %v", tc.replies)
+	}
+}

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -35,9 +35,20 @@ func TestKeyboardFromReplies(t *testing.T) {
 			[]string{"Vanilla", "Chocolate", "Mint", "Lemon Sorbet", "Papaya", "Strawberry"},
 			&telegram.ReplyKeyboardMarkup{
 				[][]telegram.KeyboardButton{
-					{{Text: "Vanilla"}, {Text: "Chocolate"}, {Text: "Mint"}},
-					{{Text: "Lemon Sorbet"}, {Text: "Papaya"}},
-					{{Text: "Strawberry"}},
+					{{Text: "Vanilla"}, {Text: "Chocolate"}},
+					{{Text: "Mint"}, {Text: "Lemon Sorbet"}},
+					{{Text: "Papaya"}, {Text: "Strawberry"}},
+				},
+				true, true,
+			},
+		},
+		{
+			[]string{"A", "B", "C", "D", "Chicken", "Fish", "Peanut Butter Pickle"},
+			&telegram.ReplyKeyboardMarkup{
+				[][]telegram.KeyboardButton{
+					{{Text: "A"}, {Text: "B"}, {Text: "C"}, {Text: "D"}},
+					{{Text: "Chicken"}, {Text: "Fish"}},
+					{{Text: "Peanut Butter Pickle"}},
 				},
 				true, true,
 			},

--- a/handlers/telegram/telegram_test.go
+++ b/handlers/telegram/telegram_test.go
@@ -581,7 +581,7 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		PostParams: map[string]string{
 			"text":         "Are you happy?",
 			"chat_id":      "12345",
-			"reply_markup": `{"resize_keyboard":true,"one_time_keyboard":true,"keyboard":[[{"text":"Yes"},{"text":"No"}]]}`,
+			"reply_markup": `{"keyboard":[[{"text":"Yes"},{"text":"No"}]],"resize_keyboard":true,"one_time_keyboard":true}`,
 		},
 		SendPrep: setSendURL},
 	{Label: "Unicode Send",

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -111,10 +111,11 @@ func BasePathForURL(rawURL string) (string, error) {
 }
 
 // StringsToRows takes a slice of strings and re-organizes it into rows and columns
-func StringsToRows(strs []string, maxRowRunes, maxRows int) [][]string {
+func StringsToRows(strs []string, maxRows, maxRowRunes, paddingRunes int) [][]string {
+	// calculate rune length if it's all one row
 	totalRunes := 0
 	for i := range strs {
-		totalRunes += utf8.RuneCountInString(strs[i])
+		totalRunes += utf8.RuneCountInString(strs[i]) + paddingRunes*2
 	}
 
 	if totalRunes <= maxRowRunes {
@@ -134,7 +135,7 @@ func StringsToRows(strs []string, maxRowRunes, maxRows int) [][]string {
 	rowRunes := 0
 
 	for _, str := range strs {
-		strRunes := utf8.RuneCountInString(str)
+		strRunes := utf8.RuneCountInString(str) + paddingRunes*2
 
 		// take a new row if we can't fit this string and the current row isn't empty and we haven't hit the row limit
 		if rowRunes+strRunes > maxRowRunes && len(rows[curRow]) > 0 && len(rows) < maxRows {

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -109,3 +109,42 @@ func BasePathForURL(rawURL string) (string, error) {
 	}
 	return path.Base(parsedURL.Path), nil
 }
+
+// StringsToRows takes a slice of strings and re-organizes it into rows and columns
+func StringsToRows(strs []string, maxRowRunes, maxRows int) [][]string {
+	totalRunes := 0
+	for i := range strs {
+		totalRunes += utf8.RuneCountInString(strs[i])
+	}
+
+	if totalRunes <= maxRowRunes {
+		// if all strings fit on a single row, do that
+		return [][]string{strs}
+	} else if len(strs) <= maxRows {
+		// if each string can be a row, do that
+		rows := make([][]string, len(strs))
+		for i := range strs {
+			rows[i] = []string{strs[i]}
+		}
+		return rows
+	}
+
+	rows := [][]string{{}}
+	curRow := 0
+	rowRunes := 0
+
+	for _, str := range strs {
+		strRunes := utf8.RuneCountInString(str)
+
+		// take a new row if we can't fit this string and the current row isn't empty and we haven't hit the row limit
+		if rowRunes+strRunes > maxRowRunes && len(rows[curRow]) > 0 && len(rows) < maxRows {
+			rows = append(rows, []string{})
+			curRow += 1
+			rowRunes = 0
+		}
+
+		rows[curRow] = append(rows[curRow], str)
+		rowRunes += strRunes
+	}
+	return rows
+}

--- a/utils/misc_test.go
+++ b/utils/misc_test.go
@@ -1,51 +1,116 @@
-package utils
+package utils_test
 
 import (
 	"net/url"
 	"testing"
 
+	"github.com/nyaruka/courier/utils"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSignHMAC256(t *testing.T) {
 	assert.Equal(t, "ce9a66626ee60f41beb538bbbafbf308cb8462a495c7abc6d04762ef9982f1e1",
-		SignHMAC256("DkGBlzdnzYeb2nm0", "valueToEncrypt"))
-	assert.Len(t, SignHMAC256("ZXwAumfRSejDxJGa", "newValueToEncrypt"), 64)
+		utils.SignHMAC256("DkGBlzdnzYeb2nm0", "valueToEncrypt"))
+	assert.Len(t, utils.SignHMAC256("ZXwAumfRSejDxJGa", "newValueToEncrypt"), 64)
 }
 
 func TestMapAsJSON(t *testing.T) {
-	assert.Equal(t, "{}", string(MapAsJSON(map[string]string{})))
-	assert.Equal(t, "{\"foo\":\"bar\"}", string(MapAsJSON(map[string]string{"foo": "bar"})))
+	assert.Equal(t, "{}", string(utils.MapAsJSON(map[string]string{})))
+	assert.Equal(t, "{\"foo\":\"bar\"}", string(utils.MapAsJSON(map[string]string{"foo": "bar"})))
 }
 
 func TestJoinNonEmpty(t *testing.T) {
-	assert.Equal(t, "", JoinNonEmpty(" "))
-	assert.Equal(t, "hello world", JoinNonEmpty(" ", "", "hello", "", "world"))
+	assert.Equal(t, "", utils.JoinNonEmpty(" "))
+	assert.Equal(t, "hello world", utils.JoinNonEmpty(" ", "", "hello", "", "world"))
 }
 
 func TestStringArrayContains(t *testing.T) {
-	assert.False(t, StringArrayContains([]string{}, "x"))
-	assert.False(t, StringArrayContains([]string{"a", "b"}, "x"))
-	assert.True(t, StringArrayContains([]string{"a", "b", "x", "y"}, "x"))
+	assert.False(t, utils.StringArrayContains([]string{}, "x"))
+	assert.False(t, utils.StringArrayContains([]string{"a", "b"}, "x"))
+	assert.True(t, utils.StringArrayContains([]string{"a", "b", "x", "y"}, "x"))
 }
 
 func TestCleanString(t *testing.T) {
-	assert.Equal(t, "\x41hello", CleanString("\x02\x41hello"))
-	assert.Equal(t, "😅 happy!", CleanString("😅 happy!"))
-	assert.Equal(t, "Hello  There", CleanString("Hello \x00 There"))
-	assert.Equal(t, "Hello There", CleanString("Hello There\u0000"))
-	assert.Equal(t, "Hello z There", CleanString("Hello \xc5z There"))
+	assert.Equal(t, "\x41hello", utils.CleanString("\x02\x41hello"))
+	assert.Equal(t, "😅 happy!", utils.CleanString("😅 happy!"))
+	assert.Equal(t, "Hello  There", utils.CleanString("Hello \x00 There"))
+	assert.Equal(t, "Hello There", utils.CleanString("Hello There\u0000"))
+	assert.Equal(t, "Hello z There", utils.CleanString("Hello \xc5z There"))
 
 	text, _ := url.PathUnescape("hi%1C%00%00%00%00%00%07%E0%00")
-	assert.Equal(t, "hi\x1c\a", CleanString(text))
+	assert.Equal(t, "hi\x1c\a", utils.CleanString(text))
 }
 
 func TestURLGetFile(t *testing.T) {
-	test1, err := BasePathForURL("https://example.com/test.pdf")
+	test1, err := utils.BasePathForURL("https://example.com/test.pdf")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "test.pdf", test1)
 
-	test2, err := BasePathForURL("application/pdf:https://some-url.host.service.com/media/999/zz99/9999/da514731-4bed-428c-afb9-860dd94530cc.xlsx")
+	test2, err := utils.BasePathForURL("application/pdf:https://some-url.host.service.com/media/999/zz99/9999/da514731-4bed-428c-afb9-860dd94530cc.xlsx")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "da514731-4bed-428c-afb9-860dd94530cc.xlsx", test2)
+}
+
+func TestStringsToRows(t *testing.T) {
+	tcs := []struct {
+		replies     []string
+		maxRowRunes int
+		maxRows     int
+		expected    [][]string
+	}{
+		{
+
+			replies:     []string{"OK"},
+			maxRowRunes: 30,
+			maxRows:     3,
+			expected: [][]string{
+				{"OK"},
+			},
+		},
+		{
+			// all values fit in single row
+			replies:     []string{"Yes", "No", "Maybe"},
+			maxRowRunes: 30,
+			maxRows:     3,
+			expected: [][]string{
+				{"Yes", "No", "Maybe"},
+			},
+		},
+		{
+			// all values can be their own row
+			replies:     []string{"12345678901234567890", "23456789012345678901", "34567890123456789012"},
+			maxRowRunes: 25,
+			maxRows:     3,
+			expected: [][]string{
+				{"12345678901234567890"},
+				{"23456789012345678901"},
+				{"34567890123456789012"},
+			},
+		},
+		{
+			replies:     []string{"1234567890", "2345678901", "3456789012", "4567890123"},
+			maxRowRunes: 25,
+			maxRows:     3,
+			expected: [][]string{
+				{"1234567890", "2345678901"},
+				{"3456789012", "4567890123"},
+			},
+		},
+		{
+			// we break chars per row limit rather than row limit
+			replies:     []string{"Vanilla", "Chocolate", "Strawberry", "Lemon Sorbet", "Ecuadorian Amazonian Papayas", "Mint"},
+			maxRowRunes: 30,
+			maxRows:     3,
+			expected: [][]string{
+				{"Vanilla", "Chocolate", "Strawberry"},
+				{"Lemon Sorbet"},
+				{"Ecuadorian Amazonian Papayas", "Mint"},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		rows := utils.StringsToRows(tc.replies, tc.maxRowRunes, tc.maxRows)
+		assert.Equal(t, tc.expected, rows, "rows mismatch for replies %v", tc.replies)
+	}
 }

--- a/utils/misc_test.go
+++ b/utils/misc_test.go
@@ -53,34 +53,38 @@ func TestURLGetFile(t *testing.T) {
 
 func TestStringsToRows(t *testing.T) {
 	tcs := []struct {
-		replies     []string
-		maxRowRunes int
-		maxRows     int
-		expected    [][]string
+		replies      []string
+		maxRows      int
+		maxRowRunes  int
+		paddingRunes int
+		expected     [][]string
 	}{
 		{
 
-			replies:     []string{"OK"},
-			maxRowRunes: 30,
-			maxRows:     3,
+			replies:      []string{"OK"},
+			maxRows:      3,
+			maxRowRunes:  30,
+			paddingRunes: 2,
 			expected: [][]string{
 				{"OK"},
 			},
 		},
 		{
 			// all values fit in single row
-			replies:     []string{"Yes", "No", "Maybe"},
-			maxRowRunes: 30,
-			maxRows:     3,
+			replies:      []string{"Yes", "No", "Maybe"},
+			maxRows:      3,
+			maxRowRunes:  30,
+			paddingRunes: 2,
 			expected: [][]string{
 				{"Yes", "No", "Maybe"},
 			},
 		},
 		{
 			// all values can be their own row
-			replies:     []string{"12345678901234567890", "23456789012345678901", "34567890123456789012"},
-			maxRowRunes: 25,
-			maxRows:     3,
+			replies:      []string{"12345678901234567890", "23456789012345678901", "34567890123456789012"},
+			maxRows:      3,
+			maxRowRunes:  25,
+			paddingRunes: 2,
 			expected: [][]string{
 				{"12345678901234567890"},
 				{"23456789012345678901"},
@@ -88,9 +92,10 @@ func TestStringsToRows(t *testing.T) {
 			},
 		},
 		{
-			replies:     []string{"1234567890", "2345678901", "3456789012", "4567890123"},
-			maxRowRunes: 25,
-			maxRows:     3,
+			replies:      []string{"1234567890", "2345678901", "3456789012", "4567890123"},
+			maxRows:      3,
+			maxRowRunes:  25,
+			paddingRunes: 1,
 			expected: [][]string{
 				{"1234567890", "2345678901"},
 				{"3456789012", "4567890123"},
@@ -98,19 +103,20 @@ func TestStringsToRows(t *testing.T) {
 		},
 		{
 			// we break chars per row limit rather than row limit
-			replies:     []string{"Vanilla", "Chocolate", "Strawberry", "Lemon Sorbet", "Ecuadorian Amazonian Papayas", "Mint"},
-			maxRowRunes: 30,
-			maxRows:     3,
+			replies:      []string{"Vanilla", "Chocolate", "Strawberry", "Lemon Sorbet", "Ecuadorian Amazonian Papayas", "Mint"},
+			maxRows:      3,
+			maxRowRunes:  30,
+			paddingRunes: 2,
 			expected: [][]string{
-				{"Vanilla", "Chocolate", "Strawberry"},
-				{"Lemon Sorbet"},
+				{"Vanilla", "Chocolate"},
+				{"Strawberry", "Lemon Sorbet"},
 				{"Ecuadorian Amazonian Papayas", "Mint"},
 			},
 		},
 	}
 
 	for _, tc := range tcs {
-		rows := utils.StringsToRows(tc.replies, tc.maxRowRunes, tc.maxRows)
+		rows := utils.StringsToRows(tc.replies, tc.maxRows, tc.maxRowRunes, tc.paddingRunes)
 		assert.Equal(t, tc.expected, rows, "rows mismatch for replies %v", tc.replies)
 	}
 }


### PR DESCRIPTION
Does #373 for Telegram. Adds some generic buttony layout stuff we should be able to re-use for other channels that support keyboard things

![3e5f9dec-6b26-49f0-951b-479aeb443d3b](https://user-images.githubusercontent.com/675558/129279985-b4e6fc74-dac8-4ee4-95cb-21b291786339.jpg)
![7c6448ac-809e-4a86-9d69-c2d0d3625377](https://user-images.githubusercontent.com/675558/129279989-ceba6d2a-0700-4b09-bd1e-08431508527f.jpg)
![b8d934c9-e034-45f9-9800-fbc01f328b6e](https://user-images.githubusercontent.com/675558/129279993-085bbec7-943c-4c0e-8710-e3ed41489204.jpg)
