### PR TITLE
Fix receiving attachments in WAC

### DIFF
--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -247,6 +247,11 @@ func downloadMediaToS3(ctx context.Context, b *backend, channel courier.Channel,
 		}
 	}
 
+	// to allow download media from wac when receive media message
+	if channel.ChannelType() == "WAC" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", b.config.WhatsappAdminSystemUserToken))
+	}
+
 	resp, err := utils.GetHTTPClient().Do(req)
 	if err != nil {
 		return "", err

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -247,11 +247,6 @@ func downloadMediaToS3(ctx context.Context, b *backend, channel courier.Channel,
 		}
 	}
 
-	// to allow download media from wac when receive media message
-	if channel.ChannelType() == "WAC" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", b.config.WhatsappAdminSystemUserToken))
-	}
-
 	resp, err := utils.GetHTTPClient().Do(req)
 	if err != nil {
 		return "", err

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -319,8 +319,7 @@ func (h *handler) receiveVerify(ctx context.Context, channel courier.Channel, w 
 	return nil, err
 }
 
-func resolveMediaURL(channel courier.Channel, mediaID string) (string, error) {
-	token := channel.StringConfigForKey(courier.ConfigAuthToken, "")
+func resolveMediaURL(channel courier.Channel, mediaID string, token string) (string, error) {
 	if token == "" {
 		return "", fmt.Errorf("missing token for WA channel")
 	}
@@ -390,6 +389,8 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 	// the list of data we will return in our response
 	data := make([]interface{}, 0, 2)
 
+	token := h.Server().Config().WhatsappAdminSystemUserToken
+
 	var contactNames = make(map[string]string)
 
 	// for each entry
@@ -424,21 +425,21 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 					text = msg.Text.Body
 				} else if msg.Type == "audio" && msg.Audio != nil {
 					text = msg.Audio.Caption
-					mediaURL, err = resolveMediaURL(channel, msg.Audio.ID)
+					mediaURL, err = resolveMediaURL(channel, msg.Audio.ID, token)
 				} else if msg.Type == "voice" && msg.Voice != nil {
 					text = msg.Voice.Caption
-					mediaURL, err = resolveMediaURL(channel, msg.Voice.ID)
+					mediaURL, err = resolveMediaURL(channel, msg.Voice.ID, token)
 				} else if msg.Type == "button" && msg.Button != nil {
 					text = msg.Button.Text
 				} else if msg.Type == "document" && msg.Document != nil {
 					text = msg.Document.Caption
-					mediaURL, err = resolveMediaURL(channel, msg.Document.ID)
+					mediaURL, err = resolveMediaURL(channel, msg.Document.ID, token)
 				} else if msg.Type == "image" && msg.Image != nil {
 					text = msg.Image.Caption
-					mediaURL, err = resolveMediaURL(channel, msg.Image.ID)
+					mediaURL, err = resolveMediaURL(channel, msg.Image.ID, token)
 				} else if msg.Type == "video" && msg.Video != nil {
 					text = msg.Video.Caption
-					mediaURL, err = resolveMediaURL(channel, msg.Video.ID)
+					mediaURL, err = resolveMediaURL(channel, msg.Video.ID, token)
 				} else if msg.Type == "location" && msg.Location != nil {
 					mediaURL = fmt.Sprintf("geo:%f,%f", msg.Location.Latitude, msg.Location.Longitude)
 				} else {

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -1395,6 +1395,22 @@ func (h *handler) getTemplate(msg courier.Msg) (*MsgTemplating, error) {
 	return templating, err
 }
 
+// BuildDownloadMediaRequest to download media for message attachment with Bearer token set
+func (h *handler) BuildDownloadMediaRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string) (*http.Request, error) {
+	token := h.Server().Config().WhatsappAdminSystemUserToken
+	if token == "" {
+		return nil, fmt.Errorf("missing token for WAC channel")
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, attachmentURL, nil)
+
+	// set the access token as the authorization header for WAC
+	if channel.ChannelType() == "WAC" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return req, nil
+}
+
 type TemplateMetadata struct {
 	Templating *MsgTemplating `json:"templating"`
 }

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -319,7 +319,7 @@ func (h *handler) receiveVerify(ctx context.Context, channel courier.Channel, w 
 	return nil, err
 }
 
-func resolveMediaURL(channel courier.Channel, mediaID string, token string) (string, error) {
+func resolveMediaURL(mediaID string, token string) (string, error) {
 	if token == "" {
 		return "", fmt.Errorf("missing token for WA channel")
 	}
@@ -425,21 +425,21 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 					text = msg.Text.Body
 				} else if msg.Type == "audio" && msg.Audio != nil {
 					text = msg.Audio.Caption
-					mediaURL, err = resolveMediaURL(channel, msg.Audio.ID, token)
+					mediaURL, err = resolveMediaURL(msg.Audio.ID, token)
 				} else if msg.Type == "voice" && msg.Voice != nil {
 					text = msg.Voice.Caption
-					mediaURL, err = resolveMediaURL(channel, msg.Voice.ID, token)
+					mediaURL, err = resolveMediaURL(msg.Voice.ID, token)
 				} else if msg.Type == "button" && msg.Button != nil {
 					text = msg.Button.Text
 				} else if msg.Type == "document" && msg.Document != nil {
 					text = msg.Document.Caption
-					mediaURL, err = resolveMediaURL(channel, msg.Document.ID, token)
+					mediaURL, err = resolveMediaURL(msg.Document.ID, token)
 				} else if msg.Type == "image" && msg.Image != nil {
 					text = msg.Image.Caption
-					mediaURL, err = resolveMediaURL(channel, msg.Image.ID, token)
+					mediaURL, err = resolveMediaURL(msg.Image.ID, token)
 				} else if msg.Type == "video" && msg.Video != nil {
 					text = msg.Video.Caption
-					mediaURL, err = resolveMediaURL(channel, msg.Video.ID, token)
+					mediaURL, err = resolveMediaURL(msg.Video.ID, token)
 				} else if msg.Type == "location" && msg.Location != nil {
 					mediaURL = fmt.Sprintf("geo:%f,%f", msg.Location.Latitude, msg.Location.Longitude)
 				} else {

--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -283,7 +283,7 @@ func TestHandler(t *testing.T) {
 		defer r.Body.Close()
 
 		// invalid auth token
-		if accessToken != "Bearer a123" {
+		if accessToken != "Bearer a123" && accessToken != "Bearer wac_admin_system_user_token" {
 			fmt.Printf("Access token: %s\n", accessToken)
 			http.Error(w, "invalid auth token", 403)
 			return

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -202,6 +202,7 @@ func newServer(backend courier.Backend) courier.Server {
 	config := courier.NewConfig()
 	config.FacebookWebhookSecret = "fb_webhook_secret"
 	config.FacebookApplicationSecret = "fb_app_secret"
+	config.WhatsappAdminSystemUserToken = "wac_admin_system_user_token"
 
 	return courier.NewServerWithLogger(config, backend, logger)
 


### PR DESCRIPTION
Receiving attachments is not working properly. First, the token used to fetch the media url, channel auth_token, does not exist as WAC channels do not have this token in the channel settings. The token that must be used is the `whatsapp_admin_system_user_token` and in addition, for the media to be downloaded, it is necessary to use the same token.