### PR TITLE
Simpler `Msg` interface

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -140,8 +140,6 @@ func (ts *BackendTestSuite) TestMsgUnmarshal() {
 	ts.True(msg.IsResend())
 	flow_ref := courier.FlowReference{UUID: "9de3663f-c5c5-4c92-9f45-ecbc09abcc85", Name: "Favorites"}
 	ts.Equal(&flow_ref, msg.Flow())
-	ts.Equal("Favorites", msg.FlowName())
-	ts.Equal("9de3663f-c5c5-4c92-9f45-ecbc09abcc85", msg.FlowUUID())
 
 	msgJSONNoQR := `{
 		"text": "Test message 21",
@@ -168,8 +166,6 @@ func (ts *BackendTestSuite) TestMsgUnmarshal() {
 	ts.Equal("", msg.ResponseToExternalID())
 	ts.False(msg.IsResend())
 	ts.Nil(msg.Flow())
-	ts.Equal("", msg.FlowName())
-	ts.Equal("", msg.FlowUUID())
 }
 
 func (ts *BackendTestSuite) TestDeleteMsgByExternalID() {

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -354,20 +354,6 @@ func (m *DBMsg) Flow() *courier.FlowReference     { return m.Flow_ }
 func (m *DBMsg) Origin() courier.MsgOrigin        { return m.Origin_ }
 func (m *DBMsg) ContactLastSeenOn() *time.Time    { return m.ContactLastSeenOn_ }
 
-func (m *DBMsg) FlowName() string {
-	if m.Flow_ == nil {
-		return ""
-	}
-	return m.Flow_.Name
-}
-
-func (m *DBMsg) FlowUUID() string {
-	if m.Flow_ == nil {
-		return ""
-	}
-	return m.Flow_.UUID
-}
-
 func (m *DBMsg) Topic() string {
 	if m.Metadata_ == nil {
 		return ""

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -331,29 +331,21 @@ type DBMsg struct {
 	alreadyWritten bool
 }
 
-func (m *DBMsg) ID() courier.MsgID                { return m.ID_ }
-func (m *DBMsg) EventID() int64                   { return int64(m.ID_) }
-func (m *DBMsg) UUID() courier.MsgUUID            { return m.UUID_ }
-func (m *DBMsg) Text() string                     { return m.Text_ }
-func (m *DBMsg) Attachments() []string            { return m.Attachments_ }
-func (m *DBMsg) QuickReplies() []string           { return m.QuickReplies_ }
-func (m *DBMsg) Locale() i18n.Locale              { return i18n.Locale(string(m.Locale_)) }
-func (m *DBMsg) ExternalID() string               { return string(m.ExternalID_) }
-func (m *DBMsg) URN() urns.URN                    { return m.URN_ }
-func (m *DBMsg) URNAuth() string                  { return m.URNAuth_ }
-func (m *DBMsg) URNAuthTokens() map[string]string { return m.URNAuthTokens_ }
-func (m *DBMsg) ContactName() string              { return m.ContactName_ }
-func (m *DBMsg) HighPriority() bool               { return m.HighPriority_ }
-func (m *DBMsg) ReceivedOn() *time.Time           { return m.SentOn_ }
-func (m *DBMsg) SentOn() *time.Time               { return m.SentOn_ }
-func (m *DBMsg) ResponseToExternalID() string     { return m.ResponseToExternalID_ }
-func (m *DBMsg) IsResend() bool                   { return m.IsResend_ }
-func (m *DBMsg) Channel() courier.Channel         { return m.channel }
-func (m *DBMsg) SessionStatus() string            { return m.SessionStatus_ }
-func (m *DBMsg) Flow() *courier.FlowReference     { return m.Flow_ }
-func (m *DBMsg) Origin() courier.MsgOrigin        { return m.Origin_ }
-func (m *DBMsg) ContactLastSeenOn() *time.Time    { return m.ContactLastSeenOn_ }
+func (m *DBMsg) EventID() int64           { return int64(m.ID_) }
+func (m *DBMsg) ID() courier.MsgID        { return m.ID_ }
+func (m *DBMsg) UUID() courier.MsgUUID    { return m.UUID_ }
+func (m *DBMsg) ExternalID() string       { return string(m.ExternalID_) }
+func (m *DBMsg) Text() string             { return m.Text_ }
+func (m *DBMsg) Attachments() []string    { return m.Attachments_ }
+func (m *DBMsg) URN() urns.URN            { return m.URN_ }
+func (m *DBMsg) Channel() courier.Channel { return m.channel }
 
+// outgoing specific
+func (m *DBMsg) QuickReplies() []string        { return m.QuickReplies_ }
+func (m *DBMsg) Locale() i18n.Locale           { return i18n.Locale(string(m.Locale_)) }
+func (m *DBMsg) URNAuth() string               { return m.URNAuth_ }
+func (m *DBMsg) Origin() courier.MsgOrigin     { return m.Origin_ }
+func (m *DBMsg) ContactLastSeenOn() *time.Time { return m.ContactLastSeenOn_ }
 func (m *DBMsg) Topic() string {
 	if m.Metadata_ == nil {
 		return ""
@@ -361,51 +353,30 @@ func (m *DBMsg) Topic() string {
 	topic, _, _, _ := jsonparser.Get(m.Metadata_, "topic")
 	return string(topic)
 }
-
-// Metadata returns the metadata for this message
 func (m *DBMsg) Metadata() json.RawMessage {
 	return m.Metadata_
 }
+func (m *DBMsg) ResponseToExternalID() string { return m.ResponseToExternalID_ }
+func (m *DBMsg) SentOn() *time.Time           { return m.SentOn_ }
+func (m *DBMsg) IsResend() bool               { return m.IsResend_ }
+func (m *DBMsg) Flow() *courier.FlowReference { return m.Flow_ }
+func (m *DBMsg) SessionStatus() string        { return m.SessionStatus_ }
+func (m *DBMsg) HighPriority() bool           { return m.HighPriority_ }
 
-func (m *DBMsg) hash() string {
-	hash := sha1.Sum([]byte(m.Text_ + "|" + strings.Join(m.Attachments_, "|")))
-	return hex.EncodeToString(hash[:])
-}
-
-// WithContactName can be used to set the contact name on a msg
-func (m *DBMsg) WithContactName(name string) courier.Msg { m.ContactName_ = name; return m }
-
-// WithReceivedOn can be used to set sent_on on a msg in a chained call
-func (m *DBMsg) WithReceivedOn(date time.Time) courier.Msg { m.SentOn_ = &date; return m }
-
-// WithID can be used to set the id on a msg in a chained call
-func (m *DBMsg) WithID(id courier.MsgID) courier.Msg { m.ID_ = id; return m }
-
-// WithUUID can be used to set the id on a msg in a chained call
-func (m *DBMsg) WithUUID(uuid courier.MsgUUID) courier.Msg { m.UUID_ = uuid; return m }
-
-// WithMetadata can be used to add metadata to a Msg
-func (m *DBMsg) WithMetadata(metadata json.RawMessage) courier.Msg { m.Metadata_ = metadata; return m }
-
-// WithFlow can be used to add flow to a Msg
-func (m *DBMsg) WithFlow(flow *courier.FlowReference) courier.Msg { m.Flow_ = flow; return m }
-
-// WithAttachment can be used to append to the media urls for a message
+// incoming specific
+func (m *DBMsg) ReceivedOn() *time.Time { return m.SentOn_ }
 func (m *DBMsg) WithAttachment(url string) courier.Msg {
 	m.Attachments_ = append(m.Attachments_, url)
 	return m
 }
-
-func (m *DBMsg) WithLocale(lc i18n.Locale) courier.Msg { m.Locale_ = null.String(lc); return m }
-
-// WithURNAuth sets the URN auth to be used for sending (only used to create messages in tests)
-func (m *DBMsg) WithURNAuth(token string) courier.Msg {
-	m.URNAuth_ = token
-	return m
-}
-
-// WithURNAuthTokens can be used to save URN auth tokens from an incoming message
+func (m *DBMsg) WithContactName(name string) courier.Msg { m.ContactName_ = name; return m }
 func (m *DBMsg) WithURNAuthTokens(tokens map[string]string) courier.Msg {
 	m.URNAuthTokens_ = tokens
 	return m
+}
+func (m *DBMsg) WithReceivedOn(date time.Time) courier.Msg { m.SentOn_ = &date; return m }
+
+func (m *DBMsg) hash() string {
+	hash := sha1.Sum([]byte(m.Text_ + "|" + strings.Join(m.Attachments_, "|")))
+	return hex.EncodeToString(hash[:])
 }

--- a/handlers/firebase/firebase_test.go
+++ b/handlers/firebase/firebase_test.go
@@ -45,16 +45,16 @@ var testChannels = []courier.Channel{
 
 var testCases = []IncomingTestCase{
 	{
-		Label:                "Receive Valid Message",
-		URL:                  receiveURL,
-		Data:                 "from=12345&date=2017-01-01T08:50:00.000&fcm_token=token&name=fred&msg=hello+world",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("hello world"),
-		ExpectedURN:          "fcm:12345",
-		ExpectedDate:         time.Date(2017, 1, 1, 8, 50, 0, 0, time.UTC),
-		ExpectedURNAuth:      "token",
-		ExpectedContactName:  Sp("fred"),
+		Label:                 "Receive Valid Message",
+		URL:                   receiveURL,
+		Data:                  "from=12345&date=2017-01-01T08:50:00.000&fcm_token=token&name=fred&msg=hello+world",
+		ExpectedRespStatus:    200,
+		ExpectedBodyContains:  "Accepted",
+		ExpectedMsgText:       Sp("hello world"),
+		ExpectedURN:           "fcm:12345",
+		ExpectedDate:          time.Date(2017, 1, 1, 8, 50, 0, 0, time.UTC),
+		ExpectedURNAuthTokens: map[string]string{"default": "token"},
+		ExpectedContactName:   Sp("fred"),
 	},
 	{
 		Label:                "Receive Invalid Date",

--- a/handlers/highconnection/highconnection.go
+++ b/handlers/highconnection/highconnection.go
@@ -139,8 +139,13 @@ func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.Chann
 
 	status := h.Backend().NewStatusUpdate(msg.Channel(), msg.ID(), courier.MsgStatusErrored, clog)
 	parts := handlers.SplitMsgByChannel(msg.Channel(), handlers.GetTextAndAttachments(msg), maxMsgLength)
-	for _, part := range parts {
 
+	var flowName string
+	if msg.Flow() != nil {
+		flowName = msg.Flow().Name
+	}
+
+	for _, part := range parts {
 		form := url.Values{
 			"accountid":  []string{username},
 			"password":   []string{password},
@@ -148,7 +153,7 @@ func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.Chann
 			"to":         []string{msg.URN().Path()},
 			"ret_id":     []string{msg.ID().String()},
 			"datacoding": []string{"8"},
-			"user_data":  []string{msg.FlowName()},
+			"user_data":  []string{flowName},
 			"ret_url":    []string{statusURL},
 			"ret_mo_url": []string{receiveURL},
 		}

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -166,7 +166,7 @@ func RunIncomingTestCases(t *testing.T, channels []courier.Channel, handler cour
 
 			if tc.ExpectedMsgText != nil || tc.ExpectedAttachments != nil {
 				require.Len(mb.WrittenMsgs(), 1, "expected a msg to be written")
-				msg := mb.WrittenMsgs()[0]
+				msg := mb.WrittenMsgs()[0].(*test.MockMsg)
 
 				if tc.ExpectedMsgText != nil {
 					assert.Equal(t, *tc.ExpectedMsgText, msg.Text())
@@ -314,7 +314,7 @@ func RunOutgoingTestCases(t *testing.T, channel courier.Channel, handler courier
 		t.Run(tc.Label, func(t *testing.T) {
 			require := require.New(t)
 
-			msg := mb.NewOutgoingMsg(channel, 10, urns.URN(tc.MsgURN), tc.MsgText, tc.MsgHighPriority, tc.MsgQuickReplies, tc.MsgTopic, tc.MsgResponseToExternalID, msgOrigin, tc.MsgContactLastSeenOn)
+			msg := mb.NewOutgoingMsg(channel, 10, urns.URN(tc.MsgURN), tc.MsgText, tc.MsgHighPriority, tc.MsgQuickReplies, tc.MsgTopic, tc.MsgResponseToExternalID, msgOrigin, tc.MsgContactLastSeenOn).(*test.MockMsg)
 			msg.WithLocale(tc.MsgLocale)
 
 			for _, a := range tc.MsgAttachments {

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -40,21 +40,21 @@ type IncomingTestCase struct {
 	Headers       map[string]string
 	MultipartForm map[string]string
 
-	ExpectedRespStatus   int
-	ExpectedBodyContains string
-	ExpectedContactName  *string
-	ExpectedMsgText      *string
-	ExpectedURN          urns.URN
-	ExpectedURNAuth      string
-	ExpectedAttachments  []string
-	ExpectedDate         time.Time
-	ExpectedMsgStatus    courier.MsgStatus
-	ExpectedExternalID   string
-	ExpectedMsgID        int64
-	ExpectedEvent        courier.ChannelEventType
-	ExpectedEventExtra   map[string]string
-	ExpectedErrors       []*courier.ChannelError
-	NoLogsExpected       bool
+	ExpectedRespStatus    int
+	ExpectedBodyContains  string
+	ExpectedContactName   *string
+	ExpectedMsgText       *string
+	ExpectedURN           urns.URN
+	ExpectedURNAuthTokens map[string]string
+	ExpectedAttachments   []string
+	ExpectedDate          time.Time
+	ExpectedMsgStatus     courier.MsgStatus
+	ExpectedExternalID    string
+	ExpectedMsgID         int64
+	ExpectedEvent         courier.ChannelEventType
+	ExpectedEventExtra    map[string]string
+	ExpectedErrors        []*courier.ChannelError
+	NoLogsExpected        bool
 }
 
 // MockedRequest is a fake HTTP request
@@ -181,7 +181,7 @@ func RunIncomingTestCases(t *testing.T, channels []courier.Channel, handler cour
 					assert.Equal(t, tc.ExpectedExternalID, msg.ExternalID())
 				}
 				assert.Equal(t, tc.ExpectedURN, msg.URN())
-				assert.Equal(t, tc.ExpectedURNAuth, msg.URNAuthTokens()["default"])
+				assert.Equal(t, tc.ExpectedURNAuthTokens, msg.URNAuthTokens())
 			} else {
 				assert.Empty(t, mb.WrittenMsgs(), "unexpected msg written")
 			}

--- a/msg.go
+++ b/msg.go
@@ -78,20 +78,9 @@ type Msg interface {
 	HighPriority() bool
 
 	// incoming specific
-	URNAuthTokens() map[string]string
-	ContactName() string
 	ReceivedOn() *time.Time
-
 	WithAttachment(url string) Msg
 	WithContactName(name string) Msg
 	WithURNAuthTokens(tokens map[string]string) Msg
 	WithReceivedOn(date time.Time) Msg
-
-	// only used to create outgoing messages for testing
-	WithID(id MsgID) Msg
-	WithUUID(uuid MsgUUID) Msg
-	WithMetadata(metadata json.RawMessage) Msg
-	WithFlow(flow *FlowReference) Msg
-	WithLocale(i18n.Locale) Msg
-	WithURNAuth(token string) Msg
 }

--- a/msg.go
+++ b/msg.go
@@ -52,46 +52,46 @@ const (
 
 // Msg is our interface to represent an incoming or outgoing message
 type Msg interface {
+	Event
+
 	ID() MsgID
 	UUID() MsgUUID
+	ExternalID() string
 	Text() string
 	Attachments() []string
-	Locale() i18n.Locale
-	ExternalID() string
 	URN() urns.URN
-	URNAuth() string
-	URNAuthTokens() map[string]string
-	ContactName() string
+	Channel() Channel
+
+	// outgoing specific
 	QuickReplies() []string
+	Locale() i18n.Locale
+	URNAuth() string
 	Origin() MsgOrigin
 	ContactLastSeenOn() *time.Time
 	Topic() string
 	Metadata() json.RawMessage
 	ResponseToExternalID() string
-	IsResend() bool
-
-	Flow() *FlowReference
-	FlowName() string
-	FlowUUID() string
-
-	Channel() Channel
-
-	ReceivedOn() *time.Time
 	SentOn() *time.Time
-
+	IsResend() bool
+	Flow() *FlowReference
+	SessionStatus() string
 	HighPriority() bool
 
+	// incoming specific
+	URNAuthTokens() map[string]string
+	ContactName() string
+	ReceivedOn() *time.Time
+
+	WithAttachment(url string) Msg
 	WithContactName(name string) Msg
+	WithURNAuthTokens(tokens map[string]string) Msg
 	WithReceivedOn(date time.Time) Msg
+
+	// only used to create outgoing messages for testing
 	WithID(id MsgID) Msg
 	WithUUID(uuid MsgUUID) Msg
-	WithAttachment(url string) Msg
-	WithLocale(i18n.Locale) Msg
-	WithURNAuth(token string) Msg
-	WithURNAuthTokens(tokens map[string]string) Msg
 	WithMetadata(metadata json.RawMessage) Msg
 	WithFlow(flow *FlowReference) Msg
-
-	EventID() int64
-	SessionStatus() string
+	WithLocale(i18n.Locale) Msg
+	WithURNAuth(token string) Msg
 }

--- a/responses_test.go
+++ b/responses_test.go
@@ -43,7 +43,7 @@ func TestWriteAndLogUnauthorized(t *testing.T) {
 
 func TestWriteMsgSuccess(t *testing.T) {
 	ch := test.NewMockChannel("5fccf4b6-48d7-4f5a-bce8-b0d1fd5342ec", "NX", "+1234567890", "US", nil)
-	msg := test.NewMockBackend().NewIncomingMsg(ch, "tel:+0987654321", "hi there", "", nil).WithUUID("588aafc4-ab5c-48ce-89e8-05c9fdeeafb7")
+	msg := test.NewMockBackend().NewIncomingMsg(ch, "tel:+0987654321", "hi there", "", nil).(*test.MockMsg).WithUUID("588aafc4-ab5c-48ce-89e8-05c9fdeeafb7")
 	w := httptest.NewRecorder()
 
 	err := courier.WriteMsgSuccess(w, []courier.Msg{msg})

--- a/test/backend.go
+++ b/test/backend.go
@@ -97,7 +97,7 @@ func (mb *MockBackend) DeleteMsgByExternalID(ctx context.Context, channel courie
 
 // NewIncomingMsg creates a new message from the given params
 func (mb *MockBackend) NewIncomingMsg(channel courier.Channel, urn urns.URN, text string, extID string, clog *courier.ChannelLog) courier.Msg {
-	m := &mockMsg{
+	m := &MockMsg{
 		channel: channel, urn: urn, text: text, externalID: extID,
 	}
 
@@ -114,7 +114,7 @@ func (mb *MockBackend) NewIncomingMsg(channel courier.Channel, urn urns.URN, tex
 func (mb *MockBackend) NewOutgoingMsg(channel courier.Channel, id courier.MsgID, urn urns.URN, text string, highPriority bool, quickReplies []string,
 	topic string, responseToExternalID string, origin courier.MsgOrigin, contactLastSeenOn *time.Time) courier.Msg {
 
-	return &mockMsg{
+	return &MockMsg{
 		channel:              channel,
 		id:                   id,
 		urn:                  urn,
@@ -190,7 +190,7 @@ func (mb *MockBackend) SetErrorOnQueue(shouldError bool) {
 
 // WriteMsg queues the passed in message internally
 func (mb *MockBackend) WriteMsg(ctx context.Context, m courier.Msg, clog *courier.ChannelLog) error {
-	mock := m.(*mockMsg)
+	mock := m.(*MockMsg)
 
 	// this msg has already been written (we received it twice), we are a no op
 	if mock.alreadyWritten {
@@ -205,7 +205,7 @@ func (mb *MockBackend) WriteMsg(ctx context.Context, m courier.Msg, clog *courie
 	}
 
 	mb.writtenMsgs = append(mb.writtenMsgs, m)
-	mb.lastContactName = m.(*mockMsg).contactName
+	mb.lastContactName = m.(*MockMsg).contactName
 
 	if m.ExternalID() != "" {
 		mb.seenExternalIDs[fmt.Sprintf("%s|%s", m.Channel().UUID(), m.ExternalID())] = m.UUID()

--- a/test/msg.go
+++ b/test/msg.go
@@ -48,23 +48,8 @@ func NewMockMsg(id courier.MsgID, uuid courier.MsgUUID, channel courier.Channel,
 	}
 }
 
-func (m *mockMsg) SessionStatus() string        { return "" }
-func (m *mockMsg) Flow() *courier.FlowReference { return m.flow }
-
-func (m *mockMsg) FlowName() string {
-	if m.flow == nil {
-		return ""
-	}
-	return m.flow.Name
-}
-
-func (m *mockMsg) FlowUUID() string {
-	if m.flow == nil {
-		return ""
-	}
-	return m.flow.UUID
-}
-
+func (m *mockMsg) SessionStatus() string            { return "" }
+func (m *mockMsg) Flow() *courier.FlowReference     { return m.flow }
 func (m *mockMsg) Channel() courier.Channel         { return m.channel }
 func (m *mockMsg) ID() courier.MsgID                { return m.id }
 func (m *mockMsg) EventID() int64                   { return int64(m.id) }

--- a/test/msg.go
+++ b/test/msg.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 )
 
-type mockMsg struct {
+type MockMsg struct {
 	id                   courier.MsgID
 	uuid                 courier.MsgUUID
 	channel              courier.Channel
@@ -35,11 +35,10 @@ type mockMsg struct {
 
 	receivedOn *time.Time
 	sentOn     *time.Time
-	wiredOn    *time.Time
 }
 
-func NewMockMsg(id courier.MsgID, uuid courier.MsgUUID, channel courier.Channel, urn urns.URN, text string) courier.Msg {
-	return &mockMsg{
+func NewMockMsg(id courier.MsgID, uuid courier.MsgUUID, channel courier.Channel, urn urns.URN, text string) *MockMsg {
+	return &MockMsg{
 		id:      id,
 		uuid:    uuid,
 		channel: channel,
@@ -48,49 +47,51 @@ func NewMockMsg(id courier.MsgID, uuid courier.MsgUUID, channel courier.Channel,
 	}
 }
 
-func (m *mockMsg) SessionStatus() string            { return "" }
-func (m *mockMsg) Flow() *courier.FlowReference     { return m.flow }
-func (m *mockMsg) Channel() courier.Channel         { return m.channel }
-func (m *mockMsg) ID() courier.MsgID                { return m.id }
-func (m *mockMsg) EventID() int64                   { return int64(m.id) }
-func (m *mockMsg) UUID() courier.MsgUUID            { return m.uuid }
-func (m *mockMsg) Text() string                     { return m.text }
-func (m *mockMsg) Attachments() []string            { return m.attachments }
-func (m *mockMsg) Locale() i18n.Locale              { return m.locale }
-func (m *mockMsg) ExternalID() string               { return m.externalID }
-func (m *mockMsg) URN() urns.URN                    { return m.urn }
-func (m *mockMsg) URNAuth() string                  { return m.urnAuth }
-func (m *mockMsg) URNAuthTokens() map[string]string { return m.urnAuthTokens }
-func (m *mockMsg) ContactName() string              { return m.contactName }
-func (m *mockMsg) HighPriority() bool               { return m.highPriority }
-func (m *mockMsg) QuickReplies() []string           { return m.quickReplies }
-func (m *mockMsg) Origin() courier.MsgOrigin        { return m.origin }
-func (m *mockMsg) ContactLastSeenOn() *time.Time    { return m.contactLastSeenOn }
-func (m *mockMsg) Topic() string                    { return m.topic }
-func (m *mockMsg) ResponseToExternalID() string     { return m.responseToExternalID }
-func (m *mockMsg) Metadata() json.RawMessage        { return m.metadata }
-func (m *mockMsg) IsResend() bool                   { return m.isResend }
-func (m *mockMsg) ReceivedOn() *time.Time           { return m.receivedOn }
-func (m *mockMsg) SentOn() *time.Time               { return m.sentOn }
-func (m *mockMsg) WiredOn() *time.Time              { return m.wiredOn }
+func (m *MockMsg) EventID() int64           { return int64(m.id) }
+func (m *MockMsg) ID() courier.MsgID        { return m.id }
+func (m *MockMsg) UUID() courier.MsgUUID    { return m.uuid }
+func (m *MockMsg) ExternalID() string       { return m.externalID }
+func (m *MockMsg) Text() string             { return m.text }
+func (m *MockMsg) Attachments() []string    { return m.attachments }
+func (m *MockMsg) URN() urns.URN            { return m.urn }
+func (m *MockMsg) Channel() courier.Channel { return m.channel }
 
-func (m *mockMsg) WithContactName(name string) courier.Msg { m.contactName = name; return m }
-func (m *mockMsg) WithURNAuth(token string) courier.Msg {
-	m.urnAuth = token
-	return m
-}
-func (m *mockMsg) WithURNAuthTokens(tokens map[string]string) courier.Msg {
-	m.urnAuthTokens = tokens
-	return m
-}
-func (m *mockMsg) WithReceivedOn(date time.Time) courier.Msg { m.receivedOn = &date; return m }
-func (m *mockMsg) WithID(id courier.MsgID) courier.Msg       { m.id = id; return m }
-func (m *mockMsg) WithUUID(uuid courier.MsgUUID) courier.Msg { m.uuid = uuid; return m }
-func (m *mockMsg) WithAttachment(url string) courier.Msg {
+// outgoing specific
+func (m *MockMsg) QuickReplies() []string        { return m.quickReplies }
+func (m *MockMsg) Locale() i18n.Locale           { return m.locale }
+func (m *MockMsg) URNAuth() string               { return m.urnAuth }
+func (m *MockMsg) Origin() courier.MsgOrigin     { return m.origin }
+func (m *MockMsg) ContactLastSeenOn() *time.Time { return m.contactLastSeenOn }
+func (m *MockMsg) Topic() string                 { return m.topic }
+func (m *MockMsg) Metadata() json.RawMessage     { return m.metadata }
+func (m *MockMsg) ResponseToExternalID() string  { return m.responseToExternalID }
+func (m *MockMsg) SentOn() *time.Time            { return m.sentOn }
+func (m *MockMsg) IsResend() bool                { return m.isResend }
+func (m *MockMsg) Flow() *courier.FlowReference  { return m.flow }
+func (m *MockMsg) SessionStatus() string         { return "" }
+func (m *MockMsg) HighPriority() bool            { return m.highPriority }
+
+// incoming specific
+func (m *MockMsg) ReceivedOn() *time.Time { return m.receivedOn }
+func (m *MockMsg) WithAttachment(url string) courier.Msg {
 	m.attachments = append(m.attachments, url)
 	return m
 }
-func (m *mockMsg) WithLocale(lc i18n.Locale) courier.Msg             { m.locale = lc; return m }
-func (m *mockMsg) WithMetadata(metadata json.RawMessage) courier.Msg { m.metadata = metadata; return m }
+func (m *MockMsg) WithContactName(name string) courier.Msg { m.contactName = name; return m }
+func (m *MockMsg) WithURNAuthTokens(tokens map[string]string) courier.Msg {
+	m.urnAuthTokens = tokens
+	return m
+}
+func (m *MockMsg) WithReceivedOn(date time.Time) courier.Msg { m.receivedOn = &date; return m }
 
-func (m *mockMsg) WithFlow(flow *courier.FlowReference) courier.Msg { m.flow = flow; return m }
+// used for testing created incoming messages
+func (m *MockMsg) URNAuthTokens() map[string]string { return m.urnAuthTokens }
+func (m *MockMsg) ContactName() string              { return m.contactName }
+
+// used to create outgoing messages for testing
+func (m *MockMsg) WithID(id courier.MsgID) courier.Msg               { m.id = id; return m }
+func (m *MockMsg) WithUUID(uuid courier.MsgUUID) courier.Msg         { m.uuid = uuid; return m }
+func (m *MockMsg) WithMetadata(metadata json.RawMessage) courier.Msg { m.metadata = metadata; return m }
+func (m *MockMsg) WithFlow(flow *courier.FlowReference) courier.Msg  { m.flow = flow; return m }
+func (m *MockMsg) WithLocale(lc i18n.Locale) courier.Msg             { m.locale = lc; return m }
+func (m *MockMsg) WithURNAuth(token string) courier.Msg              { m.urnAuth = token; return m }


### PR DESCRIPTION
Methods only used for testing only need to be on `MockMsg`