### PR TITLE
Fix receiving quick replies and list replies in WAC

### DIFF
--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -175,6 +175,17 @@ type moPayload struct {
 						Text    string `json:"text"`
 						Payload string `json:"payload"`
 					} `json:"button"`
+					Interactive struct {
+						Type        string `json:"type"`
+						ButtonReply struct {
+							ID    string `json:"id"`
+							Title string `json:"title"`
+						} `json:"button_reply,omitempty"`
+						ListReply struct {
+							ID    string `json:"id"`
+							Title string `json:"title"`
+						} `json:"list_reply,omitempty"`
+					} `json:"interactive,omitempty"`
 				} `json:"messages"`
 				Statuses []struct {
 					ID           string `json:"id"`
@@ -441,6 +452,10 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 					mediaURL, err = resolveMediaURL(channel, msg.Video.ID)
 				} else if msg.Type == "location" && msg.Location != nil {
 					mediaURL = fmt.Sprintf("geo:%f,%f", msg.Location.Latitude, msg.Location.Longitude)
+				} else if msg.Type == "interactive" && msg.Interactive.Type == "button_reply" {
+					text = msg.Interactive.ButtonReply.Title
+				} else if msg.Type == "interactive" && msg.Interactive.Type == "list_reply" {
+					text = msg.Interactive.ListReply.Title
 				} else {
 					// we received a message type we do not support.
 					courier.LogRequestError(r, channel, fmt.Errorf("unsupported message type %s", msg.Type))

--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -275,6 +275,12 @@ var testCasesWAC = []ChannelHandleTestCase{
 		MsgStatus: Sp("S"), ExternalID: Sp("external_id"), PrepRequest: addValidSignature},
 	{Label: "Receive Invalid Status", URL: wacReceiveURL, Data: string(courier.ReadFile("./testdata/wac/invalidStatusWAC.json")), Status: 400, Response: `"unknown status: in_orbit"`, PrepRequest: addValidSignature},
 	{Label: "Receive Ignore Status", URL: wacReceiveURL, Data: string(courier.ReadFile("./testdata/wac/ignoreStatusWAC.json")), Status: 200, Response: `"ignoring status: deleted"`, PrepRequest: addValidSignature},
+	{Label: "Receive Valid Interactive Button Reply Message", URL: wacReceiveURL, Data: string(courier.ReadFile("./testdata/wac/buttonReplyWAC.json")), Status: 200, Response: "Handled", NoQueueErrorCheck: true, NoInvalidChannelCheck: true,
+		Text: Sp("Yes"), URN: Sp("whatsapp:5678"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)),
+		PrepRequest: addValidSignature},
+	{Label: "Receive Valid Interactive List Reply Message", URL: wacReceiveURL, Data: string(courier.ReadFile("./testdata/wac/listReplyWAC.json")), Status: 200, Response: "Handled", NoQueueErrorCheck: true, NoInvalidChannelCheck: true,
+		Text: Sp("Yes"), URN: Sp("whatsapp:5678"), ExternalID: Sp("external_id"), Date: Tp(time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC)),
+		PrepRequest: addValidSignature},
 }
 
 func TestHandler(t *testing.T) {

--- a/handlers/facebookapp/testdata/wac/buttonReplyWAC.json
+++ b/handlers/facebookapp/testdata/wac/buttonReplyWAC.json
@@ -1,0 +1,43 @@
+{
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "8856996819413533",
+            "changes": [
+                {
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "metadata": {
+                            "display_phone_number": "+250 788 123 200",
+                            "phone_number_id": "12345"
+                        },
+                        "contacts": [
+                            {
+                                "profile": {
+                                    "name": "Kerry Fisher"
+                                },
+                                "wa_id": "5678"
+                            }
+                        ],
+                        "messages": [
+                            {
+                                "from": "5678",
+                                "id": "external_id",
+                                "interactive": {
+                                    "type": "button_reply",
+                                    "button_reply": {
+                                        "id": "id_button_reply",
+                                        "title": "Yes"
+                                    }
+                                },
+                                "timestamp": "1454119029",
+                                "type": "interactive"
+                            }
+                        ]
+                    },
+                    "field": "messages"
+                }
+            ]
+        }
+    ]
+}

--- a/handlers/facebookapp/testdata/wac/listReplyWAC.json
+++ b/handlers/facebookapp/testdata/wac/listReplyWAC.json
@@ -1,0 +1,43 @@
+{
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "8856996819413533",
+            "changes": [
+                {
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "metadata": {
+                            "display_phone_number": "+250 788 123 200",
+                            "phone_number_id": "12345"
+                        },
+                        "contacts": [
+                            {
+                                "profile": {
+                                    "name": "Kerry Fisher"
+                                },
+                                "wa_id": "5678"
+                            }
+                        ],
+                        "messages": [
+                            {
+                                "from": "5678",
+                                "id": "external_id",
+                                "interactive": {
+                                    "type": "list_reply",
+                                    "list_reply": {
+                                        "id": "id_list_reply",
+                                        "title": "Yes"
+                                    }
+                                },
+                                "timestamp": "1454119029",
+                                "type": "interactive"
+                            }
+                        ]
+                    },
+                    "field": "messages"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
The quick replies were not being identified in the receive, causing problems during the exchange of messages. I identified that they are part of this `Interactive` type that also has list replies, I took advantage and added these as well.