### PR TITLE
Rework writing msg statuses to always use id resolving

### DIFF
--- a/handlers/dialog360/dialog360.go
+++ b/handlers/dialog360/dialog360.go
@@ -328,13 +328,6 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 
 				event := h.Backend().NewMsgStatusForExternalID(channel, status.ID, msgStatus, clog)
 				err := h.Backend().WriteMsgStatus(ctx, event)
-
-				// we don't know about this message, just tell them we ignored it
-				if err == courier.ErrMsgNotFound {
-					data = append(data, courier.NewInfoData(fmt.Sprintf("message id: %s not found, ignored", status.ID)))
-					continue
-				}
-
 				if err != nil {
 					return nil, nil, err
 				}

--- a/handlers/facebook/facebook.go
+++ b/handlers/facebook/facebook.go
@@ -411,13 +411,6 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 			for _, mid := range msg.Delivery.MIDs {
 				event := h.Backend().NewMsgStatusForExternalID(channel, mid, courier.MsgDelivered, clog)
 				err := h.Backend().WriteMsgStatus(ctx, event)
-
-				// we don't know about this message, just tell them we ignored it
-				if err == courier.ErrMsgNotFound {
-					data = append(data, courier.NewInfoData("message not found, ignored"))
-					continue
-				}
-
 				if err != nil {
 					return nil, err
 				}

--- a/handlers/facebookapp/facebookapp.go
+++ b/handlers/facebookapp/facebookapp.go
@@ -524,13 +524,6 @@ func (h *handler) processCloudWhatsAppPayload(ctx context.Context, channel couri
 
 				event := h.Backend().NewMsgStatusForExternalID(channel, status.ID, msgStatus, clog)
 				err := h.Backend().WriteMsgStatus(ctx, event)
-
-				// we don't know about this message, just tell them we ignored it
-				if err == courier.ErrMsgNotFound {
-					data = append(data, courier.NewInfoData(fmt.Sprintf("message id: %s not found, ignored", status.ID)))
-					continue
-				}
-
 				if err != nil {
 					return nil, nil, err
 				}
@@ -766,13 +759,6 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel c
 			for _, mid := range msg.Delivery.MIDs {
 				event := h.Backend().NewMsgStatusForExternalID(channel, mid, courier.MsgDelivered, clog)
 				err := h.Backend().WriteMsgStatus(ctx, event)
-
-				// we don't know about this message, just tell them we ignored it
-				if err == courier.ErrMsgNotFound {
-					data = append(data, courier.NewInfoData("message not found, ignored"))
-					continue
-				}
-
 				if err != nil {
 					return nil, nil, err
 				}

--- a/handlers/infobip/infobip.go
+++ b/handlers/infobip/infobip.go
@@ -70,11 +70,6 @@ func (h *handler) statusMessage(ctx context.Context, channel courier.Channel, w 
 		// write our status
 		status := h.Backend().NewMsgStatusForExternalID(channel, s.MessageID, msgStatus, clog)
 		err := h.Backend().WriteMsgStatus(ctx, status)
-		if err == courier.ErrMsgNotFound {
-			data = append(data, courier.NewInfoData(fmt.Sprintf("ignoring status update message id: %s, not found", s.MessageID)))
-			continue
-		}
-
 		if err != nil {
 			return nil, err
 		}

--- a/handlers/responses.go
+++ b/handlers/responses.go
@@ -24,10 +24,6 @@ func WriteMsgsAndResponse(ctx context.Context, h courier.ChannelHandler, msgs []
 // WriteMsgStatusAndResponse write the passed in status to our backend
 func WriteMsgStatusAndResponse(ctx context.Context, h courier.ChannelHandler, channel courier.Channel, status courier.MsgStatus, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
 	err := h.Server().Backend().WriteMsgStatus(ctx, status)
-	if err == courier.ErrMsgNotFound {
-		return nil, WriteAndLogRequestIgnored(ctx, h, channel, w, r, "msg not found, ignored")
-	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/whatsapp/whatsapp.go
+++ b/handlers/whatsapp/whatsapp.go
@@ -271,13 +271,6 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 
 		event := h.Backend().NewMsgStatusForExternalID(channel, status.ID, msgStatus, clog)
 		err := h.Backend().WriteMsgStatus(ctx, event)
-
-		// we don't know about this message, just tell them we ignored it
-		if err == courier.ErrMsgNotFound {
-			data = append(data, courier.NewInfoData(fmt.Sprintf("message id: %s not found, ignored", status.ID)))
-			continue
-		}
-
 		if err != nil {
 			return nil, err
 		}

--- a/msg.go
+++ b/msg.go
@@ -3,7 +3,6 @@ package courier
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -12,12 +11,6 @@ import (
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/null/v2"
 )
-
-// ErrMsgNotFound is returned when trying to queue the status for a Msg that doesn't exit
-var ErrMsgNotFound = errors.New("message not found")
-
-// ErrWrongIncomingMsgStatus use do ignore the status update if the DB raise this
-var ErrWrongIncomingMsgStatus = errors.New("incoming messages can only be PENDING or HANDLED")
 
 // MsgID is our typing of the db int type
 type MsgID null.Int64


### PR DESCRIPTION
* Ensure that if we get an error trying to resolve a msg id, that msg is spooled
* Change flushing spooled statuses to use the same code path as the status writer