### PR TITLE
Remove no longer used `channel_uuid` and `channel_type` fields from msg events

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -1142,8 +1142,6 @@ func (ts *BackendTestSuite) TestWriteMsg() {
 		"contact_id":      float64(contact.ID_),
 		"org_id":          float64(1),
 		"channel_id":      float64(10),
-		"channel_uuid":    "dbc126ed-66bc-4e28-b67b-81dc3327c95d",
-		"channel_type":    "KN",
 		"msg_id":          float64(msg.ID_),
 		"msg_uuid":        msg.UUID_.String(),
 		"msg_external_id": msg.ExternalID(),

--- a/backends/rapidpro/task.go
+++ b/backends/rapidpro/task.go
@@ -17,8 +17,6 @@ func queueMsgHandling(rc redis.Conn, c *DBContact, m *DBMsg) error {
 		"contact_id":      c.ID_,
 		"org_id":          channel.OrgID_,
 		"channel_id":      channel.ID_,
-		"channel_uuid":    channel.UUID_,        // deprecated
-		"channel_type":    channel.ChannelType_, // deprecated
 		"msg_id":          m.ID_,
 		"msg_uuid":        m.UUID_.String(),
 		"msg_external_id": m.ExternalID(),


### PR DESCRIPTION
In the end mailroom just uses `channel_id`