### PR TITLE
Do more error wrapping when creating contacts and URNs

### DIFF
--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/buger/jsonparser"
+	"github.com/pkg/errors"
 
 	"mime"
 
@@ -134,7 +135,7 @@ func writeMsgToDB(ctx context.Context, b *backend, m *DBMsg) error {
 
 	// our db is down, write to the spool, we will write/queue this later
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error getting contact for message")
 	}
 
 	// set our contact and urn ids from our contact
@@ -143,14 +144,14 @@ func writeMsgToDB(ctx context.Context, b *backend, m *DBMsg) error {
 
 	rows, err := b.db.NamedQueryContext(ctx, insertMsgSQL, m)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error inserting message")
 	}
 	defer rows.Close()
 
 	rows.Next()
 	err = rows.Scan(&m.ID_)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error scanning for inserted message id")
 	}
 
 	// queue this up to be handled by RapidPro

--- a/backends/rapidpro/urn.go
+++ b/backends/rapidpro/urn.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/nyaruka/null"
+	"github.com/pkg/errors"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/nyaruka/courier"
@@ -209,14 +210,14 @@ func contactURNForURN(db *sqlx.Tx, channel *DBChannel, contactID ContactID, urn 
 	}
 	err := db.Get(contactURN, selectOrgURN, channel.OrgID(), urn.Identity())
 	if err != nil && err != sql.ErrNoRows {
-		return nil, err
+		return nil, errors.Wrap(err, "error looking up URN by identity")
 	}
 
 	// we didn't find it, let's insert it
 	if err == sql.ErrNoRows {
 		err = insertContactURN(db, contactURN)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "error inserting URN")
 		}
 	}
 
@@ -232,7 +233,7 @@ func contactURNForURN(db *sqlx.Tx, channel *DBChannel, contactID ContactID, urn 
 		contactURN.Display = display
 		err = updateContactURN(db, contactURN)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "error updating URN")
 		}
 	}
 
@@ -242,7 +243,7 @@ func contactURNForURN(db *sqlx.Tx, channel *DBChannel, contactID ContactID, urn 
 		err = updateContactURN(db, contactURN)
 	}
 
-	return contactURN, err
+	return contactURN, errors.Wrap(err, "error updating URN auth")
 }
 
 const insertURN = `


### PR DESCRIPTION
So we can see where the `context canceled` errors are coming from