### PR TITLE
Adds the Africa's Talking 'Expired' Status in Its Handler

### DIFF
--- a/handlers/africastalking/africastalking.go
+++ b/handlers/africastalking/africastalking.go
@@ -91,6 +91,7 @@ var statusMapping = map[string]courier.MsgStatusValue{
 	"Buffered": courier.MsgSent,
 	"Rejected": courier.MsgFailed,
 	"Failed":   courier.MsgFailed,
+	"Expired":  courier.MsgFailed,
 }
 
 // receiveStatus is our HTTP handler function for status updates
@@ -105,7 +106,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w 
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r,
-			fmt.Errorf("unknown status '%s', must be one of 'Success','Sent','Buffered','Rejected' or 'Failed'", form.Status))
+			fmt.Errorf("unknown status '%s', must be one of 'Success','Sent','Buffered','Rejected', 'Failed', or 'Expired'", form.Status))
 	}
 
 	// write our status

--- a/handlers/africastalking/africastalking_test.go
+++ b/handlers/africastalking/africastalking_test.go
@@ -26,7 +26,8 @@ var (
 
 	missingStatus = "id=ATXid_dda018a640edfcc5d2ce455de3e4a6e7"
 	invalidStatus = "id=ATXid_dda018a640edfcc5d2ce455de3e4a6e7&status=Borked"
-	validStatus   = "id=ATXid_dda018a640edfcc5d2ce455de3e4a6e7&status=Success"
+	successStatus = "id=ATXid_dda018a640edfcc5d2ce455de3e4a6e7&status=Success"
+	expiredStatus = "id=ATXid_dda018a640edfcc5d2ce455de3e4a6e7&status=Expired"
 )
 
 var testCases = []ChannelHandleTestCase{
@@ -42,7 +43,8 @@ var testCases = []ChannelHandleTestCase{
 	{Label: "Invalid Date", URL: receiveURL, Data: invalidDate, Status: 400, Response: "invalid date format"},
 	{Label: "Status Invalid", URL: statusURL, Status: 400, Data: invalidStatus, Response: "unknown status"},
 	{Label: "Status Missing", URL: statusURL, Status: 400, Data: missingStatus, Response: "field 'status' required"},
-	{Label: "Status Valid", URL: statusURL, Status: 200, Data: validStatus, Response: `"status":"D"`},
+	{Label: "Status Success", URL: statusURL, Status: 200, Data: successStatus, Response: `"status":"D"`},
+	{Label: "Status Expired", URL: statusURL, Status: 200, Data: expiredStatus, Response: `"status":"F"`},
 }
 
 func TestHandler(t *testing.T) {


### PR DESCRIPTION
Add support for the 'Expired' status from Africa's Talking which seems
to be thrown but isn't handled. Courier currently throws the following
error when it encounters this status:

time="2021-11-10T10:29:10+03:00" level=info msg="request errored"
channel_uuid=<UUID> elapsed_ms=0.109525 error="unknown status
'Expired', must be one of 'Success','Sent', 'Buffered','Rejected'
or 'Failed'" url=/c/at/<UUID>/status

Mark messages that have this status as failed as it doesn't appear
messages that have this status get delivered to users.

Signed-off-by: Jason Rogena <jason@rogena.me>