### PR TITLE
Support for viewing sent links in Whatsapp messages

### DIFF
--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -359,7 +359,7 @@ var waIgnoreStatuses = map[string]bool{
 type mtTextPayload struct {
 	To   string `json:"to"    validate:"required"`
 	Type string `json:"type"  validate:"required"`
-	Preview_URL bool `json:"preview_url,omitempty"`
+	PreviewURL bool `json:"preview_url,omitempty"`
 	Text struct {
 		Body string `json:"body" validate:"required"`
 	} `json:"text"`
@@ -806,7 +806,7 @@ func buildPayloads(msg courier.Msg, h *handler) ([]interface{}, []*courier.Chann
 						payload = mtTextPayload{
 							To:          msg.URN().Path(),
 							Type:        "text",
-							Preview_URL: true,
+							PreviewURL: true,
 						}
 					} else {
 						payload = mtTextPayload{

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -359,6 +359,7 @@ var waIgnoreStatuses = map[string]bool{
 type mtTextPayload struct {
 	To   string `json:"to"    validate:"required"`
 	Type string `json:"type"  validate:"required"`
+	Preview_URL bool `json:"preview_url,omitempty"`
 	Text struct {
 		Body string `json:"body" validate:"required"`
 	} `json:"text"`
@@ -798,9 +799,20 @@ func buildPayloads(msg courier.Msg, h *handler) ([]interface{}, []*courier.Chann
 				}
 			} else {
 				for _, part := range parts {
-					payload := mtTextPayload{
-						To:   msg.URN().Path(),
-						Type: "text",
+
+					//check if you have a link
+					var payload mtTextPayload
+					if strings.Contains(part, "https://") || strings.Contains(part, "http://") {
+						payload = mtTextPayload{
+							To:          msg.URN().Path(),
+							Type:        "text",
+							Preview_URL: true,
+						}
+					} else {
+						payload = mtTextPayload{
+							To:          msg.URN().Path(),
+							Type:        "text",
+						}
 					}
 					payload.Text.Body = part
 					payloads = append(payloads, payload)

--- a/handlers/whatsapp/whatsapp_test.go
+++ b/handlers/whatsapp/whatsapp_test.go
@@ -370,6 +370,12 @@ func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel,
 }
 
 var defaultSendTestCases = []ChannelSendTestCase{
+	{Label: "Link Sending",
+		Text: "Link Sending https://link.com", URN: "whatsapp:250788123123", Path: "/v1/messages",
+		Status: "W", ExternalID: "157b5e14568e8",
+		ResponseBody: `{ "messages": [{"id": "157b5e14568e8"}] }`, ResponseStatus: 201,
+		RequestBody: `{"to":"250788123123","type":"text","preview_url":true,"text":{"body":"Link Sending https://link.com"}}`,
+		SendPrep:    setSendURL},
 	{Label: "Plain Send",
 		Text: "Simple Message", URN: "whatsapp:250788123123", Path: "/v1/messages",
 		Status: "W", ExternalID: "157b5e14568e8",


### PR DESCRIPTION
Support to include a URL preview in messages with links sent on Whatsapp. Add `"preview_url": true` to the message body as indicated in the [documentation](https://developers.facebook.com/docs/whatsapp/api/messages/text#urls).