### PR TITLE
Remove expiration_timestamp from moPayload in WAC

### DIFF
--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -198,7 +198,6 @@ type moPayload struct {
 						Origin *struct {
 							Type string `json:"type"`
 						} `json:"origin"`
-						ExpirationTimestamp int64 `json:"expiration_timestamp"`
 					} `json:"conversation"`
 					Pricing *struct {
 						PricingModel string `json:"pricing_model"`


### PR DESCRIPTION
Cloud API updated one of the attributes coming in the payload of webhooks for status update, the `expiration_timestamp` which is currently not used at all in the WAC handler, is coming with the type `string` in some cases, causing divergence with `int64 ` that it has in the `moPayload` struct. As it is not used, it is best to remove it.