### PR TITLE
Msg interfaces separation

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -80,7 +80,7 @@ type Backend interface {
 	// MarkOutgoingMsgComplete marks the passed in message as having been processed. Note this should be called even in the case
 	// of errors during sending as it will manage the number of active workers per channel. The optional status parameter can be
 	// used to determine any sort of deduping of msg sends
-	MarkOutgoingMsgComplete(context.Context, Msg, StatusUpdate)
+	MarkOutgoingMsgComplete(context.Context, MsgOut, StatusUpdate)
 
 	// SaveAttachment saves an attachment to backend storage
 	SaveAttachment(context.Context, Channel, string, []byte, string) (string, error)

--- a/backend.go
+++ b/backend.go
@@ -42,10 +42,10 @@ type Backend interface {
 	DeleteMsgByExternalID(ctx context.Context, channel Channel, externalID string) error
 
 	// NewIncomingMsg creates a new message from the given params
-	NewIncomingMsg(Channel, urns.URN, string, string, *ChannelLog) Msg
+	NewIncomingMsg(Channel, urns.URN, string, string, *ChannelLog) MsgIn
 
 	// WriteMsg writes the passed in message to our backend
-	WriteMsg(context.Context, Msg, *ChannelLog) error
+	WriteMsg(context.Context, MsgIn, *ChannelLog) error
 
 	// NewStatusUpdate creates a new status update for the given message id
 	NewStatusUpdate(Channel, MsgID, MsgStatus, *ChannelLog) StatusUpdate

--- a/backend.go
+++ b/backend.go
@@ -67,7 +67,7 @@ type Backend interface {
 
 	// PopNextOutgoingMsg returns the next message that needs to be sent, callers should call MarkOutgoingMsgComplete with the
 	// returned message when they have dealt with the message (regardless of whether it was sent or not)
-	PopNextOutgoingMsg(context.Context) (Msg, error)
+	PopNextOutgoingMsg(context.Context) (MsgOut, error)
 
 	// WasMsgSent returns whether the backend thinks the passed in message was already sent. This can be used in cases where
 	// a backend wants to implement a failsafe against double sending messages (say if they were double queued)

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -399,7 +399,7 @@ func (b *backend) NewIncomingMsg(channel courier.Channel, urn urns.URN, text str
 }
 
 // PopNextOutgoingMsg pops the next message that needs to be sent
-func (b *backend) PopNextOutgoingMsg(ctx context.Context) (courier.Msg, error) {
+func (b *backend) PopNextOutgoingMsg(ctx context.Context) (courier.MsgOut, error) {
 	// pop the next message off our queue
 	rc := b.redisPool.Get()
 	defer rc.Close()

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -481,7 +481,7 @@ func (b *backend) ClearMsgSent(ctx context.Context, id courier.MsgID) error {
 }
 
 // MarkOutgoingMsgComplete marks the passed in message as having completed processing, freeing up a worker for that channel
-func (b *backend) MarkOutgoingMsgComplete(ctx context.Context, msg courier.Msg, status courier.StatusUpdate) {
+func (b *backend) MarkOutgoingMsgComplete(ctx context.Context, msg courier.MsgOut, status courier.StatusUpdate) {
 	rc := b.redisPool.Get()
 	defer rc.Close()
 

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -380,7 +380,7 @@ func (b *backend) DeleteMsgByExternalID(ctx context.Context, channel courier.Cha
 }
 
 // NewIncomingMsg creates a new message from the given params
-func (b *backend) NewIncomingMsg(channel courier.Channel, urn urns.URN, text string, extID string, clog *courier.ChannelLog) courier.Msg {
+func (b *backend) NewIncomingMsg(channel courier.Channel, urn urns.URN, text string, extID string, clog *courier.ChannelLog) courier.MsgIn {
 	// strip out invalid UTF8 and NULL chars
 	urn = urns.URN(dbutil.ToValidUTF8(string(urn)))
 	text = dbutil.ToValidUTF8(text)
@@ -510,7 +510,7 @@ func (b *backend) MarkOutgoingMsgComplete(ctx context.Context, msg courier.MsgOu
 }
 
 // WriteMsg writes the passed in message to our store
-func (b *backend) WriteMsg(ctx context.Context, m courier.Msg, clog *courier.ChannelLog) error {
+func (b *backend) WriteMsg(ctx context.Context, m courier.MsgIn, clog *courier.ChannelLog) error {
 	timeout, cancel := context.WithTimeout(ctx, backendTimeout)
 	defer cancel()
 

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -167,16 +167,16 @@ func (m *Msg) HighPriority() bool           { return m.HighPriority_ }
 
 // incoming specific
 func (m *Msg) ReceivedOn() *time.Time { return m.SentOn_ }
-func (m *Msg) WithAttachment(url string) courier.Msg {
+func (m *Msg) WithAttachment(url string) courier.MsgIn {
 	m.Attachments_ = append(m.Attachments_, url)
 	return m
 }
-func (m *Msg) WithContactName(name string) courier.Msg { m.ContactName_ = name; return m }
-func (m *Msg) WithURNAuthTokens(tokens map[string]string) courier.Msg {
+func (m *Msg) WithContactName(name string) courier.MsgIn { m.ContactName_ = name; return m }
+func (m *Msg) WithURNAuthTokens(tokens map[string]string) courier.MsgIn {
 	m.URNAuthTokens_ = tokens
 	return m
 }
-func (m *Msg) WithReceivedOn(date time.Time) courier.Msg { m.SentOn_ = &date; return m }
+func (m *Msg) WithReceivedOn(date time.Time) courier.MsgIn { m.SentOn_ = &date; return m }
 
 func (m *Msg) hash() string {
 	hash := sha1.Sum([]byte(m.Text_ + "|" + strings.Join(m.Attachments_, "|")))
@@ -184,7 +184,7 @@ func (m *Msg) hash() string {
 }
 
 // WriteMsg creates a message given the passed in arguments
-func writeMsg(ctx context.Context, b *backend, msg courier.Msg, clog *courier.ChannelLog) error {
+func writeMsg(ctx context.Context, b *backend, msg courier.MsgIn, clog *courier.ChannelLog) error {
 	m := msg.(*Msg)
 
 	// this msg has already been written (we received it twice), we are a no op

--- a/channel_log.go
+++ b/channel_log.go
@@ -117,7 +117,7 @@ func NewChannelLogForIncoming(logType ChannelLogType, ch Channel, r *httpx.Recor
 }
 
 // NewChannelLogForSend creates a new channel log for a message send
-func NewChannelLogForSend(msg Msg, redactVals []string) *ChannelLog {
+func NewChannelLogForSend(msg MsgOut, redactVals []string) *ChannelLog {
 	return newChannelLog(ChannelLogTypeMsgSend, msg.Channel(), nil, true, redactVals)
 }
 

--- a/handler.go
+++ b/handler.go
@@ -30,7 +30,7 @@ type ChannelHandler interface {
 	Send(context.Context, MsgOut, *ChannelLog) (StatusUpdate, error)
 
 	WriteStatusSuccessResponse(context.Context, http.ResponseWriter, []StatusUpdate) error
-	WriteMsgSuccessResponse(context.Context, http.ResponseWriter, []Msg) error
+	WriteMsgSuccessResponse(context.Context, http.ResponseWriter, []MsgIn) error
 	WriteRequestError(context.Context, http.ResponseWriter, error) error
 	WriteRequestIgnored(context.Context, http.ResponseWriter, string) error
 }

--- a/handler.go
+++ b/handler.go
@@ -27,7 +27,7 @@ type ChannelHandler interface {
 	UseChannelRouteUUID() bool
 	RedactValues(Channel) []string
 	GetChannel(context.Context, *http.Request) (Channel, error)
-	Send(context.Context, Msg, *ChannelLog) (StatusUpdate, error)
+	Send(context.Context, MsgOut, *ChannelLog) (StatusUpdate, error)
 
 	WriteStatusSuccessResponse(context.Context, http.ResponseWriter, []StatusUpdate) error
 	WriteMsgSuccessResponse(context.Context, http.ResponseWriter, []Msg) error

--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -76,7 +76,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	msg := h.Backend().NewIncomingMsg(channel, urn, form.Text, form.ID, clog).WithReceivedOn(date)
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 type statusForm struct {

--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -114,7 +114,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w 
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	isSharedStr := msg.Channel().ConfigForKey(configIsShared, false)
 	isShared, _ := isSharedStr.(bool)
 

--- a/handlers/africastalking/handler_test.go
+++ b/handlers/africastalking/handler_test.go
@@ -111,7 +111,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/arabiacell/handler.go
+++ b/handlers/arabiacell/handler.go
@@ -56,7 +56,7 @@ type mtResponse struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for AC channel")

--- a/handlers/arabiacell/handler_test.go
+++ b/handlers/arabiacell/handler_test.go
@@ -44,7 +44,7 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -101,7 +101,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	}
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 type moStatusData struct {

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -172,7 +172,7 @@ type mtResponse struct {
 }
 
 // Send implements courier.ChannelHandler
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for BW channel")

--- a/handlers/bandwidth/handler_test.go
+++ b/handlers/bandwidth/handler_test.go
@@ -247,7 +247,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL + "?%s"
 }
 

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -104,7 +104,7 @@ func (h *BaseHandler) WriteStatusSuccessResponse(ctx context.Context, w http.Res
 }
 
 // WriteMsgSuccessResponse writes a success response for the messages
-func (h *BaseHandler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *BaseHandler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	return courier.WriteMsgSuccess(w, msgs)
 }
 

--- a/handlers/bongolive/handler.go
+++ b/handlers/bongolive/handler.go
@@ -101,11 +101,11 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	msg := h.Backend().NewIncomingMsg(channel, urn, form.Message, form.ID, clog).WithReceivedOn(time.Now().UTC())
 
 	// and finally queue our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 
 }
 
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	return writeBongoLiveResponse(w)
 }
 

--- a/handlers/bongolive/handler.go
+++ b/handlers/bongolive/handler.go
@@ -126,7 +126,7 @@ func writeBongoLiveResponse(w http.ResponseWriter) error {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for %s channel", msg.Channel().ChannelType())

--- a/handlers/bongolive/handler_test.go
+++ b/handlers/bongolive/handler_test.go
@@ -82,7 +82,7 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/burstsms/handler.go
+++ b/handlers/burstsms/handler.go
@@ -57,7 +57,7 @@ type mtResponse struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for BS channel")

--- a/handlers/burstsms/handler_test.go
+++ b/handlers/burstsms/handler_test.go
@@ -57,7 +57,7 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -131,7 +131,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	msg := h.Backend().NewIncomingMsg(channel, urn, text, payload.MessageID, clog).WithReceivedOn(date.UTC())
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // utility method to decode crazy clickatell 16 bit format

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -154,7 +154,7 @@ func decodeUTF16BE(b []byte) (string, error) {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	apiKey := msg.Channel().StringConfigForKey(courier.ConfigAPIKey, "")
 	if apiKey == "" {
 		return nil, fmt.Errorf("no api_key set for CT channel")

--- a/handlers/clickatell/handler_test.go
+++ b/handlers/clickatell/handler_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/clickmobile/handler.go
+++ b/handlers/clickmobile/handler.go
@@ -80,7 +80,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	msg := h.Backend().NewIncomingMsg(channel, urn, payload.Text, payload.ReferenceID, clog)
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 type mtPayload struct {

--- a/handlers/clickmobile/handler.go
+++ b/handlers/clickmobile/handler.go
@@ -98,7 +98,7 @@ type mtPayload struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for CM channel")

--- a/handlers/clickmobile/handler_test.go
+++ b/handlers/clickmobile/handler_test.go
@@ -143,7 +143,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	c.(*test.MockChannel).SetConfig(courier.ConfigSendURL, s.URL)
 	sendURL = s.URL
 

--- a/handlers/clicksend/handler.go
+++ b/handlers/clicksend/handler.go
@@ -61,7 +61,7 @@ type mtPayload struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("Missing 'username' config for CS channel")

--- a/handlers/clicksend/handler_test.go
+++ b/handlers/clicksend/handler_test.go
@@ -48,7 +48,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -87,7 +87,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	msg := h.Backend().NewIncomingMsg(channel, urn, form.Message, form.MessageID, clog)
 
 	// and finally queue our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 type statusForm struct {
@@ -139,7 +139,7 @@ func (h *handler) WriteStatusSuccessResponse(ctx context.Context, w http.Respons
 }
 
 // DartMedia expects "000" from a status request
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, "000")
 	return err

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -146,7 +146,7 @@ func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWr
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for %s channel", msg.Channel().ChannelType())

--- a/handlers/dart/handler_test.go
+++ b/handlers/dart/handler_test.go
@@ -94,7 +94,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	daHandler := h.(*handler)
 	daHandler.sendURL = s.URL
 }

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -290,7 +290,7 @@ func resolveMediaURL(channel courier.Channel, mediaID string, clog *courier.Chan
 }
 
 // Send implements courier.ChannelHandler
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	conn := h.Backend().RedisPool().Get()
 	defer conn.Close()
 

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -315,7 +315,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 }
 
 // setSendURL takes care of setting the base_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	c.(*test.MockChannel).SetConfig("base_url", s.URL)
 }
 

--- a/handlers/discord/handler.go
+++ b/handlers/discord/handler.go
@@ -143,7 +143,7 @@ func (h *handler) receiveStatus(ctx context.Context, statusString string, channe
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	sendURL := msg.Channel().StringConfigForKey(courier.ConfigSendURL, "")
 	if sendURL == "" {
 		return nil, fmt.Errorf("no send url set for DS channel")

--- a/handlers/discord/handler.go
+++ b/handlers/discord/handler.go
@@ -103,7 +103,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	}
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // buildStatusHandler deals with building a handler that takes what status is received in the URL

--- a/handlers/discord/handler_test.go
+++ b/handlers/discord/handler_test.go
@@ -111,7 +111,7 @@ var sendTestCases = []OutgoingTestCase{
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	// this is actually a path, which we'll combine with the test server URL
 	sendURL := c.StringConfigForKey("send_path", "/discord/rp/send")
 	sendURL, _ = utils.AddURLPath(s.URL, sendURL)

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -106,7 +106,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w 
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	// get our authentication token
 	auth := msg.Channel().StringConfigForKey(courier.ConfigAuthToken, "")
 	if auth == "" {

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -70,7 +70,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	msg := h.Backend().NewIncomingMsg(channel, urn, form.Text, "", clog).WithReceivedOn(date)
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 type statusForm struct {

--- a/handlers/dmark/handler_test.go
+++ b/handlers/dmark/handler_test.go
@@ -91,7 +91,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -216,11 +216,11 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	msg := h.Backend().NewIncomingMsg(channel, urn, text, "", clog).WithReceivedOn(date)
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // WriteMsgSuccessResponse writes our response in TWIML format
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	moResponse := msgs[0].Channel().StringConfigForKey(configMOResponse, "")
 	if moResponse == "" {
 		return courier.WriteMsgSuccess(w, msgs)

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -271,7 +271,7 @@ func (h *handler) receiveStatus(ctx context.Context, statusString string, channe
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	channel := msg.Channel()
 
 	sendURL := channel.StringConfigForKey(courier.ConfigSendURL, "")

--- a/handlers/external/handler_test.go
+++ b/handlers/external/handler_test.go
@@ -280,7 +280,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	// this is actually a path, which we'll combine with the test server URL
 	sendURL := c.StringConfigForKey("send_path", "")
 	sendURL, _ = utils.AddURLPath(s.URL, sendURL)

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -471,7 +471,7 @@ type mtQuickReply struct {
 	ContentType string `json:"content_type"`
 }
 
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	// can't do anything without an access token
 	accessToken := msg.Channel().StringConfigForKey(courier.ConfigAuthToken, "")
 	if accessToken == "" {

--- a/handlers/facebook_legacy/handler_test.go
+++ b/handlers/facebook_legacy/handler_test.go
@@ -728,7 +728,7 @@ func TestVerify(t *testing.T) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -140,7 +140,7 @@ type mtNotification struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	title := msg.Channel().StringConfigForKey(configTitle, "")
 	if title == "" {
 		return nil, fmt.Errorf("no FCM_TITLE set for FCM channel")

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -84,7 +84,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	dbMsg := h.Backend().NewIncomingMsg(channel, urn, form.Msg, "", clog).WithReceivedOn(date).WithContactName(form.Name).WithURNAuthTokens(authTokens)
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{dbMsg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{dbMsg}, w, r, clog)
 }
 
 type registerForm struct {

--- a/handlers/firebase/handler_test.go
+++ b/handlers/firebase/handler_test.go
@@ -96,7 +96,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the base_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/freshchat/handler.go
+++ b/handlers/freshchat/handler.go
@@ -93,7 +93,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		msg.WithAttachment(mediaURL)
 	}
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {

--- a/handlers/freshchat/handler.go
+++ b/handlers/freshchat/handler.go
@@ -96,7 +96,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
 }
 
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 
 	agentID := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if agentID == "" {

--- a/handlers/freshchat/handler_test.go
+++ b/handlers/freshchat/handler_test.go
@@ -82,7 +82,7 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler("FC", "FreshChat", false), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	apiURL = s.URL
 }
 

--- a/handlers/generic.go
+++ b/handlers/generic.go
@@ -29,7 +29,7 @@ func NewTelReceiveHandler(h courier.ChannelHandler, fromField string, bodyField 
 		}
 		// build our msg
 		msg := h.Server().Backend().NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(time.Now().UTC())
-		return WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+		return WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 	}
 }
 

--- a/handlers/globe/handler.go
+++ b/handlers/globe/handler.go
@@ -78,7 +78,7 @@ func (h *handler) receiveMessage(ctx context.Context, c courier.Channel, w http.
 		return nil, handlers.WriteAndLogRequestIgnored(ctx, h, c, w, r, "no messages, ignored")
 	}
 
-	msgs := make([]courier.Msg, 0, 1)
+	msgs := make([]courier.MsgIn, 0, 1)
 
 	// parse each inbound message
 	for _, glMsg := range payload.InboundSMSMessageList.InboundSMSMessage {

--- a/handlers/globe/handler.go
+++ b/handlers/globe/handler.go
@@ -120,7 +120,7 @@ type mtPayload struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	appID := msg.Channel().StringConfigForKey(configAppID, "")
 	if appID == "" {
 		return nil, fmt.Errorf("Missing 'app_id' config for GL channel")

--- a/handlers/globe/handler_test.go
+++ b/handlers/globe/handler_test.go
@@ -166,7 +166,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL + "?%s"
 }
 

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -122,7 +122,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w 
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for HX channel")

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -83,7 +83,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	msg := h.Backend().NewIncomingMsg(channel, urn, text, msgID, clog).WithReceivedOn(date.UTC())
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 type statusForm struct {

--- a/handlers/highconnection/handler_test.go
+++ b/handlers/highconnection/handler_test.go
@@ -87,7 +87,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSend takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/hormuud/handler.go
+++ b/handlers/hormuud/handler.go
@@ -63,7 +63,7 @@ func (h *handler) receiveMessage(ctx context.Context, c courier.Channel, w http.
 	}
 
 	msg := h.Backend().NewIncomingMsg(c, urn, payload.MessageText, "", clog)
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 type mtPayload struct {
@@ -129,7 +129,7 @@ type tokenResponse struct {
 }
 
 // FetchToken gets the current token for this channel, either from Redis if cached or by requesting it
-func (h *handler) FetchToken(ctx context.Context, channel courier.Channel, msg courier.Msg, clog *courier.ChannelLog) (string, error) {
+func (h *handler) FetchToken(ctx context.Context, channel courier.Channel, msg courier.MsgOut, clog *courier.ChannelLog) (string, error) {
 	// first check whether we have it in redis
 	conn := h.Backend().RedisPool().Get()
 	token, err := redis.String(conn.Do("GET", fmt.Sprintf("hm_token_%s", channel.UUID())))

--- a/handlers/hormuud/handler.go
+++ b/handlers/hormuud/handler.go
@@ -76,7 +76,7 @@ type mtPayload struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	status := h.Backend().NewStatusUpdate(msg.Channel(), msg.ID(), courier.MsgStatusErrored, clog)
 
 	token, err := h.FetchToken(ctx, msg.Channel(), msg, clog)

--- a/handlers/hormuud/handler_test.go
+++ b/handlers/hormuud/handler_test.go
@@ -67,7 +67,7 @@ func TestIncoming(t *testing.T) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/i2sms/handler.go
+++ b/handlers/i2sms/handler.go
@@ -84,7 +84,7 @@ type mtResponse struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for I2 channel")

--- a/handlers/i2sms/handler.go
+++ b/handlers/i2sms/handler.go
@@ -63,7 +63,7 @@ func (h *handler) receive(ctx context.Context, c courier.Channel, w http.Respons
 
 	// build our msg
 	msg := h.Backend().NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(time.Now().UTC())
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 //	{
@@ -152,7 +152,7 @@ func (h *handler) RedactValues(ch courier.Channel) []string {
 }
 
 // WriteMsgSuccessResponse writes a success response for the messages, i2SMS expects an empty body in our response
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	w.Header().Add("Content-type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write([]byte{})

--- a/handlers/i2sms/handler_test.go
+++ b/handlers/i2sms/handler_test.go
@@ -45,7 +45,7 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -159,7 +159,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for IB channel")

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -120,7 +120,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		return nil, handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, "ignoring request, no message")
 	}
 
-	msgs := []courier.Msg{}
+	msgs := []courier.MsgIn{}
 	for _, infobipMessage := range payload.Results {
 		messageID := infobipMessage.MessageID
 		text := infobipMessage.Text

--- a/handlers/infobip/handler_test.go
+++ b/handlers/infobip/handler_test.go
@@ -298,7 +298,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSend takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -119,7 +119,7 @@ func writeJasminACK(w http.ResponseWriter) error {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for JS channel")

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -97,10 +97,10 @@ func (h *handler) receiveMessage(ctx context.Context, c courier.Channel, w http.
 	msg := h.Backend().NewIncomingMsg(c, urn, text, form.ID, clog).WithReceivedOn(time.Now().UTC())
 
 	// and finally queue our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	return writeJasminACK(w)
 }
 

--- a/handlers/jasmin/handler_test.go
+++ b/handlers/jasmin/handler_test.go
@@ -85,7 +85,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	c.(*test.MockChannel).SetConfig("send_url", s.URL)
 }
 

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -163,7 +163,7 @@ type mtPayload struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	accessToken, err := h.getAccessToken(ctx, msg.Channel(), clog)
 	if err != nil {
 		return nil, err

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -145,7 +145,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	}
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 func buildMediaURL(mediaID string) string {

--- a/handlers/jiochat/handler_test.go
+++ b/handlers/jiochat/handler_test.go
@@ -345,7 +345,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 }
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -153,7 +153,7 @@ type mtPayload struct {
 }
 
 // Send implements courier.ChannelHandler
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	apiKey := msg.Channel().StringConfigForKey(courier.ConfigAPIKey, "")
 	if apiKey == "" {
 		return nil, fmt.Errorf("no API key set for JCL channel")

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -121,7 +121,7 @@ func (h *handler) receiveMessage(ctx context.Context, c courier.Channel, w http.
 	}
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 var statusMapping = map[string]courier.MsgStatus{

--- a/handlers/justcall/handler_test.go
+++ b/handlers/justcall/handler_test.go
@@ -268,7 +268,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSend takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -135,7 +135,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w 
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	accountSID := msg.Channel().StringConfigForKey(configAccountSID, "")
 	apiKey := msg.Channel().StringConfigForKey(configApiKey, "")
 

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -100,7 +100,7 @@ func (h *handler) receiveMsg(ctx context.Context, channel courier.Channel, w htt
 	}
 
 	// write msg
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 var statusMapping = map[string]courier.MsgStatus{

--- a/handlers/kaleyra/handler_test.go
+++ b/handlers/kaleyra/handler_test.go
@@ -109,7 +109,7 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	baseURL = s.URL
 }
 

--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -118,7 +118,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w 
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for KN channel")

--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -77,7 +77,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	msg := h.Backend().NewIncomingMsg(channel, urn, form.Message, form.ID, clog).WithReceivedOn(date)
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 var statusMapping = map[int]courier.MsgStatus{

--- a/handlers/kannel/handler_test.go
+++ b/handlers/kannel/handler_test.go
@@ -129,12 +129,12 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	c.(*test.MockChannel).SetConfig("send_url", s.URL)
 }
 
 // setSendURLWithQuery takes care of setting the send_url to our test server host
-func setSendURLWithQuery(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURLWithQuery(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	c.(*test.MockChannel).SetConfig("send_url", s.URL+"?auth=foo")
 }
 

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -283,7 +283,7 @@ type mtResponse struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	authToken := msg.Channel().StringConfigForKey(courier.ConfigAuthToken, "")
 	if authToken == "" {
 		return nil, fmt.Errorf("no auth token set for LN channel: %s", msg.Channel().UUID())

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -116,7 +116,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		return nil, err
 	}
 
-	msgs := []courier.Msg{}
+	msgs := []courier.MsgIn{}
 
 	for _, lineEvent := range payload.Events {
 		if lineEvent.ReplyToken == "" || (lineEvent.Source.Type == "" && lineEvent.Source.UserID == "") || (lineEvent.Message.Type == "" && lineEvent.Message.ID == "") {

--- a/handlers/line/handler_test.go
+++ b/handlers/line/handler_test.go
@@ -392,7 +392,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	replySendURL = s.URL + "/v2/bot/message/reply"
 	pushSendURL = s.URL + "/v2/bot/message/push"
 }

--- a/handlers/m3tech/handler.go
+++ b/handlers/m3tech/handler.go
@@ -69,7 +69,7 @@ func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWr
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for M3 channel")

--- a/handlers/m3tech/handler.go
+++ b/handlers/m3tech/handler.go
@@ -58,11 +58,11 @@ func (h *handler) receiveMessage(ctx context.Context, c courier.Channel, w http.
 
 	// create and write the message
 	msg := h.Backend().NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(time.Now().UTC())
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // WriteMsgSuccessResponse writes a success response for the messages
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	w.Header().Set("Content-Type", "application/json")
 	_, err := fmt.Fprintf(w, "SMS Accepted: %d", msgs[0].ID())
 	return err

--- a/handlers/m3tech/handler_test.go
+++ b/handlers/m3tech/handler_test.go
@@ -48,7 +48,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/macrokiosk/handler.go
+++ b/handlers/macrokiosk/handler.go
@@ -150,7 +150,7 @@ type mtPayload struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	password := msg.Channel().StringConfigForKey(courier.ConfigPassword, "")
 	servID := msg.Channel().StringConfigForKey(configMacrokioskServiceID, "")

--- a/handlers/macrokiosk/handler.go
+++ b/handlers/macrokiosk/handler.go
@@ -129,11 +129,11 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 
 	// create and write the message
 	msg := h.Backend().NewIncomingMsg(channel, urn, form.Text, form.MsgID, clog).WithReceivedOn(date.UTC())
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // WriteMsgSuccessResponse
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, "-1") // MacroKiosk expects "-1" back for successful requests
 	return err

--- a/handlers/macrokiosk/handler_test.go
+++ b/handlers/macrokiosk/handler_test.go
@@ -73,7 +73,7 @@ func TestIncoming(t *testing.T) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/mblox/handler.go
+++ b/handlers/mblox/handler.go
@@ -99,7 +99,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 		msg := h.Backend().NewIncomingMsg(channel, urn, payload.Body, payload.ID, clog).WithReceivedOn(date.UTC())
 
 		// and finally write our message
-		return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+		return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 	}
 
 	return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, fmt.Errorf("not handled, unknown type: %s", payload.Type))

--- a/handlers/mblox/handler.go
+++ b/handlers/mblox/handler.go
@@ -113,7 +113,7 @@ type mtPayload struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	password := msg.Channel().StringConfigForKey(courier.ConfigPassword, "")
 	if username == "" || password == "" {

--- a/handlers/mblox/handler_test.go
+++ b/handlers/mblox/handler_test.go
@@ -90,7 +90,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -181,7 +181,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		}
 	}
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -184,7 +184,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
 }
 
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 
 	authToken := msg.Channel().StringConfigForKey(courier.ConfigAuthToken, "")
 	if authToken == "" {

--- a/handlers/messagebird/handler_test.go
+++ b/handlers/messagebird/handler_test.go
@@ -187,11 +187,11 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler("MBD", "Messagebird", true), defaultReceiveTestCases)
 }
 
-func setSmsSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSmsSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	smsURL = s.URL
 }
 
-func setMmsSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setMmsSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	mmsURL = s.URL
 }
 

--- a/handlers/messangi/handler.go
+++ b/handlers/messangi/handler.go
@@ -60,7 +60,7 @@ type mtResponse struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	publicKey := msg.Channel().StringConfigForKey(configPublicKey, "")
 	if publicKey == "" {
 		return nil, fmt.Errorf("no public_key set for MG channel")

--- a/handlers/messangi/handler_test.go
+++ b/handlers/messangi/handler_test.go
@@ -42,7 +42,7 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/meta/facebook_test.go
+++ b/handlers/meta/facebook_test.go
@@ -336,7 +336,7 @@ func TestFacebookVerify(t *testing.T) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 	graphURL = s.URL
 }

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -632,7 +632,7 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel c
 	return events, data, nil
 }
 
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	if msg.Channel().ChannelType() == "FBA" || msg.Channel().ChannelType() == "IG" {
 		return h.sendFacebookInstagramMsg(ctx, msg, clog)
 	} else if msg.Channel().ChannelType() == "WAC" {
@@ -642,7 +642,7 @@ func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.Chann
 	return nil, fmt.Errorf("unssuported channel type")
 }
 
-func (h *handler) sendFacebookInstagramMsg(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) sendFacebookInstagramMsg(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	// can't do anything without an access token
 	accessToken := msg.Channel().StringConfigForKey(courier.ConfigAuthToken, "")
 	if accessToken == "" {
@@ -798,7 +798,7 @@ func (h *handler) sendFacebookInstagramMsg(ctx context.Context, msg courier.Msg,
 	return status, nil
 }
 
-func (h *handler) sendWhatsAppMsg(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) sendWhatsAppMsg(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	// can't do anything without an access token
 	accessToken := h.Server().Config().WhatsappAdminSystemUserToken
 

--- a/handlers/meta/whatsapp/templates.go
+++ b/handlers/meta/whatsapp/templates.go
@@ -17,7 +17,7 @@ type MsgTemplating struct {
 	Variables []string `json:"variables"`
 }
 
-func GetTemplating(msg courier.Msg) (*MsgTemplating, error) {
+func GetTemplating(msg courier.MsgOut) (*MsgTemplating, error) {
 	if len(msg.Metadata()) == 0 {
 		return nil, nil
 	}

--- a/handlers/mtarget/handler.go
+++ b/handlers/mtarget/handler.go
@@ -144,7 +144,7 @@ func (h *handler) receiveMsg(ctx context.Context, c courier.Channel, w http.Resp
 
 	// otherwise, create and write the message
 	msg := h.Backend().NewIncomingMsg(c, urn, text, msgID, clog).WithReceivedOn(time.Now().UTC())
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // Send sends the given message, logging any HTTP calls or errors

--- a/handlers/mtarget/handler.go
+++ b/handlers/mtarget/handler.go
@@ -148,7 +148,7 @@ func (h *handler) receiveMsg(ctx context.Context, c courier.Channel, w http.Resp
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for MT channel")

--- a/handlers/mtarget/handler_test.go
+++ b/handlers/mtarget/handler_test.go
@@ -83,7 +83,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/mtn/handler.go
+++ b/handlers/mtn/handler.go
@@ -87,7 +87,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 
 		// create and write the message
 		msg := h.Backend().NewIncomingMsg(channel, urn, payload.Message, "", clog).WithReceivedOn(date)
-		return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+		return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 
 	} else {
 		clog.SetType(courier.ChannelLogTypeMsgStatus)

--- a/handlers/mtn/handler.go
+++ b/handlers/mtn/handler.go
@@ -121,7 +121,7 @@ type mtPayload struct {
 }
 
 // Send implements courier.ChannelHandler
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	accessToken, err := h.getAccessToken(ctx, msg.Channel(), clog)
 	if err != nil {
 		return nil, err

--- a/handlers/mtn/handler_test.go
+++ b/handlers/mtn/handler_test.go
@@ -159,7 +159,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	apiHostURL = s.URL
 }
 

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -166,7 +166,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 
 	// create and write the message
 	msg := h.Backend().NewIncomingMsg(channel, urn, form.Text, form.MessageID, clog)
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // Send sends the given message, logging any HTTP calls or errors

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -170,7 +170,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	nexmoAPIKey := msg.Channel().StringConfigForKey(configNexmoAPIKey, "")
 	if nexmoAPIKey == "" {
 		return nil, fmt.Errorf("no nexmo API key set for NX channel")

--- a/handlers/nexmo/handler_test.go
+++ b/handlers/nexmo/handler_test.go
@@ -119,7 +119,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/novo/handler.go
+++ b/handlers/novo/handler.go
@@ -74,7 +74,7 @@ func (h *handler) receiveMessage(ctx context.Context, c courier.Channel, w http.
 
 	// create and write the message
 	msg := h.Backend().NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(time.Now().UTC())
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // Send sends the given message, logging any HTTP calls or errors

--- a/handlers/novo/handler.go
+++ b/handlers/novo/handler.go
@@ -78,7 +78,7 @@ func (h *handler) receiveMessage(ctx context.Context, c courier.Channel, w http.
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	merchantID := msg.Channel().StringConfigForKey(configMerchantId, "")
 	if merchantID == "" {
 		return nil, fmt.Errorf("no merchant_id set for NV channel")

--- a/handlers/novo/handler_test.go
+++ b/handlers/novo/handler_test.go
@@ -57,7 +57,7 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL + "?%s"
 }
 

--- a/handlers/playmobile/handler.go
+++ b/handlers/playmobile/handler.go
@@ -146,7 +146,7 @@ func (h *handler) receiveMessage(ctx context.Context, c courier.Channel, w http.
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(configUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for PM channel")

--- a/handlers/playmobile/handler.go
+++ b/handlers/playmobile/handler.go
@@ -105,7 +105,7 @@ func (h *handler) receiveMessage(ctx context.Context, c courier.Channel, w http.
 		return nil, handlers.WriteAndLogRequestIgnored(ctx, h, c, w, r, "no messages, ignored")
 	}
 
-	msgs := make([]courier.Msg, 0, 1)
+	msgs := make([]courier.MsgIn, 0, 1)
 
 	// parse each inbound message
 	for _, pmMsg := range payload.Message {

--- a/handlers/playmobile/handler_test.go
+++ b/handlers/playmobile/handler_test.go
@@ -128,7 +128,7 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL + "?%s"
 }
 

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -124,7 +124,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 
 	// create and write the message
 	msg := h.Backend().NewIncomingMsg(channel, urn, form.Text, form.MessageUUID, clog)
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 type mtPayload struct {

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -136,7 +136,7 @@ type mtPayload struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	authID := msg.Channel().StringConfigForKey(configPlivoAuthID, "")
 	authToken := msg.Channel().StringConfigForKey(configPlivoAuthToken, "")
 	plivoAppID := msg.Channel().StringConfigForKey(configPlivoAPPID, "")

--- a/handlers/plivo/handler_test.go
+++ b/handlers/plivo/handler_test.go
@@ -69,7 +69,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL + "/%s/"
 }
 

--- a/handlers/redrabbit/handler.go
+++ b/handlers/redrabbit/handler.go
@@ -36,7 +36,7 @@ func (h *handler) Initialize(s courier.Server) error {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	password := msg.Channel().StringConfigForKey(courier.ConfigPassword, "")
 	if username == "" || password == "" {

--- a/handlers/redrabbit/handler_test.go
+++ b/handlers/redrabbit/handler_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/responses.go
+++ b/handlers/responses.go
@@ -8,7 +8,7 @@ import (
 )
 
 // WriteMsgsAndResponse writes the passed in message to our backend
-func WriteMsgsAndResponse(ctx context.Context, h courier.ChannelHandler, msgs []courier.Msg, w http.ResponseWriter, r *http.Request, clog *courier.ChannelLog) ([]courier.Event, error) {
+func WriteMsgsAndResponse(ctx context.Context, h courier.ChannelHandler, msgs []courier.MsgIn, w http.ResponseWriter, r *http.Request, clog *courier.ChannelLog) ([]courier.Event, error) {
 	events := make([]courier.Event, len(msgs))
 	for i, m := range msgs {
 		err := h.Server().Backend().WriteMsg(ctx, m, clog)

--- a/handlers/rocketchat/handler.go
+++ b/handlers/rocketchat/handler.go
@@ -79,7 +79,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		msg.WithAttachment(attachment.URL)
 	}
 
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // BuildAttachmentRequest download media for message attachment with RC auth_token/user_id set

--- a/handlers/rocketchat/handler.go
+++ b/handlers/rocketchat/handler.go
@@ -105,7 +105,7 @@ type mtPayload struct {
 	Attachments []Attachment `json:"attachments,omitempty"`
 }
 
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	baseURL := msg.Channel().StringConfigForKey(configBaseURL, "")
 	secret := msg.Channel().StringConfigForKey(configSecret, "")
 	botUsername := msg.Channel().StringConfigForKey(configBotUsername, "")

--- a/handlers/rocketchat/handler_test.go
+++ b/handlers/rocketchat/handler_test.go
@@ -104,7 +104,7 @@ func BenchmarkHandler(b *testing.B) {
 	handlers.RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	c.(*test.MockChannel).SetConfig(configBaseURL, s.URL)
 }
 

--- a/handlers/shaqodoon/handler.go
+++ b/handlers/shaqodoon/handler.go
@@ -83,7 +83,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	sendURL := msg.Channel().StringConfigForKey(courier.ConfigSendURL, "")
 	if sendURL == "" {
 		return nil, fmt.Errorf("missing send_url for SQ channel")

--- a/handlers/shaqodoon/handler.go
+++ b/handlers/shaqodoon/handler.go
@@ -79,7 +79,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 
 	// create and write the message
 	msg := h.Backend().NewIncomingMsg(channel, urn, form.Text, "", clog).WithReceivedOn(date)
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // Send sends the given message, logging any HTTP calls or errors

--- a/handlers/shaqodoon/handler_test.go
+++ b/handlers/shaqodoon/handler_test.go
@@ -51,7 +51,7 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), handleTestCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	c.(*test.MockChannel).SetConfig(courier.ConfigSendURL, s.URL)
 }
 

--- a/handlers/slack/handler.go
+++ b/handlers/slack/handler.go
@@ -181,7 +181,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.Ch
 	return status, nil
 }
 
-func sendTextMsgPart(msg courier.Msg, token string, clog *courier.ChannelLog) error {
+func sendTextMsgPart(msg courier.MsgOut, token string, clog *courier.ChannelLog) error {
 	sendURL := apiURL + "/chat.postMessage"
 
 	msgPayload := &mtPayload{
@@ -221,7 +221,7 @@ func sendTextMsgPart(msg courier.Msg, token string, clog *courier.ChannelLog) er
 	return nil
 }
 
-func parseAttachmentToFileParams(msg courier.Msg, attachment string, clog *courier.ChannelLog) (*FileParams, error) {
+func parseAttachmentToFileParams(msg courier.MsgOut, attachment string, clog *courier.ChannelLog) (*FileParams, error) {
 	_, attURL := handlers.SplitAttachment(attachment)
 
 	req, err := http.NewRequest(http.MethodGet, attURL, nil)
@@ -241,7 +241,7 @@ func parseAttachmentToFileParams(msg courier.Msg, attachment string, clog *couri
 	return &FileParams{File: respBody, FileName: filename, Channels: msg.URN().Path()}, nil
 }
 
-func sendFilePart(msg courier.Msg, token string, fileParams *FileParams, clog *courier.ChannelLog) error {
+func sendFilePart(msg courier.MsgOut, token string, fileParams *FileParams, clog *courier.ChannelLog) error {
 	uploadURL := apiURL + "/files.upload"
 
 	body := &bytes.Buffer{}

--- a/handlers/slack/handler.go
+++ b/handlers/slack/handler.go
@@ -145,7 +145,7 @@ func (h *handler) resolveFile(ctx context.Context, channel courier.Channel, file
 	return filePath, nil
 }
 
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	botToken := msg.Channel().StringConfigForKey(configBotToken, "")
 	if botToken == "" {
 		return nil, fmt.Errorf("missing bot token for SL/slack channel")

--- a/handlers/slack/handler.go
+++ b/handlers/slack/handler.go
@@ -97,7 +97,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 			msg.WithAttachment(attURL)
 		}
 
-		return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+		return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 	}
 	return nil, handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, "Ignoring request, no message")
 }

--- a/handlers/slack/handler_test.go
+++ b/handlers/slack/handler_test.go
@@ -124,7 +124,7 @@ const videoFileMsg = `{
 	"event_time": 1653427243
 }`
 
-func setSendUrl(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	apiURL = s.URL
 }
 
@@ -186,7 +186,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		MockResponseStatus:  200,
 		ExpectedRequestBody: `{"channel":"U0123ABCDEF","text":"Simple Message"}`,
 		ExpectedMsgStatus:   "W",
-		SendPrep:            setSendUrl,
+		SendPrep:            setSendURL,
 	},
 	{
 		Label:               "Unicode Send",
@@ -196,7 +196,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		MockResponseStatus:  200,
 		ExpectedRequestBody: `{"channel":"U0123ABCDEF","text":"☺"}`,
 		ExpectedMsgStatus:   "W",
-		SendPrep:            setSendUrl,
+		SendPrep:            setSendURL,
 	},
 	{
 		Label:               "Send Text Auth Error",
@@ -207,7 +207,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedRequestBody: `{"channel":"U0123ABCDEF","text":"Hello"}`,
 		ExpectedMsgStatus:   "E",
 		ExpectedErrors:      []*courier.ChannelError{courier.NewChannelError("", "", "invalid_auth")},
-		SendPrep:            setSendUrl,
+		SendPrep:            setSendURL,
 	},
 }
 
@@ -225,7 +225,7 @@ var fileSendTestCases = []OutgoingTestCase{
 			}: httpx.NewMockResponse(200, nil, []byte(`{"ok":true,"file":{"id":"F1L3SL4CK1D"}}`)),
 		},
 		ExpectedMsgStatus: "W",
-		SendPrep:          setSendUrl,
+		SendPrep:          setSendURL,
 	},
 	{
 		Label:          "Send Image",
@@ -240,7 +240,7 @@ var fileSendTestCases = []OutgoingTestCase{
 			}: httpx.NewMockResponse(200, nil, []byte(`{"ok":true,"file":{"id":"F1L3SL4CK1D"}}`)),
 		},
 		ExpectedMsgStatus: "W",
-		SendPrep:          setSendUrl,
+		SendPrep:          setSendURL,
 	},
 }
 

--- a/handlers/smscentral/handler.go
+++ b/handlers/smscentral/handler.go
@@ -59,7 +59,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	// build our msg
 	msg := h.Backend().NewIncomingMsg(channel, urn, form.Message, "", clog)
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // Send sends the given message, logging any HTTP calls or errors

--- a/handlers/smscentral/handler.go
+++ b/handlers/smscentral/handler.go
@@ -63,7 +63,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for SC channel")

--- a/handlers/smscentral/handler_test.go
+++ b/handlers/smscentral/handler_test.go
@@ -68,7 +68,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSend takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -85,11 +85,11 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	msg := h.Backend().NewIncomingMsg(channel, urn, payload.Body.Text, payload.Service.RequestID, clog).WithReceivedOn(date)
 
 	// and write it
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // Start Mobile expects a XML response from a message receive request
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	w.Header().Set("Content-Type", "text/xml")
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, `<answer type="async"><state>Accepted</state></answer>`)

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -121,7 +121,7 @@ type mtResponse struct {
 	State   string   `xml:"state"`
 }
 
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for ST channel: %s", msg.Channel().UUID())

--- a/handlers/start/handler_test.go
+++ b/handlers/start/handler_test.go
@@ -160,7 +160,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -178,7 +178,7 @@ func (h *handler) sendMsgPart(msg courier.Msg, token string, path string, form u
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	confAuth := msg.Channel().ConfigForKey(courier.ConfigAuthToken, "")
 	authToken, isStr := confAuth.(string)
 	if !isStr || authToken == "" {

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -130,7 +130,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		msg.WithAttachment(mediaURL)
 	}
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 type mtResponse struct {

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -142,7 +142,7 @@ type mtResponse struct {
 	} `json:"result"`
 }
 
-func (h *handler) sendMsgPart(msg courier.Msg, token string, path string, form url.Values, keyboard *ReplyKeyboardMarkup, clog *courier.ChannelLog) (string, bool, error) {
+func (h *handler) sendMsgPart(msg courier.MsgOut, token string, path string, form url.Values, keyboard *ReplyKeyboardMarkup, clog *courier.ChannelLog) (string, bool, error) {
 	// either include or remove our keyboard
 	if keyboard == nil {
 		form.Add("reply_markup", `{"remove_keyboard":true}`)

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -783,7 +783,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	apiURL = s.URL
 }
 

--- a/handlers/telesom/handler.go
+++ b/handlers/telesom/handler.go
@@ -60,7 +60,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	dbMsg := h.Backend().NewIncomingMsg(channel, urn, form.Message, "", clog)
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{dbMsg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{dbMsg}, w, r, clog)
 
 }
 

--- a/handlers/telesom/handler.go
+++ b/handlers/telesom/handler.go
@@ -65,7 +65,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for TS channel")

--- a/handlers/telesom/handler_test.go
+++ b/handlers/telesom/handler_test.go
@@ -83,7 +83,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	c.(*test.MockChannel).SetConfig(courier.ConfigSendURL, s.URL)
 	sendURL = s.URL
 

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -266,7 +266,7 @@ func RunIncomingTestCases(t *testing.T, channels []courier.Channel, handler cour
 }
 
 // SendPrepFunc allows test cases to modify the channel, msg or server before a message is sent
-type SendPrepFunc func(*httptest.Server, courier.ChannelHandler, courier.Channel, courier.Msg)
+type SendPrepFunc func(*httptest.Server, courier.ChannelHandler, courier.Channel, courier.MsgOut)
 
 // OutgoingTestCase defines the test values for a particular test case
 type OutgoingTestCase struct {

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -70,7 +70,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
 	}
 
-	var msg courier.Msg
+	var msg courier.MsgIn
 
 	if form.Type == "sms" {
 		msg = h.Backend().NewIncomingMsg(channel, urn, form.Message, "", clog)
@@ -83,7 +83,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	} else {
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, fmt.Errorf("unknown message type: %s", form.Type))
 	}
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // guid: thinQ guid returned when an outbound message is sent via our API

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -135,7 +135,7 @@ type mtMessage struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	accountID := msg.Channel().StringConfigForKey(configAccountID, "")
 	if accountID == "" {
 		return nil, fmt.Errorf("no account id set for TQ channel")

--- a/handlers/thinq/handler_test.go
+++ b/handlers/thinq/handler_test.go
@@ -91,7 +91,7 @@ func TestIncoming(t *testing.T) {
 	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL + "?account_id=%s"
 	sendMMSURL = s.URL + "?account_id=%s"
 }

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -214,7 +214,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w 
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	// build our callback URL
 	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
 	callbackURL := fmt.Sprintf("https://%s/c/%s/%s/status?id=%d&action=callback", callbackDomain, strings.ToLower(string(h.ChannelType())), msg.Channel().UUID(), msg.ID())

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -148,7 +148,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		mediaURL := r.PostForm.Get(fmt.Sprintf("MediaUrl%d", i))
 		msg.WithAttachment(mediaURL)
 	}
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // receiveStatus is our HTTP handler function for status updates
@@ -454,7 +454,7 @@ func twCalculateSignature(url string, form url.Values, authToken string) ([]byte
 }
 
 // WriteMsgSuccessResponse writes our response in TWIML format
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	w.Header().Set("Content-Type", "text/xml")
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><Response/>`)

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -544,7 +544,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	if c.ChannelType() == courier.ChannelType("TW") || c.ChannelType() == courier.ChannelType("SW") {
 		c.(*test.MockChannel).SetConfig("send_url", s.URL)
 	} else {

--- a/handlers/twitter/handler.go
+++ b/handlers/twitter/handler.go
@@ -248,7 +248,7 @@ type mtAttachment struct {
 	} `json:"media"`
 }
 
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	apiKey := msg.Channel().StringConfigForKey(configAPIKey, "")
 	apiSecret := msg.Channel().StringConfigForKey(configAPISecret, "")
 	accessToken := msg.Channel().StringConfigForKey(configAccessToken, "")

--- a/handlers/twitter/handler.go
+++ b/handlers/twitter/handler.go
@@ -146,7 +146,7 @@ func (h *handler) receiveEvents(ctx context.Context, c courier.Channel, w http.R
 	}
 
 	// the list of messages we read
-	msgs := make([]courier.Msg, 0, 2)
+	msgs := make([]courier.MsgIn, 0, 2)
 
 	// for each entry
 	for _, entry := range payload.DirectMessageEvents {

--- a/handlers/twitter/handler.go
+++ b/handlers/twitter/handler.go
@@ -363,7 +363,7 @@ func generateSignature(secret string, content string) string {
 	return base64.StdEncoding.EncodeToString(h.Sum(nil))
 }
 
-func uploadMediaToTwitter(msg courier.Msg, mediaUrl string, attachmentMimeType string, attachmentURL string, client *http.Client, clog *courier.ChannelLog) (string, error) {
+func uploadMediaToTwitter(msg courier.MsgOut, mediaUrl string, attachmentMimeType string, attachmentURL string, client *http.Client, clog *courier.ChannelLog) (string, error) {
 	// retrieve the media to be sent from S3
 	req, _ := http.NewRequest(http.MethodGet, attachmentURL, nil)
 

--- a/handlers/twitter/handler_test.go
+++ b/handlers/twitter/handler_test.go
@@ -189,7 +189,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendDomain = s.URL
 	uploadDomain = s.URL
 }

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -18,7 +18,7 @@ var (
 )
 
 // GetTextAndAttachments returns both the text of our message as well as any attachments, newline delimited
-func GetTextAndAttachments(m courier.Msg) string {
+func GetTextAndAttachments(m courier.MsgOut) string {
 	buf := bytes.NewBuffer([]byte(m.Text()))
 	for _, a := range m.Attachments() {
 		_, url := SplitAttachment(a)

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -267,7 +267,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel courier.Channel, w h
 			msg.WithAttachment(mediaURL)
 		}
 		// and finally write our message
-		return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+		return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 	}
 
 	return nil, courier.WriteError(w, http.StatusBadRequest, fmt.Errorf("not handled, unknown event: %s", event))

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -349,7 +349,7 @@ type mtResponse struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	authToken := msg.Channel().StringConfigForKey(courier.ConfigAuthToken, "")
 	if authToken == "" {
 		return nil, fmt.Errorf("missing auth token in config")

--- a/handlers/viber/handler_test.go
+++ b/handlers/viber/handler_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // setSend takes care of setting the sendURL to call
-func setSendURL(server *httptest.Server, h courier.ChannelHandler, channel courier.Channel, msg courier.Msg) {
+func setSendURL(server *httptest.Server, h courier.ChannelHandler, channel courier.Channel, msg courier.MsgOut) {
 	sendURL = server.URL
 }
 

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -416,7 +416,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.Ch
 }
 
 // buildTextAndAttachmentParams builds msg text with attachment links (if needed) and attachments list param, also returns the errors that occurred
-func buildTextAndAttachmentParams(msg courier.Msg, clog *courier.ChannelLog) (string, string) {
+func buildTextAndAttachmentParams(msg courier.MsgOut, clog *courier.ChannelLog) (string, string) {
 	var msgAttachments []string
 
 	textBuf := bytes.Buffer{}

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -374,7 +374,7 @@ func takeFirstAttachmentUrl(payload moNewMessagePayload) string {
 	return ""
 }
 
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	status := h.Backend().NewStatusUpdate(msg.Channel(), msg.ID(), courier.MsgStatusErrored, clog)
 
 	params := buildApiBaseParams(msg.Channel())

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -381,7 +381,7 @@ func TestDescribeURN(t *testing.T) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	apiBaseURL = s.URL
 	URLPhotoUploadServer = s.URL + "/upload/photo"
 }

--- a/handlers/wavy/handler.go
+++ b/handlers/wavy/handler.go
@@ -110,7 +110,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	msg := h.Backend().NewIncomingMsg(channel, urn, payload.Message, payload.ID, clog).WithReceivedOn(date.UTC())
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 
 }
 

--- a/handlers/wavy/handler.go
+++ b/handlers/wavy/handler.go
@@ -120,7 +120,7 @@ type mtPayload struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for %s channel", msg.Channel().ChannelType())

--- a/handlers/wavy/handler_test.go
+++ b/handlers/wavy/handler_test.go
@@ -168,7 +168,7 @@ func BenchmarkHandler(b *testing.B) {
 	RunChannelBenchmarks(b, testChannels, newHandler(), testCases)
 }
 
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -152,11 +152,11 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	}
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
 // WriteMsgSuccessResponse writes our response
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, "") // WeChat expected empty string to not retry looking for passive reply
 	return err

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -177,7 +177,7 @@ type mtPayload struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	accessToken, err := h.getAccessToken(ctx, msg.Channel(), clog)
 	if err != nil {
 		return nil, err

--- a/handlers/wechat/handler_test.go
+++ b/handlers/wechat/handler_test.go
@@ -293,7 +293,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 }
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURL = s.URL
 }
 

--- a/handlers/whatsapp_legacy/handler.go
+++ b/handlers/whatsapp_legacy/handler.go
@@ -836,7 +836,7 @@ func buildPayloads(msg courier.MsgOut, h *handler, clog *courier.ChannelLog) ([]
 }
 
 // fetchMediaID tries to fetch the id for the uploaded media, setting the result in redis.
-func (h *handler) fetchMediaID(msg courier.Msg, mimeType, mediaURL string, clog *courier.ChannelLog) (string, error) {
+func (h *handler) fetchMediaID(msg courier.MsgOut, mimeType, mediaURL string, clog *courier.ChannelLog) (string, error) {
 	// check in cache first
 	rc := h.Backend().RedisPool().Get()
 	defer rc.Close()
@@ -908,7 +908,7 @@ func (h *handler) fetchMediaID(msg courier.Msg, mimeType, mediaURL string, clog 
 	return mediaID, nil
 }
 
-func sendWhatsAppMsg(rc redis.Conn, msg courier.Msg, sendPath *url.URL, payload any, clog *courier.ChannelLog) (string, string, error) {
+func sendWhatsAppMsg(rc redis.Conn, msg courier.MsgOut, sendPath *url.URL, payload any, clog *courier.ChannelLog) (string, string, error) {
 	jsonBody, err := json.Marshal(payload)
 
 	if err != nil {

--- a/handlers/whatsapp_legacy/handler.go
+++ b/handlers/whatsapp_legacy/handler.go
@@ -493,7 +493,7 @@ type mtErrorPayload struct {
 const maxMsgLength = 4096
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	conn := h.Backend().RedisPool().Get()
 	defer conn.Close()
 
@@ -556,7 +556,7 @@ func (h *handler) WriteRequestError(ctx context.Context, w http.ResponseWriter, 
 	return courier.WriteError(w, http.StatusOK, err)
 }
 
-func buildPayloads(msg courier.Msg, h *handler, clog *courier.ChannelLog) ([]any, error) {
+func buildPayloads(msg courier.MsgOut, h *handler, clog *courier.ChannelLog) ([]any, error) {
 	var payloads []any
 	var err error
 
@@ -1116,7 +1116,7 @@ func checkWhatsAppContact(channel courier.Channel, baseURL string, urn urns.URN,
 	}
 }
 
-func (h *handler) getTemplating(msg courier.Msg) (*MsgTemplating, error) {
+func (h *handler) getTemplating(msg courier.MsgOut) (*MsgTemplating, error) {
 	if len(msg.Metadata()) == 0 {
 		return nil, nil
 	}

--- a/handlers/whatsapp_legacy/handler_test.go
+++ b/handlers/whatsapp_legacy/handler_test.go
@@ -542,7 +542,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the base_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	retryParam = "retry"
 	c.(*test.MockChannel).SetConfig("base_url", s.URL)
 }

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -97,7 +97,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for YO channel")

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -93,7 +93,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	dbMsg := h.Backend().NewIncomingMsg(channel, urn, form.Message, "", clog).WithReceivedOn(date)
 
 	// and finally write our message
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{dbMsg}, w, r, clog)
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{dbMsg}, w, r, clog)
 }
 
 // Send sends the given message, logging any HTTP calls or errors

--- a/handlers/yo/handler_test.go
+++ b/handlers/yo/handler_test.go
@@ -49,7 +49,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the send_url to our test server host
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	sendURLs = []string{s.URL}
 }
 

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -179,7 +179,7 @@ type mtPayload struct {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	channel := msg.Channel()
 
 	token := channel.StringConfigForKey(courier.ConfigAPIKey, "")

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -99,7 +99,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 
 	contactName := payload.Visitor.Name
 
-	msgs := []courier.Msg{}
+	msgs := []courier.MsgIn{}
 
 	for _, content := range payload.Message.Contents {
 

--- a/handlers/zenvia/handlers_test.go
+++ b/handlers/zenvia/handlers_test.go
@@ -243,7 +243,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 // setSendURL takes care of setting the sendURL to call
-func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.Msg) {
+func setSendURL(s *httptest.Server, h courier.ChannelHandler, c courier.Channel, m courier.MsgOut) {
 	whatsappSendURL = s.URL
 	smsSendURL = s.URL
 }

--- a/log.go
+++ b/log.go
@@ -22,7 +22,7 @@ func LogMsgStatusReceived(r *http.Request, status StatusUpdate) {
 }
 
 // LogMsgReceived logs that we received the passed in message
-func LogMsgReceived(r *http.Request, msg Msg) {
+func LogMsgReceived(r *http.Request, msg MsgIn) {
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		logrus.WithFields(logrus.Fields{
 			"channel_uuid":    msg.Channel().UUID(),

--- a/msg.go
+++ b/msg.go
@@ -50,7 +50,7 @@ const (
 // Msg interface
 //-----------------------------------------------------------------------------
 
-// Msg is our interface to represent an incoming or outgoing message
+// Msg is our interface for common methods for an incoming or outgoing message
 type Msg interface {
 	Event
 
@@ -61,13 +61,6 @@ type Msg interface {
 	Attachments() []string
 	URN() urns.URN
 	Channel() Channel
-
-	// incoming specific
-	ReceivedOn() *time.Time
-	WithAttachment(url string) Msg
-	WithContactName(name string) Msg
-	WithURNAuthTokens(tokens map[string]string) Msg
-	WithReceivedOn(date time.Time) Msg
 }
 
 // MsgOut is our interface to represent an outgoing
@@ -88,4 +81,16 @@ type MsgOut interface {
 	Flow() *FlowReference
 	SessionStatus() string
 	HighPriority() bool
+}
+
+// MsgIn is our interface to represent an incoming
+type MsgIn interface {
+	Msg
+
+	// incoming specific
+	ReceivedOn() *time.Time
+	WithAttachment(url string) MsgIn
+	WithContactName(name string) MsgIn
+	WithURNAuthTokens(tokens map[string]string) MsgIn
+	WithReceivedOn(date time.Time) MsgIn
 }

--- a/msg.go
+++ b/msg.go
@@ -62,6 +62,18 @@ type Msg interface {
 	URN() urns.URN
 	Channel() Channel
 
+	// incoming specific
+	ReceivedOn() *time.Time
+	WithAttachment(url string) Msg
+	WithContactName(name string) Msg
+	WithURNAuthTokens(tokens map[string]string) Msg
+	WithReceivedOn(date time.Time) Msg
+}
+
+// MsgOut is our interface to represent an outgoing
+type MsgOut interface {
+	Msg
+
 	// outgoing specific
 	QuickReplies() []string
 	Locale() i18n.Locale
@@ -76,11 +88,4 @@ type Msg interface {
 	Flow() *FlowReference
 	SessionStatus() string
 	HighPriority() bool
-
-	// incoming specific
-	ReceivedOn() *time.Time
-	WithAttachment(url string) Msg
-	WithContactName(name string) Msg
-	WithURNAuthTokens(tokens map[string]string) Msg
-	WithReceivedOn(date time.Time) Msg
 }

--- a/responses.go
+++ b/responses.go
@@ -48,7 +48,7 @@ func WriteChannelEventSuccess(w http.ResponseWriter, event ChannelEvent) error {
 }
 
 // WriteMsgSuccess writes a JSON response for the passed in msg indicating we handled it
-func WriteMsgSuccess(w http.ResponseWriter, msgs []Msg) error {
+func WriteMsgSuccess(w http.ResponseWriter, msgs []MsgIn) error {
 	data := []any{}
 	for _, msg := range msgs {
 		data = append(data, NewMsgReceiveData(msg))
@@ -85,7 +85,7 @@ type MsgReceiveData struct {
 }
 
 // NewMsgReceiveData creates a new data response for the passed in msg parameters
-func NewMsgReceiveData(msg Msg) MsgReceiveData {
+func NewMsgReceiveData(msg MsgIn) MsgReceiveData {
 	return MsgReceiveData{
 		"msg",
 		msg.Channel().UUID(),

--- a/responses_test.go
+++ b/responses_test.go
@@ -46,7 +46,7 @@ func TestWriteMsgSuccess(t *testing.T) {
 	msg := test.NewMockBackend().NewIncomingMsg(ch, "tel:+0987654321", "hi there", "", nil).(*test.MockMsg).WithUUID("588aafc4-ab5c-48ce-89e8-05c9fdeeafb7")
 	w := httptest.NewRecorder()
 
-	err := courier.WriteMsgSuccess(w, []courier.Msg{msg})
+	err := courier.WriteMsgSuccess(w, []courier.MsgIn{msg.(courier.MsgIn)})
 	assert.NoError(t, err)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "{\"message\":\"Message Accepted\",\"data\":[{\"type\":\"msg\",\"channel_uuid\":\"5fccf4b6-48d7-4f5a-bce8-b0d1fd5342ec\",\"msg_uuid\":\"588aafc4-ab5c-48ce-89e8-05c9fdeeafb7\",\"text\":\"hi there\",\"urn\":\"tel:+0987654321\"}]}\n", w.Body.String())

--- a/sender.go
+++ b/sender.go
@@ -105,7 +105,7 @@ func (f *Foreman) Assign() {
 type Sender struct {
 	id      int
 	foreman *Foreman
-	job     chan Msg
+	job     chan MsgOut
 }
 
 // NewSender creates a new sender responsible for sending messages
@@ -113,7 +113,7 @@ func NewSender(foreman *Foreman, id int) *Sender {
 	sender := &Sender{
 		id:      id,
 		foreman: foreman,
-		job:     make(chan Msg, 1),
+		job:     make(chan MsgOut, 1),
 	}
 	return sender
 }
@@ -151,7 +151,7 @@ func (w *Sender) Stop() {
 	close(w.job)
 }
 
-func (w *Sender) sendMessage(msg Msg) {
+func (w *Sender) sendMessage(msg MsgOut) {
 	log := logrus.WithField("comp", "sender").WithField("sender_id", w.id).WithField("channel_uuid", msg.Channel().UUID())
 
 	server := w.foreman.server

--- a/server.go
+++ b/server.go
@@ -330,7 +330,7 @@ func (s *server) channelHandleWrapper(handler ChannelHandler, handlerFunc Channe
 
 			for _, event := range events {
 				switch e := event.(type) {
-				case Msg:
+				case MsgIn:
 					clog.SetAttached(true)
 					analytics.Gauge(fmt.Sprintf("courier.msg_receive_%s", channel.ChannelType()), secondDuration)
 					LogMsgReceived(r, e)

--- a/test/backend.go
+++ b/test/backend.go
@@ -43,7 +43,7 @@ type MockBackend struct {
 	mutex     sync.RWMutex
 	redisPool *redis.Pool
 
-	writtenMsgs          []courier.Msg
+	writtenMsgs          []courier.MsgIn
 	writtenMsgStatuses   []courier.StatusUpdate
 	writtenChannelEvents []courier.ChannelEvent
 	writtenChannelLogs   []*courier.ChannelLog
@@ -98,7 +98,7 @@ func (mb *MockBackend) DeleteMsgByExternalID(ctx context.Context, channel courie
 }
 
 // NewIncomingMsg creates a new message from the given params
-func (mb *MockBackend) NewIncomingMsg(channel courier.Channel, urn urns.URN, text string, extID string, clog *courier.ChannelLog) courier.Msg {
+func (mb *MockBackend) NewIncomingMsg(channel courier.Channel, urn urns.URN, text string, extID string, clog *courier.ChannelLog) courier.MsgIn {
 	m := &MockMsg{
 		channel: channel, urn: urn, text: text, externalID: extID,
 	}
@@ -191,7 +191,7 @@ func (mb *MockBackend) SetErrorOnQueue(shouldError bool) {
 }
 
 // WriteMsg queues the passed in message internally
-func (mb *MockBackend) WriteMsg(ctx context.Context, m courier.Msg, clog *courier.ChannelLog) error {
+func (mb *MockBackend) WriteMsg(ctx context.Context, m courier.MsgIn, clog *courier.ChannelLog) error {
 	mm := m.(*MockMsg)
 
 	// this msg has already been written (we received it twice), we are a no op
@@ -376,7 +376,7 @@ func (mb *MockBackend) RedisPool() *redis.Pool {
 // Methods not part of the backed interface but used in tests
 ////////////////////////////////////////////////////////////////////////////////
 
-func (mb *MockBackend) WrittenMsgs() []courier.Msg                    { return mb.writtenMsgs }
+func (mb *MockBackend) WrittenMsgs() []courier.MsgIn                  { return mb.writtenMsgs }
 func (mb *MockBackend) WrittenMsgStatuses() []courier.StatusUpdate    { return mb.writtenMsgStatuses }
 func (mb *MockBackend) WrittenChannelEvents() []courier.ChannelEvent  { return mb.writtenChannelEvents }
 func (mb *MockBackend) WrittenChannelLogs() []*courier.ChannelLog     { return mb.writtenChannelLogs }

--- a/test/backend.go
+++ b/test/backend.go
@@ -169,7 +169,7 @@ func (mb *MockBackend) ClearMsgSent(ctx context.Context, id courier.MsgID) error
 }
 
 // MarkOutgoingMsgComplete marks the passed msg as having been dealt with
-func (mb *MockBackend) MarkOutgoingMsgComplete(ctx context.Context, msg courier.Msg, s courier.StatusUpdate) {
+func (mb *MockBackend) MarkOutgoingMsgComplete(ctx context.Context, msg courier.MsgOut, s courier.StatusUpdate) {
 	mb.mutex.Lock()
 	defer mb.mutex.Unlock()
 

--- a/test/backend.go
+++ b/test/backend.go
@@ -36,7 +36,7 @@ type MockBackend struct {
 	channels          map[courier.ChannelUUID]courier.Channel
 	channelsByAddress map[courier.ChannelAddress]courier.Channel
 	contacts          map[urns.URN]courier.Contact
-	outgoingMsgs      []courier.Msg
+	outgoingMsgs      []courier.MsgOut
 	media             map[string]courier.Media // url -> Media
 	errorOnQueue      bool
 
@@ -114,7 +114,7 @@ func (mb *MockBackend) NewIncomingMsg(channel courier.Channel, urn urns.URN, tex
 
 // NewOutgoingMsg creates a new outgoing message from the given params
 func (mb *MockBackend) NewOutgoingMsg(channel courier.Channel, id courier.MsgID, urn urns.URN, text string, highPriority bool, quickReplies []string,
-	topic string, responseToExternalID string, origin courier.MsgOrigin, contactLastSeenOn *time.Time) courier.Msg {
+	topic string, responseToExternalID string, origin courier.MsgOrigin, contactLastSeenOn *time.Time) courier.MsgOut {
 
 	return &MockMsg{
 		channel:              channel,
@@ -131,7 +131,7 @@ func (mb *MockBackend) NewOutgoingMsg(channel courier.Channel, id courier.MsgID,
 }
 
 // PushOutgoingMsg is a test method to add a message to our queue of messages to send
-func (mb *MockBackend) PushOutgoingMsg(msg courier.Msg) {
+func (mb *MockBackend) PushOutgoingMsg(msg courier.MsgOut) {
 	mb.mutex.Lock()
 	defer mb.mutex.Unlock()
 
@@ -139,7 +139,7 @@ func (mb *MockBackend) PushOutgoingMsg(msg courier.Msg) {
 }
 
 // PopNextOutgoingMsg returns the next message that should be sent, or nil if there are none to send
-func (mb *MockBackend) PopNextOutgoingMsg(ctx context.Context) (courier.Msg, error) {
+func (mb *MockBackend) PopNextOutgoingMsg(ctx context.Context) (courier.MsgOut, error) {
 	mb.mutex.Lock()
 	defer mb.mutex.Unlock()
 

--- a/test/handler.go
+++ b/test/handler.go
@@ -44,7 +44,7 @@ func (h *mockHandler) Initialize(s courier.Server) error {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *mockHandler) Send(ctx context.Context, msg courier.Msg, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *mockHandler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
 	// log a request that contains a header value that should be redacted
 	req, _ := httpx.NewRequest("GET", "http://mock.com/send", nil, map[string]string{"Authorization": "Token sesame"})
 	trace, _ := httpx.DoTrace(http.DefaultClient, req, nil, nil, 1024)

--- a/test/handler.go
+++ b/test/handler.go
@@ -60,7 +60,7 @@ func (h *mockHandler) WriteStatusSuccessResponse(ctx context.Context, w http.Res
 	return courier.WriteStatusSuccess(w, statuses)
 }
 
-func (h *mockHandler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.Msg) error {
+func (h *mockHandler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []courier.MsgIn) error {
 	return courier.WriteMsgSuccess(w, msgs)
 }
 

--- a/test/msg.go
+++ b/test/msg.go
@@ -85,9 +85,12 @@ func (m *MockMsg) WithURNAuthTokens(tokens map[string]string) courier.Msg {
 func (m *MockMsg) WithReceivedOn(date time.Time) courier.Msg { m.receivedOn = &date; return m }
 
 // used to create outgoing messages for testing
-func (m *MockMsg) WithID(id courier.MsgID) courier.Msg               { m.id = id; return m }
-func (m *MockMsg) WithUUID(uuid courier.MsgUUID) courier.Msg         { m.uuid = uuid; return m }
-func (m *MockMsg) WithMetadata(metadata json.RawMessage) courier.Msg { m.metadata = metadata; return m }
-func (m *MockMsg) WithFlow(flow *courier.FlowReference) courier.Msg  { m.flow = flow; return m }
-func (m *MockMsg) WithLocale(lc i18n.Locale) courier.Msg             { m.locale = lc; return m }
-func (m *MockMsg) WithURNAuth(token string) courier.Msg              { m.urnAuth = token; return m }
+func (m *MockMsg) WithID(id courier.MsgID) courier.MsgOut       { m.id = id; return m }
+func (m *MockMsg) WithUUID(uuid courier.MsgUUID) courier.MsgOut { m.uuid = uuid; return m }
+func (m *MockMsg) WithMetadata(metadata json.RawMessage) courier.MsgOut {
+	m.metadata = metadata
+	return m
+}
+func (m *MockMsg) WithFlow(flow *courier.FlowReference) courier.MsgOut { m.flow = flow; return m }
+func (m *MockMsg) WithLocale(lc i18n.Locale) courier.MsgOut            { m.locale = lc; return m }
+func (m *MockMsg) WithURNAuth(token string) courier.MsgOut             { m.urnAuth = token; return m }

--- a/test/msg.go
+++ b/test/msg.go
@@ -73,16 +73,16 @@ func (m *MockMsg) HighPriority() bool            { return m.highPriority }
 
 // incoming specific
 func (m *MockMsg) ReceivedOn() *time.Time { return m.receivedOn }
-func (m *MockMsg) WithAttachment(url string) courier.Msg {
+func (m *MockMsg) WithAttachment(url string) courier.MsgIn {
 	m.attachments = append(m.attachments, url)
 	return m
 }
-func (m *MockMsg) WithContactName(name string) courier.Msg { m.contactName = name; return m }
-func (m *MockMsg) WithURNAuthTokens(tokens map[string]string) courier.Msg {
+func (m *MockMsg) WithContactName(name string) courier.MsgIn { m.contactName = name; return m }
+func (m *MockMsg) WithURNAuthTokens(tokens map[string]string) courier.MsgIn {
 	m.urnAuthTokens = tokens
 	return m
 }
-func (m *MockMsg) WithReceivedOn(date time.Time) courier.Msg { m.receivedOn = &date; return m }
+func (m *MockMsg) WithReceivedOn(date time.Time) courier.MsgIn { m.receivedOn = &date; return m }
 
 // used to create outgoing messages for testing
 func (m *MockMsg) WithID(id courier.MsgID) courier.MsgOut       { m.id = id; return m }


### PR DESCRIPTION
This separates the `courier.Msg` interfaces into 2 interfaces `courier.MsgOut` for outgoing messages and `courier.MsgIn` for incoming messages.
And changes all methods to expect the proper interface according to whether they are to handle for outgoing or incoming messages.

