### PR TITLE
Fix URLs of attachments in WAC handler

### DIFF
--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -1175,11 +1175,15 @@ func (h *handler) sendCloudAPIWhatsappMsg(ctx context.Context, msg courier.Msg) 
 		} else if i < len(msg.Attachments()) {
 			attType, attURL := handlers.SplitAttachment(msg.Attachments()[i])
 			attType = strings.Split(attType, "/")[0]
+			parsedURL, err := url.Parse(attURL)
+			if err != nil {
+				return status, err
+			}
 			if attType == "application" {
 				attType = "document"
 			}
 			payload.Type = attType
-			media := wacMTMedia{Link: attURL}
+			media := wacMTMedia{Link: parsedURL.String()}
 
 			if attType == "image" {
 				payload.Image = &media


### PR DESCRIPTION
Files where the name has spaces or some special character end up not being sent because their link is not being encoded to correct this.