### PR TITLE
Allow empty attachments, e.g. a txt file

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -99,9 +99,6 @@ func FetchAndStoreAttachment(ctx context.Context, b Backend, channel Channel, at
 		// just have problems
 		return nil, errors.Errorf("non 2XX response code (%d) trying to fetch attachment", trace.Response.StatusCode)
 	}
-	if len(trace.ResponseBody) == 0 {
-		return nil, errors.New("received empty response trying to fetch attachment")
-	}
 
 	mimeType := ""
 	extension := filepath.Ext(parsedURL.Path)

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -22,9 +22,6 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 		"http://mock.com/media/hello.mp3": {
 			httpx.NewMockResponse(502, nil, []byte(`Timeout`)),
 		},
-		"http://mock.com/media/hello.avi": {
-			httpx.NewMockResponse(200, nil, nil), // 200 status code but empty response
-		},
 	}))
 
 	defer uuids.SetGenerator(uuids.DefaultGenerator)
@@ -51,11 +48,6 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 
 	att, err = courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello.mp3", clog)
 	assert.EqualError(t, err, "non 2XX response code (502) trying to fetch attachment")
-	assert.Nil(t, att)
-	assert.Len(t, mb.SavedAttachments(), 1)
-
-	att, err = courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello.avi", clog)
-	assert.EqualError(t, err, "received empty response trying to fetch attachment")
 	assert.Nil(t, att)
 	assert.Len(t, mb.SavedAttachments(), 1)
 }


### PR DESCRIPTION
https://sentry.io/organizations/nyaruka/issues/3708720249/events/d835aac10c7347b5a4befeb915d1105b/?project=205713