### PR TITLE
Allow msg id to be passed to fetch attachment requests and saved on the channel log

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -30,6 +30,7 @@ type fetchAttachmentRequest struct {
 	ChannelType ChannelType `json:"channel_type" validate:"required"`
 	ChannelUUID ChannelUUID `json:"channel_uuid" validate:"required,uuid"`
 	URL         string      `json:"url"          validate:"required"`
+	MsgID       MsgID       `json:"msg_id"`
 }
 
 type fetchAttachmentResponse struct {
@@ -56,7 +57,7 @@ func fetchAttachment(ctx context.Context, b Backend, r *http.Request) (*fetchAtt
 		return nil, errors.Wrap(err, "error getting channel")
 	}
 
-	clog := NewChannelLogForAttachmentFetch(ch, GetHandler(ch.ChannelType()).RedactValues(ch))
+	clog := NewChannelLogForAttachmentFetch(ch, fa.MsgID, GetHandler(ch.ChannelType()).RedactValues(ch))
 
 	attachment, err := FetchAndStoreAttachment(ctx, b, ch, fa.URL, clog)
 

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -33,7 +33,7 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 	mockChannel := test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", map[string]interface{}{})
 	mb.AddChannel(mockChannel)
 
-	clog := courier.NewChannelLogForAttachmentFetch(mockChannel, []string{"sesame"})
+	clog := courier.NewChannelLogForAttachmentFetch(mockChannel, courier.MsgID(123), []string{"sesame"})
 
 	att, err := courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello.jpg", clog)
 	assert.NoError(t, err)

--- a/channel_log.go
+++ b/channel_log.go
@@ -107,8 +107,8 @@ func NewChannelLogForSend(msg Msg, redactVals []string) *ChannelLog {
 }
 
 // NewChannelLogForSend creates a new channel log for an attachment fetch
-func NewChannelLogForAttachmentFetch(ch Channel, redactVals []string) *ChannelLog {
-	return newChannelLog(ChannelLogTypeAttachmentFetch, ch, nil, NilMsgID, redactVals)
+func NewChannelLogForAttachmentFetch(ch Channel, msgID MsgID, redactVals []string) *ChannelLog {
+	return newChannelLog(ChannelLogTypeAttachmentFetch, ch, nil, msgID, redactVals)
 }
 
 // NewChannelLog creates a new channel log with the given type and channel


### PR DESCRIPTION
I left this out initially because we're in theory moving toward not saving channel logs with msg ids.. but until we get there.. it's useful to have