### PR TITLE
🔐 Fetch access token for JioChat and WeChat channels as needed

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -77,7 +77,7 @@ func FetchAndStoreAttachment(ctx context.Context, b Backend, channel Channel, at
 	builder, isBuilder := handler.(AttachmentRequestBuilder)
 	if isBuilder {
 		httpClient = builder.AttachmentRequestClient(channel)
-		attRequest, err = builder.BuildAttachmentRequest(ctx, b, channel, parsedURL.String())
+		attRequest, err = builder.BuildAttachmentRequest(ctx, b, channel, parsedURL.String(), clog)
 	} else {
 		httpClient = utils.GetHTTPClient()
 		attRequest, err = http.NewRequest(http.MethodGet, attURL, nil)

--- a/handler.go
+++ b/handler.go
@@ -42,7 +42,7 @@ type URNDescriber interface {
 
 // AttachmentRequestBuilder is the interface handlers which can allow a custom way to download attachment media for messages should satisfy
 type AttachmentRequestBuilder interface {
-	BuildAttachmentRequest(context.Context, Backend, Channel, string) (*http.Request, error)
+	BuildAttachmentRequest(context.Context, Backend, Channel, string, *ChannelLog) (*http.Request, error)
 	AttachmentRequestClient(Channel) *http.Client
 }
 

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -1509,7 +1509,7 @@ func (h *handler) getTemplate(msg courier.Msg) (*MsgTemplating, error) {
 }
 
 // BuildAttachmentRequest to download media for message attachment with Bearer token set
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	token := h.Server().Config().WhatsappAdminSystemUserToken
 	if token == "" {
 		return nil, fmt.Errorf("missing token for WAC channel")

--- a/handlers/facebookapp/facebookapp_test.go
+++ b/handlers/facebookapp/facebookapp_test.go
@@ -1417,19 +1417,19 @@ func TestBuildMediaRequest(t *testing.T) {
 	s := newServer(mb)
 	wacHandler := &handler{NewBaseHandlerWithParams(courier.ChannelType("WAC"), "WhatsApp Cloud", false, nil)}
 	wacHandler.Initialize(s)
-	req, _ := wacHandler.BuildAttachmentRequest(context.Background(), mb, testChannelsWAC[0], "https://example.org/v1/media/41")
+	req, _ := wacHandler.BuildAttachmentRequest(context.Background(), mb, testChannelsWAC[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer wac_admin_system_user_token", req.Header.Get("Authorization"))
 
 	fbaHandler := &handler{NewBaseHandlerWithParams(courier.ChannelType("FBA"), "Facebook", false, nil)}
 	fbaHandler.Initialize(s)
-	req, _ = fbaHandler.BuildAttachmentRequest(context.Background(), mb, testChannelsFBA[0], "https://example.org/v1/media/41")
+	req, _ = fbaHandler.BuildAttachmentRequest(context.Background(), mb, testChannelsFBA[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, http.Header{}, req.Header)
 
 	igHandler := &handler{NewBaseHandlerWithParams(courier.ChannelType("IG"), "Instagram", false, nil)}
 	igHandler.Initialize(s)
-	req, _ = igHandler.BuildAttachmentRequest(context.Background(), mb, testChannelsFBA[0], "https://example.org/v1/media/41")
+	req, _ = igHandler.BuildAttachmentRequest(context.Background(), mb, testChannelsFBA[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, http.Header{}, req.Header)
 }

--- a/handlers/jiochat/jiochat.go
+++ b/handlers/jiochat/jiochat.go
@@ -6,12 +6,12 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/buger/jsonparser"
@@ -21,13 +21,12 @@ import (
 	"github.com/nyaruka/courier/utils"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
-	"github.com/sirupsen/logrus"
+	"github.com/pkg/errors"
 )
 
 var (
 	sendURL      = "https://channels.jiochat.com"
 	maxMsgLength = 1600
-	fetchTimeout = time.Second * 2
 )
 
 const (
@@ -41,10 +40,15 @@ func init() {
 
 type handler struct {
 	handlers.BaseHandler
+
+	fetchTokenMutex sync.Mutex
 }
 
 func newHandler() courier.ChannelHandler {
-	return &handler{handlers.NewBaseHandler(courier.ChannelType("JC"), "Jiochat")}
+	return &handler{
+		BaseHandler:     handlers.NewBaseHandler(courier.ChannelType("JC"), "Jiochat"),
+		fetchTokenMutex: sync.Mutex{},
+	}
 }
 
 // Initialize is called by the engine once everything is loaded
@@ -87,10 +91,6 @@ func (h *handler) VerifyURL(ctx context.Context, channel courier.Channel, w http
 	if encoded == form.Signature {
 		ResponseText = form.EchoStr
 		StatusCode = 200
-		go func() {
-			time.Sleep(fetchTimeout)
-			h.fetchAccessToken(ctx, channel)
-		}()
 	}
 
 	w.Header().Set("Content-Type", "text/plain")
@@ -161,71 +161,6 @@ func buildMediaURL(mediaID string) string {
 	return mediaURL.String()
 }
 
-type fetchPayload struct {
-	GrantType    string `json:"grant_type"`
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-}
-
-// fetchAccessToken tries to fetch a new token for our channel, setting the result in redis
-func (h *handler) fetchAccessToken(ctx context.Context, channel courier.Channel) error {
-	clog := courier.NewChannelLog(courier.ChannelLogTypeTokenRefresh, channel, h.RedactValues(channel))
-
-	tokenURL, _ := url.Parse(fmt.Sprintf("%s/%s", sendURL, "auth/token.action"))
-	payload := &fetchPayload{
-		GrantType:    "client_credentials",
-		ClientID:     channel.StringConfigForKey(configAppID, ""),
-		ClientSecret: channel.StringConfigForKey(configAppSecret, ""),
-	}
-
-	req, err := http.NewRequest(http.MethodPost, tokenURL.String(), bytes.NewReader(jsonx.MustMarshal(payload)))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	resp, respBody, err := handlers.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 != 2 {
-		clog.End()
-		return h.Backend().WriteChannelLog(ctx, clog)
-	}
-
-	accessToken, err := jsonparser.GetString(respBody, "access_token")
-	if err != nil {
-		clog.Error(courier.ErrorResponseValueMissing("access_token"))
-		clog.End()
-		return h.Backend().WriteChannelLog(ctx, clog)
-	}
-
-	rc := h.Backend().RedisPool().Get()
-	defer rc.Close()
-
-	cacheKey := fmt.Sprintf("jiochat_channel_access_token:%s", channel.UUID().String())
-	_, err = rc.Do("SET", cacheKey, accessToken, 7200)
-
-	if err != nil {
-		logrus.WithError(err).Error("error setting the access token to redis")
-	}
-	return err
-}
-
-func (h *handler) getAccessToken(channel courier.Channel) (string, error) {
-	rc := h.Backend().RedisPool().Get()
-	defer rc.Close()
-
-	cacheKey := fmt.Sprintf("jiochat_channel_access_token:%s", channel.UUID().String())
-	accessToken, err := redis.String(rc.Do("GET", cacheKey))
-	if err != nil {
-		return "", err
-	}
-	if accessToken == "" {
-		return "", fmt.Errorf("no access token for channel")
-	}
-
-	return accessToken, nil
-}
-
 type mtPayload struct {
 	MsgType string `json:"msgtype"`
 	ToUser  string `json:"touser"`
@@ -236,7 +171,7 @@ type mtPayload struct {
 
 // Send sends the given message, logging any HTTP calls or errors
 func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.MsgStatus, error) {
-	accessToken, err := h.getAccessToken(msg.Channel())
+	accessToken, err := h.getAccessToken(ctx, msg.Channel(), clog)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +206,7 @@ func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.Chann
 
 // DescribeURN handles Jiochat contact details
 func (h *handler) DescribeURN(ctx context.Context, channel courier.Channel, urn urns.URN, clog *courier.ChannelLog) (map[string]string, error) {
-	accessToken, err := h.getAccessToken(channel)
+	accessToken, err := h.getAccessToken(ctx, channel, clog)
 	if err != nil {
 		return nil, err
 	}
@@ -298,13 +233,13 @@ func (h *handler) DescribeURN(ctx context.Context, channel courier.Channel, urn 
 }
 
 // BuildAttachmentRequest download media for message attachment
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	parsedURL, err := url.Parse(attachmentURL)
 	if err != nil {
 		return nil, err
 	}
 
-	accessToken, err := h.getAccessToken(channel)
+	accessToken, err := h.getAccessToken(ctx, channel, clog)
 	if err != nil {
 		return nil, err
 	}
@@ -320,3 +255,70 @@ func (*handler) AttachmentRequestClient(ch courier.Channel) *http.Client {
 }
 
 var _ courier.AttachmentRequestBuilder = (*handler)(nil)
+
+func (h *handler) getAccessToken(ctx context.Context, channel courier.Channel, clog *courier.ChannelLog) (string, error) {
+	rc := h.Backend().RedisPool().Get()
+	defer rc.Close()
+
+	tokenKey := fmt.Sprintf("channel-token:%s", channel.UUID().String())
+
+	h.fetchTokenMutex.Lock()
+	defer h.fetchTokenMutex.Unlock()
+
+	token, err := redis.String(rc.Do("GET", tokenKey))
+	if err != nil && err != redis.ErrNil {
+		return "", errors.Wrap(err, "error reading cached access token")
+	}
+
+	if token != "" {
+		return token, nil
+	}
+
+	token, err = h.fetchAccessToken(ctx, channel, clog)
+	if err != nil {
+		return "", errors.Wrap(err, "error fetching new access token")
+	}
+
+	_, err = rc.Do("SET", tokenKey, token, "EX", 7200)
+	if err != nil {
+		return "", errors.Wrap(err, "error updating cached access token")
+	}
+
+	return token, nil
+}
+
+type fetchPayload struct {
+	GrantType    string `json:"grant_type"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+// fetchAccessToken tries to fetch a new token for our channel
+func (h *handler) fetchAccessToken(ctx context.Context, channel courier.Channel, clog *courier.ChannelLog) (string, error) {
+	tokenURL, _ := url.Parse(fmt.Sprintf("%s/%s", sendURL, "auth/token.action"))
+	payload := &fetchPayload{
+		GrantType:    "client_credentials",
+		ClientID:     channel.StringConfigForKey(configAppID, ""),
+		ClientSecret: channel.StringConfigForKey(configAppSecret, ""),
+	}
+
+	req, err := http.NewRequest(http.MethodPost, tokenURL.String(), bytes.NewReader(jsonx.MustMarshal(payload)))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, respBody, err := handlers.RequestHTTP(req, clog)
+	if err != nil || resp.StatusCode/100 != 2 {
+		return "", err
+	}
+
+	token, err := jsonparser.GetString(respBody, "access_token")
+	if err != nil {
+		clog.Error(courier.ErrorResponseValueMissing("access_token"))
+		return "", err
+	}
+
+	return token, nil
+}

--- a/handlers/jiochat/jiochat_test.go
+++ b/handlers/jiochat/jiochat_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 var testChannels = []courier.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "JC", "2020", "US", map[string]interface{}{configAppSecret: "secret", configAppID: "app-id"}),
+	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "JC", "2020", "US", map[string]interface{}{configAppSecret: "secret123", configAppID: "app-id"}),
 }
 
 var (
@@ -99,7 +99,7 @@ func addValidSignature(r *http.Request) {
 	timestamp := t.Format("20060102150405")
 	nonce := "nonce"
 
-	stringSlice := []string{"secret", timestamp, nonce}
+	stringSlice := []string{"secret123", timestamp, nonce}
 	sort.Strings(stringSlice)
 
 	value := strings.Join(stringSlice, "")
@@ -123,7 +123,7 @@ func addInvalidSignature(r *http.Request) {
 	timestamp := t.Format("20060102150405")
 	nonce := "nonce"
 
-	stringSlice := []string{"secret", timestamp, nonce}
+	stringSlice := []string{"secret123", timestamp, nonce}
 	sort.Strings(stringSlice)
 
 	value := strings.Join(stringSlice, "")
@@ -297,7 +297,7 @@ func TestDescribeURN(t *testing.T) {
 		assert.Equal(t, metadata, tc.expectedMetadata)
 	}
 
-	AssertChannelLogRedaction(t, clog, []string{"secret"})
+	AssertChannelLogRedaction(t, clog, []string{"secret123"})
 }
 
 func TestBuildAttachmentRequest(t *testing.T) {
@@ -339,6 +339,8 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	assert.Equal(t, "https://channels.jiochat.com/media/download.action?media_id=13", req.URL.String())
 	assert.Equal(t, "Bearer SESAME", req.Header.Get("Authorization"))
 	assert.Len(t, clog.HTTPLogs(), 1)
+
+	AssertChannelLogRedaction(t, clog, []string{"secret123"})
 }
 
 // setSendURL takes care of setting the sendURL to call
@@ -412,7 +414,7 @@ func setupBackend(mb *test.MockBackend) {
 
 func TestSending(t *testing.T) {
 	maxMsgLength = 160
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "JC", "2020", "US", map[string]interface{}{configAppSecret: "secret", configAppID: "app-id"})
+	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "JC", "2020", "US", map[string]interface{}{configAppSecret: "secret123", configAppID: "app-id"})
 
-	RunChannelSendTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"secret"}, setupBackend)
+	RunChannelSendTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"secret123"}, setupBackend)
 }

--- a/handlers/jiochat/jiochat_test.go
+++ b/handlers/jiochat/jiochat_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
-	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -18,6 +16,7 @@ import (
 	"github.com/nyaruka/courier"
 	. "github.com/nyaruka/courier/handlers"
 	"github.com/nyaruka/courier/test"
+	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -227,55 +226,6 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func TestFetchAccessToken(t *testing.T) {
-	fetchCalled := false
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "auth/token.action") {
-			defer r.Body.Close()
-			// valid token
-			w.Write([]byte(`{"access_token": "TOKEN"}`))
-		}
-
-		// mark that we were called
-		fetchCalled = true
-	}))
-	sendURL = server.URL
-	fetchTimeout = time.Millisecond
-
-	RunChannelTestCases(t, testChannels, newHandler(), []ChannelHandleTestCase{
-		{
-			Label:                "Receive Message",
-			URL:                  receiveURL,
-			Data:                 validMsg,
-			ExpectedRespStatus:   200,
-			ExpectedBodyContains: "Accepted",
-			ExpectedMsgText:      Sp("Simple Message"),
-			ExpectedURN:          "jiochat:1234",
-		},
-		{
-			Label:                "Verify URL",
-			URL:                  verifyURL,
-			ExpectedRespStatus:   200,
-			ExpectedBodyContains: "SUCCESS",
-			PrepRequest:          addValidSignature,
-		},
-		{
-			Label:                "Verify URL Invalid signature",
-			URL:                  verifyURL,
-			ExpectedRespStatus:   400,
-			ExpectedBodyContains: "unknown request",
-			PrepRequest:          addInvalidSignature},
-	})
-
-	// wait for our fetch to be called
-	time.Sleep(100 * time.Millisecond)
-
-	if !fetchCalled {
-		t.Error("fetch access point should have been called")
-	}
-
-}
-
 // mocks the call to the Jiochat API
 func buildMockJCAPI(testCases []ChannelHandleTestCase) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -323,17 +273,14 @@ func TestDescribeURN(t *testing.T) {
 	defer JCAPI.Close()
 
 	mb := test.NewMockBackend()
-	conn := mb.RedisPool().Get()
 
-	_, err := conn.Do("SET", "jiochat_channel_access_token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	conn.Close()
+	// ensure there's a cached access token
+	rc := mb.RedisPool().Get()
+	defer rc.Close()
+	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 
 	s := newServer(mb)
-	handler := &handler{NewBaseHandler(courier.ChannelType("JC"), "Jiochat")}
+	handler := newHandler().(*handler)
 	handler.Initialize(s)
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, testChannels[0], handler.RedactValues(testChannels[0]))
 
@@ -353,36 +300,45 @@ func TestDescribeURN(t *testing.T) {
 	AssertChannelLogRedaction(t, clog, []string{"secret"})
 }
 
-func TestBuildMediaRequest(t *testing.T) {
+func TestBuildAttachmentRequest(t *testing.T) {
 	mb := test.NewMockBackend()
-	conn := mb.RedisPool().Get()
 
-	_, err := conn.Do("SET", "jiochat_channel_access_token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
-	if err != nil {
-		log.Fatal(err)
-	}
+	// reset send URL
+	sendURL = "https://channels.jiochat.com"
 
-	conn.Close()
-	s := newServer(mb)
-	handler := &handler{NewBaseHandler(courier.ChannelType("JC"), "Jiochat")}
-	handler.Initialize(s)
-
-	tcs := []struct {
-		url                 string
-		authorizationHeader string
-	}{
-		{
-			fmt.Sprintf("%s/media/download.action?media_id=12", sendURL),
-			"Bearer ACCESS_TOKEN",
+	defer httpx.SetRequestor(httpx.DefaultRequestor)
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+		"https://channels.jiochat.com/auth/token.action": {
+			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"access_token": "SESAME"}`)),
 		},
-	}
+	}))
 
-	for _, tc := range tcs {
-		req, _ := handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], tc.url)
-		assert.Equal(t, tc.url, req.URL.String())
-		assert.Equal(t, tc.authorizationHeader, req.Header.Get("Authorization"))
-	}
+	// ensure that we start with no cached token
+	rc := mb.RedisPool().Get()
+	defer rc.Close()
+	rc.Do("DEL", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab")
 
+	s := newServer(mb)
+	handler := newHandler().(*handler)
+	handler.Initialize(s)
+	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, testChannels[0], handler.RedactValues(testChannels[0]))
+
+	// check that request has the fetched access token
+	req, err := handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://channels.jiochat.com/media/download.action?media_id=12", clog)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://channels.jiochat.com/media/download.action?media_id=12", req.URL.String())
+	assert.Equal(t, "Bearer SESAME", req.Header.Get("Authorization"))
+
+	// and that we have a log for that request
+	assert.Len(t, clog.HTTPLogs(), 1)
+	assert.Equal(t, "https://channels.jiochat.com/auth/token.action", clog.HTTPLogs()[0].URL)
+
+	// check that another request reads token from cache
+	req, err = handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://channels.jiochat.com/media/download.action?media_id=13", clog)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://channels.jiochat.com/media/download.action?media_id=13", req.URL.String())
+	assert.Equal(t, "Bearer SESAME", req.Header.Get("Authorization"))
+	assert.Len(t, clog.HTTPLogs(), 1)
 }
 
 // setSendURL takes care of setting the sendURL to call
@@ -448,14 +404,10 @@ var defaultSendTestCases = []ChannelSendTestCase{
 }
 
 func setupBackend(mb *test.MockBackend) {
-	conn := mb.RedisPool().Get()
-
-	_, err := conn.Do("SET", "jiochat_channel_access_token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	conn.Close()
+	// ensure there's a cached access token
+	rc := mb.RedisPool().Get()
+	defer rc.Close()
+	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 }
 
 func TestSending(t *testing.T) {

--- a/handlers/line/line.go
+++ b/handlers/line/line.go
@@ -183,7 +183,7 @@ func buildMediaURL(mediaID string) string {
 }
 
 // BuildAttachmentRequest to download media for message attachment with Bearer token set
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	token := channel.StringConfigForKey(courier.ConfigAuthToken, "")
 	if token == "" {
 		return nil, fmt.Errorf("missing token for LN channel")

--- a/handlers/line/line_test.go
+++ b/handlers/line/line_test.go
@@ -608,7 +608,7 @@ func TestBuildMediaRequest(t *testing.T) {
 	mb := test.NewMockBackend()
 
 	lnHandler := &handler{NewBaseHandler(courier.ChannelType("LN"), "Line")}
-	req, _ := lnHandler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://example.org/v1/media/41")
+	req, _ := lnHandler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer the-auth-token", req.Header.Get("Authorization"))
 }

--- a/handlers/rocketchat/rocketchat.go
+++ b/handlers/rocketchat/rocketchat.go
@@ -90,7 +90,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 }
 
 // BuildAttachmentRequest download media for message attachment with RC auth_token/user_id set
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	adminAuthToken := channel.StringConfigForKey(configAdminAuthToken, "")
 	adminUserID := channel.StringConfigForKey(configAdminUserID, "")
 	if adminAuthToken == "" || adminUserID == "" {

--- a/handlers/wechat/wechat.go
+++ b/handlers/wechat/wechat.go
@@ -312,7 +312,7 @@ func (h *handler) DescribeURN(ctx context.Context, channel courier.Channel, urn 
 }
 
 // BuildAttachmentRequest download media for message attachment
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	accessToken, err := h.getAccessToken(channel)
 	if err != nil {
 		return nil, err

--- a/handlers/wechat/wechat_test.go
+++ b/handlers/wechat/wechat_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
-	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -18,6 +16,7 @@ import (
 	"github.com/nyaruka/courier"
 	. "github.com/nyaruka/courier/handlers"
 	"github.com/nyaruka/courier/test"
+	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +24,7 @@ import (
 
 var testChannels = []courier.Channel{
 	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WC", "2020", "US",
-		map[string]interface{}{courier.ConfigSecret: "secret", configAppSecret: "app-secret", configAppID: "app-id"}),
+		map[string]interface{}{courier.ConfigSecret: "secret123", configAppSecret: "app-secret123", configAppID: "app-id"}),
 }
 
 var (
@@ -97,7 +96,7 @@ func addValidSignature(r *http.Request) {
 	timestamp := t.Format("20060102150405")
 	nonce := "nonce"
 
-	stringSlice := []string{"secret", timestamp, nonce}
+	stringSlice := []string{"secret123", timestamp, nonce}
 	sort.Strings(stringSlice)
 
 	value := strings.Join(stringSlice, "")
@@ -121,7 +120,7 @@ func addInvalidSignature(r *http.Request) {
 	timestamp := t.Format("20060102150405")
 	nonce := "nonce"
 
-	stringSlice := []string{"secret", timestamp, nonce}
+	stringSlice := []string{"secret123", timestamp, nonce}
 	sort.Strings(stringSlice)
 
 	value := strings.Join(stringSlice, "")
@@ -172,56 +171,6 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func TestFetchAccessToken(t *testing.T) {
-	fetchCalled := false
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "token") {
-			defer r.Body.Close()
-			// valid token
-			w.Write([]byte(`{"access_token": "TOKEN"}`))
-		}
-
-		// mark that we were called
-		fetchCalled = true
-	}))
-	sendURL = server.URL
-	fetchTimeout = time.Millisecond
-
-	RunChannelTestCases(t, testChannels, newHandler(), []ChannelHandleTestCase{
-		{
-			Label:                "Receive Message",
-			URL:                  receiveURL,
-			Data:                 validMsg,
-			ExpectedRespStatus:   200,
-			ExpectedBodyContains: "",
-			ExpectedMsgText:      Sp("Simple Message"),
-			ExpectedURN:          "wechat:1234",
-		},
-		{
-			Label:                "Verify URL",
-			URL:                  receiveURL,
-			ExpectedRespStatus:   200,
-			ExpectedBodyContains: "SUCCESS",
-			PrepRequest:          addValidSignature,
-		},
-		{
-			Label:                "Verify URL Invalid signature",
-			URL:                  receiveURL,
-			ExpectedRespStatus:   400,
-			ExpectedBodyContains: "unknown request",
-			PrepRequest:          addInvalidSignature,
-		},
-	})
-
-	// wait for our fetch to be called
-	time.Sleep(100 * time.Millisecond)
-
-	if !fetchCalled {
-		t.Error("fetch access point should have been called")
-	}
-
-}
-
 // mocks the call to the WeChat API
 func buildMockWCAPI(testCases []ChannelHandleTestCase) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -269,17 +218,14 @@ func TestDescribeURN(t *testing.T) {
 	defer WCAPI.Close()
 
 	mb := test.NewMockBackend()
-	conn := mb.RedisPool().Get()
 
-	_, err := conn.Do("SET", "wechat_channel_access_token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	conn.Close()
+	// ensure there's a cached access token
+	rc := mb.RedisPool().Get()
+	defer rc.Close()
+	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 
 	s := newServer(mb)
-	handler := &handler{NewBaseHandler(courier.ChannelType("WC"), "WeChat")}
+	handler := newHandler().(*handler)
 	handler.Initialize(s)
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, testChannels[0], handler.RedactValues(testChannels[0]))
 
@@ -296,36 +242,46 @@ func TestDescribeURN(t *testing.T) {
 		assert.Equal(t, metadata, tc.expectedMetadata)
 	}
 
-	AssertChannelLogRedaction(t, clog, []string{"secret"})
+	AssertChannelLogRedaction(t, clog, []string{"secret123"})
 }
 
-func TestBuildMediaRequest(t *testing.T) {
+func TestBuildAttachmentRequest(t *testing.T) {
 	mb := test.NewMockBackend()
-	conn := mb.RedisPool().Get()
 
-	_, err := conn.Do("SET", "wechat_channel_access_token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
-	if err != nil {
-		log.Fatal(err)
-	}
+	// reset send URL
+	sendURL = "https://api.weixin.qq.com/cgi-bin"
 
-	conn.Close()
-	s := newServer(mb)
-	handler := &handler{NewBaseHandler(courier.ChannelType("WC"), "WeChat")}
-	handler.Initialize(s)
-
-	tcs := []struct {
-		url string
-	}{
-		{
-			fmt.Sprintf("%s/media/get?media_id=12", sendURL),
+	defer httpx.SetRequestor(httpx.DefaultRequestor)
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+		"https://api.weixin.qq.com/cgi-bin/token?appid=app-id&grant_type=client_credential&secret=app-secret123": {
+			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"access_token": "SESAME"}`)),
 		},
-	}
+	}))
 
-	for _, tc := range tcs {
-		req, _ := handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], tc.url, nil)
-		assert.Equal(t, fmt.Sprintf("%s/media/get?access_token=ACCESS_TOKEN&media_id=12", sendURL), req.URL.String())
-	}
+	// ensure that we start with no cached token
+	rc := mb.RedisPool().Get()
+	defer rc.Close()
+	rc.Do("DEL", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab")
 
+	s := newServer(mb)
+	handler := newHandler().(*handler)
+	handler.Initialize(s)
+	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, testChannels[0], handler.RedactValues(testChannels[0]))
+
+	// check that request has the fetched access token
+	req, err := handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://api.weixin.qq.com/cgi-bin/media/download.action?media_id=12", clog)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://api.weixin.qq.com/cgi-bin/media/download.action?access_token=SESAME&media_id=12", req.URL.String())
+
+	// and that we have a log for that request
+	assert.Len(t, clog.HTTPLogs(), 1)
+	assert.Equal(t, "https://api.weixin.qq.com/cgi-bin/token?appid=app-id&grant_type=client_credential&secret=**********", clog.HTTPLogs()[0].URL)
+
+	// check that another request reads token from cache
+	req, err = handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://api.weixin.qq.com/cgi-bin/media/download.action?media_id=13", clog)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://api.weixin.qq.com/cgi-bin/media/download.action?access_token=SESAME&media_id=13", req.URL.String())
+	assert.Len(t, clog.HTTPLogs(), 1)
 }
 
 // setSendURL takes care of setting the sendURL to call
@@ -388,18 +344,14 @@ var defaultSendTestCases = []ChannelSendTestCase{
 }
 
 func setupBackend(mb *test.MockBackend) {
-	conn := mb.RedisPool().Get()
-
-	_, err := conn.Do("SET", "wechat_channel_access_token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	conn.Close()
+	// ensure there's a cached access token
+	rc := mb.RedisPool().Get()
+	defer rc.Close()
+	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 }
 
 func TestSending(t *testing.T) {
 	maxMsgLength = 160
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WC", "2020", "US", map[string]interface{}{configAppSecret: "secret", configAppID: "app-id"})
-	RunChannelSendTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"secret"}, setupBackend)
+	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WC", "2020", "US", map[string]interface{}{configAppSecret: "secret123", configAppID: "app-id"})
+	RunChannelSendTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"secret123"}, setupBackend)
 }

--- a/handlers/wechat/wechat_test.go
+++ b/handlers/wechat/wechat_test.go
@@ -322,7 +322,7 @@ func TestBuildMediaRequest(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		req, _ := handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], tc.url)
+		req, _ := handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], tc.url, nil)
 		assert.Equal(t, fmt.Sprintf("%s/media/get?access_token=ACCESS_TOKEN&media_id=12", sendURL), req.URL.String())
 	}
 

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -319,7 +319,7 @@ func resolveMediaURL(channel courier.Channel, mediaID string) (string, error) {
 }
 
 // BuildAttachmentRequest to download media for message attachment with Bearer token set
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	token := channel.StringConfigForKey(courier.ConfigAuthToken, "")
 	if token == "" {
 		return nil, fmt.Errorf("missing token for WA channel")

--- a/handlers/whatsapp/whatsapp_test.go
+++ b/handlers/whatsapp/whatsapp_test.go
@@ -506,17 +506,17 @@ func TestBuildMediaRequest(t *testing.T) {
 	mb := test.NewMockBackend()
 
 	waHandler := &handler{NewBaseHandler(courier.ChannelType("WA"), "WhatsApp")}
-	req, _ := waHandler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://example.org/v1/media/41")
+	req, _ := waHandler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer the-auth-token", req.Header.Get("Authorization"))
 
 	d3Handler := &handler{NewBaseHandler(courier.ChannelType("D3"), "360Dialog")}
-	req, _ = d3Handler.BuildAttachmentRequest(context.Background(), mb, testChannels[1], "https://example.org/v1/media/41")
+	req, _ = d3Handler.BuildAttachmentRequest(context.Background(), mb, testChannels[1], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "the-auth-token", req.Header.Get("D360-API-KEY"))
 
 	txHandler := &handler{NewBaseHandler(courier.ChannelType("TXW"), "TextIt")}
-	req, _ = txHandler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://example.org/v1/media/41")
+	req, _ = txHandler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer the-auth-token", req.Header.Get("Authorization"))
 }


### PR DESCRIPTION
Instead of relying on scheduled task in RP

Also fixes channel log redaction for these channel types.