### PR TITLE
Fix bulk status updates

### DIFF
--- a/backends/rapidpro/status.go
+++ b/backends/rapidpro/status.go
@@ -305,7 +305,7 @@ WHERE
 	msgs_msg.channel_id = s.channel_id::int AND 
 	msgs_msg.direction = 'O'
 RETURNING 
-	msgs_msg.id
+	msgs_msg.id AS msg_id
 `
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Struggling to find a good way to test this.. the status update was successful, but then it was failing to get the returned id, so so it would call the error handler of the status committer... which would try to spool the update, but that would also fail because the spool directory doesn't exist, but all that is swallowed by the tests.