### PR TITLE
Fixes statusPayload struct for status update within Zenvia channels (ZV)

### DIFF
--- a/handlers/zenvia/zenvia.go
+++ b/handlers/zenvia/zenvia.go
@@ -76,8 +76,8 @@ type moPayload struct {
 type statusPayload struct {
 	CallbackMTRequest struct {
 		StatusCode string `json:"status" validate:"required"`
-		ID         string `json:"id"     validate:"required" `
-	}
+		ID         string `json:"id"     validate:"required"`
+	} `json:"callbackMtRequest"`
 }
 
 // {


### PR DESCRIPTION
- Removes extra space from statusPayload struct on ID json field;
- Adds `json:"callbackMtRequest"` at the end of statusPayload struct definition as in moPayload and mtPayload;