### PR TITLE
Rework attachment fetching to keep URL and content type separate

### DIFF
--- a/attachments_test.go
+++ b/attachments_test.go
@@ -32,10 +32,11 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 
 	clog := courier.NewChannelLogForAttachmentFetch(mockChannel, []string{"sesame"})
 
-	newURL, size, err := courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello.jpg", clog)
+	att, err := courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello.jpg", clog)
 	assert.NoError(t, err)
-	assert.Equal(t, "https://backend.com/attachments/cdf7ed27-5ad5-4028-b664-880fc7581c77.jpg", newURL)
-	assert.Equal(t, 17301, size)
+	assert.Equal(t, "image/jpeg", att.ContentType)
+	assert.Equal(t, "https://backend.com/attachments/cdf7ed27-5ad5-4028-b664-880fc7581c77.jpg", att.URL)
+	assert.Equal(t, 17301, att.Size)
 
 	assert.Len(t, mb.SavedAttachments(), 1)
 	assert.Equal(t, &test.SavedAttachment{Channel: mockChannel, ContentType: "image/jpeg", Data: testJPG, Extension: "jpg"}, mb.SavedAttachments()[0])

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -421,13 +421,12 @@ func (b *backend) SaveAttachment(ctx context.Context, ch courier.Channel, conten
 		path = fmt.Sprintf("/%s", path)
 	}
 
-	s3URL, err := b.storage.Put(ctx, path, contentType, data)
+	storageURL, err := b.storage.Put(ctx, path, contentType, data)
 	if err != nil {
 		return "", errors.Wrapf(err, "error saving attachment to storage (bytes=%d)", len(data))
 	}
 
-	// return our new media URL, which is prefixed by our content type
-	return fmt.Sprintf("%s:%s", contentType, s3URL), nil
+	return storageURL, nil
 }
 
 // ResolveMedia resolves the passed in attachment URL to a media object

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -1114,7 +1114,7 @@ func (ts *BackendTestSuite) TestSaveAttachment() {
 
 	newURL, err := ts.b.SaveAttachment(ctx, knChannel, "image/jpeg", testJPG, "jpg")
 	ts.NoError(err)
-	ts.Equal("image/jpeg:_test_storage/media/1/c00e/5d67/c00e5d67-c275-4389-aded-7d8b151cbd5b.jpg", newURL)
+	ts.Equal("_test_storage/media/1/c00e/5d67/c00e5d67-c275-4389-aded-7d8b151cbd5b.jpg", newURL)
 }
 
 func (ts *BackendTestSuite) TestWriteMsg() {

--- a/backends/rapidpro/task.go
+++ b/backends/rapidpro/task.go
@@ -16,9 +16,9 @@ func queueMsgHandling(rc redis.Conn, c *DBContact, m *DBMsg) error {
 	body := map[string]any{
 		"contact_id":      c.ID_,
 		"org_id":          channel.OrgID_,
-		"channel_id":      channel.ID_, // deprecated
-		"channel_uuid":    channel.UUID_,
-		"channel_type":    channel.ChannelType_,
+		"channel_id":      channel.ID_,
+		"channel_uuid":    channel.UUID_,        // deprecated
+		"channel_type":    channel.ChannelType_, // deprecated
 		"msg_id":          m.ID_,
 		"msg_uuid":        m.UUID_.String(),
 		"msg_external_id": m.ExternalID(),

--- a/server.go
+++ b/server.go
@@ -399,7 +399,7 @@ func (s *server) handleFetchAttachment(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
 	defer cancel()
 
-	newURL, size, clog, err := fetchAttachment(ctx, s.backend, r)
+	attachment, clog, err := fetchAttachment(ctx, s.backend, r)
 	if err != nil {
 		logrus.WithError(err).Error()
 		WriteError(w, http.StatusBadRequest, err)
@@ -408,7 +408,7 @@ func (s *server) handleFetchAttachment(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(jsonx.MustMarshal(map[string]any{"url": newURL, "size": size, "log_uuid": clog.UUID()}))
+	w.Write(jsonx.MustMarshal(map[string]any{"attachment": attachment, "log_uuid": clog.UUID()}))
 }
 
 func (s *server) handle404(w http.ResponseWriter, r *http.Request) {

--- a/server_test.go
+++ b/server_test.go
@@ -130,5 +130,5 @@ func TestFetchAttachment(t *testing.T) {
 
 	statusCode, respBody = submit(`{"channel_uuid": "e4bb1578-29da-4fa5-a214-9da19dd24230", "channel_type": "MCK", "url": "http://mock.com/media/test.jpg"}`, "sesame")
 	assert.Equal(t, 200, statusCode)
-	assert.JSONEq(t, `{"log_uuid":"c00e5d67-c275-4389-aded-7d8b151cbd5b", "size": 17301, "url": "https://backend.com/attachments/cdf7ed27-5ad5-4028-b664-880fc7581c77.jpg"}`, string(respBody))
+	assert.JSONEq(t, `{"attachment": {"content_type": "image/jpeg", "url": "https://backend.com/attachments/cdf7ed27-5ad5-4028-b664-880fc7581c77.jpg", "size": 17301}, "log_uuid": "c00e5d67-c275-4389-aded-7d8b151cbd5b"}`, string(respBody))
 }


### PR DESCRIPTION
It's convenient to store attachments as a single string but that only needs to be a last minute thing when writing to the db