### PR TITLE
Channel Event OptIn ID

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -1274,12 +1274,21 @@ func (ts *BackendTestSuite) TestChannelEvent() {
 	ts.Equal(null.String("kermit frog"), contact.Name_)
 
 	dbE := event.(*ChannelEvent)
-	dbE, err = readChannelEventFromDB(ts.b, dbE.ID_)
-	ts.NoError(err)
+	dbE = readChannelEventFromDB(ts.b, dbE.ID_)
 	ts.Equal(dbE.EventType_, courier.EventTypeReferral)
 	ts.Equal(map[string]any{"ref_id": "12345"}, dbE.Extra())
 	ts.Equal(contact.ID_, dbE.ContactID_)
 	ts.Equal(contact.URNID_, dbE.ContactURNID_)
+
+	event = ts.b.NewChannelEvent(channel, courier.EventTypeOptIn, urn, clog).WithExtra(map[string]any{"optin_id": "1", "optin_name": "Polls"})
+	err = ts.b.WriteChannelEvent(ctx, event, clog)
+	ts.NoError(err)
+
+	dbE = event.(*ChannelEvent)
+	dbE = readChannelEventFromDB(ts.b, dbE.ID_)
+	ts.Equal(dbE.EventType_, courier.EventTypeOptIn)
+	ts.Equal(map[string]any{"optin_id": "1", "optin_name": "Polls"}, dbE.Extra())
+	ts.Equal(null.Int(1), dbE.OptInID_)
 }
 
 func (ts *BackendTestSuite) TestSessionTimeout() {
@@ -1316,8 +1325,7 @@ func (ts *BackendTestSuite) TestMailroomEvents() {
 	ts.Equal(null.String("kermit frog"), contact.Name_)
 
 	dbE := event.(*ChannelEvent)
-	dbE, err = readChannelEventFromDB(ts.b, dbE.ID_)
-	ts.NoError(err)
+	dbE = readChannelEventFromDB(ts.b, dbE.ID_)
 	ts.Equal(dbE.EventType_, courier.EventTypeReferral)
 	ts.Equal(map[string]any{"ref_id": "12345"}, dbE.Extra())
 	ts.Equal(contact.ID_, dbE.ContactID_)
@@ -1552,14 +1560,15 @@ WHERE
 `
 
 const sqlSelectEvent = `
-SELECT org_id, channel_id, contact_id, contact_urn_id, event_type, extra, occurred_on, created_on, log_uuids
+SELECT id, org_id, channel_id, contact_id, contact_urn_id, event_type, optin_id, extra, occurred_on, created_on, log_uuids
   FROM channels_channelevent
  WHERE id = $1`
 
-func readChannelEventFromDB(b *backend, id ChannelEventID) (*ChannelEvent, error) {
-	e := &ChannelEvent{
-		ID_: id,
-	}
+func readChannelEventFromDB(b *backend, id ChannelEventID) *ChannelEvent {
+	e := &ChannelEvent{}
 	err := b.db.Get(e, sqlSelectEvent, id)
-	return e, err
+	if err != nil {
+		panic(err)
+	}
+	return e
 }

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -1265,7 +1265,7 @@ func (ts *BackendTestSuite) TestChannelEvent() {
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, channel, nil)
 	urn, _ := urns.NewTelURNForCountry("12065551616", channel.Country())
 
-	event := ts.b.NewChannelEvent(channel, courier.EventTypeReferral, urn, clog).WithExtra(map[string]any{"ref_id": "12345"}).WithContactName("kermit frog")
+	event := ts.b.NewChannelEvent(channel, courier.EventTypeReferral, urn, clog).WithExtra(map[string]string{"ref_id": "12345"}).WithContactName("kermit frog")
 	err := ts.b.WriteChannelEvent(ctx, event, clog)
 	ts.NoError(err)
 
@@ -1276,18 +1276,18 @@ func (ts *BackendTestSuite) TestChannelEvent() {
 	dbE := event.(*ChannelEvent)
 	dbE = readChannelEventFromDB(ts.b, dbE.ID_)
 	ts.Equal(dbE.EventType_, courier.EventTypeReferral)
-	ts.Equal(map[string]any{"ref_id": "12345"}, dbE.Extra())
+	ts.Equal(map[string]string{"ref_id": "12345"}, dbE.Extra())
 	ts.Equal(contact.ID_, dbE.ContactID_)
 	ts.Equal(contact.URNID_, dbE.ContactURNID_)
 
-	event = ts.b.NewChannelEvent(channel, courier.EventTypeOptIn, urn, clog).WithExtra(map[string]any{"optin_id": "1", "optin_name": "Polls"})
+	event = ts.b.NewChannelEvent(channel, courier.EventTypeOptIn, urn, clog).WithExtra(map[string]string{"title": "Polls", "payload": "1"})
 	err = ts.b.WriteChannelEvent(ctx, event, clog)
 	ts.NoError(err)
 
 	dbE = event.(*ChannelEvent)
 	dbE = readChannelEventFromDB(ts.b, dbE.ID_)
 	ts.Equal(dbE.EventType_, courier.EventTypeOptIn)
-	ts.Equal(map[string]any{"optin_id": "1", "optin_name": "Polls"}, dbE.Extra())
+	ts.Equal(map[string]string{"title": "Polls", "payload": "1"}, dbE.Extra())
 	ts.Equal(null.Int(1), dbE.OptInID_)
 }
 
@@ -1314,7 +1314,7 @@ func (ts *BackendTestSuite) TestMailroomEvents() {
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, channel, nil)
 	urn, _ := urns.NewTelURNForCountry("12065551616", channel.Country())
 
-	event := ts.b.NewChannelEvent(channel, courier.EventTypeReferral, urn, clog).WithExtra(map[string]any{"ref_id": "12345"}).
+	event := ts.b.NewChannelEvent(channel, courier.EventTypeReferral, urn, clog).WithExtra(map[string]string{"ref_id": "12345"}).
 		WithContactName("kermit frog").
 		WithOccurredOn(time.Date(2020, 8, 5, 13, 30, 0, 123456789, time.UTC))
 	err := ts.b.WriteChannelEvent(ctx, event, clog)
@@ -1327,7 +1327,7 @@ func (ts *BackendTestSuite) TestMailroomEvents() {
 	dbE := event.(*ChannelEvent)
 	dbE = readChannelEventFromDB(ts.b, dbE.ID_)
 	ts.Equal(dbE.EventType_, courier.EventTypeReferral)
-	ts.Equal(map[string]any{"ref_id": "12345"}, dbE.Extra())
+	ts.Equal(map[string]string{"ref_id": "12345"}, dbE.Extra())
 	ts.Equal(contact.ID_, dbE.ContactID_)
 	ts.Equal(contact.URNID_, dbE.ContactURNID_)
 

--- a/backends/rapidpro/channel_event.go
+++ b/backends/rapidpro/channel_event.go
@@ -43,6 +43,7 @@ type ChannelEvent struct {
 	ChannelID_   courier.ChannelID        `json:"channel_id"              db:"channel_id"`
 	URN_         urns.URN                 `json:"urn"                     db:"urn"`
 	EventType_   courier.ChannelEventType `json:"event_type"              db:"event_type"`
+	OptInID_     null.Int                 `json:"optin_id"                db:"optin_id"`
 	Extra_       null.Map[any]            `json:"extra"                   db:"extra"`
 	OccurredOn_  time.Time                `json:"occurred_on"             db:"occurred_on"`
 	CreatedOn_   time.Time                `json:"created_on"              db:"created_on"`
@@ -98,6 +99,13 @@ func (e *ChannelEvent) WithURNAuthTokens(tokens map[string]string) courier.Chann
 }
 
 func (e *ChannelEvent) WithExtra(extra map[string]any) courier.ChannelEvent {
+	optInID, ok := extra["optin_id"]
+	if ok {
+		asStr, _ := optInID.(string)
+		asInt, _ := strconv.Atoi(asStr)
+		e.OptInID_ = null.Int(asInt)
+	}
+
 	e.Extra_ = null.Map[any](extra)
 	return e
 }
@@ -127,8 +135,8 @@ func writeChannelEvent(ctx context.Context, b *backend, event courier.ChannelEve
 
 const sqlInsertChannelEvent = `
 INSERT INTO 
-	channels_channelevent( org_id,  channel_id,  contact_id,  contact_urn_id,  event_type,  extra,  occurred_on,  created_on,  log_uuids)
-				   VALUES(:org_id, :channel_id, :contact_id, :contact_urn_id, :event_type, :extra, :occurred_on, :created_on, :log_uuids)
+	channels_channelevent( org_id,  channel_id,  contact_id,  contact_urn_id,  event_type,  optin_id,  extra,  occurred_on,  created_on,  log_uuids)
+				   VALUES(:org_id, :channel_id, :contact_id, :contact_urn_id, :event_type, :optin_id, :extra, :occurred_on, :created_on, :log_uuids)
 RETURNING id`
 
 // writeChannelEventToDB writes the passed in msg status to our db

--- a/backends/rapidpro/channel_event.go
+++ b/backends/rapidpro/channel_event.go
@@ -44,7 +44,7 @@ type ChannelEvent struct {
 	URN_         urns.URN                 `json:"urn"                     db:"urn"`
 	EventType_   courier.ChannelEventType `json:"event_type"              db:"event_type"`
 	OptInID_     null.Int                 `json:"optin_id"                db:"optin_id"`
-	Extra_       null.Map[any]            `json:"extra"                   db:"extra"`
+	Extra_       null.Map[string]         `json:"extra"                   db:"extra"`
 	OccurredOn_  time.Time                `json:"occurred_on"             db:"occurred_on"`
 	CreatedOn_   time.Time                `json:"created_on"              db:"created_on"`
 	LogUUIDs     pq.StringArray           `json:"log_uuids"               db:"log_uuids"`
@@ -83,7 +83,7 @@ func (e *ChannelEvent) ChannelID() courier.ChannelID        { return e.ChannelID
 func (e *ChannelEvent) ChannelUUID() courier.ChannelUUID    { return e.ChannelUUID_ }
 func (e *ChannelEvent) EventType() courier.ChannelEventType { return e.EventType_ }
 func (e *ChannelEvent) URN() urns.URN                       { return e.URN_ }
-func (e *ChannelEvent) Extra() map[string]any               { return e.Extra_ }
+func (e *ChannelEvent) Extra() map[string]string            { return e.Extra_ }
 func (e *ChannelEvent) OccurredOn() time.Time               { return e.OccurredOn_ }
 func (e *ChannelEvent) CreatedOn() time.Time                { return e.CreatedOn_ }
 func (e *ChannelEvent) Channel() *Channel                   { return e.channel }
@@ -98,15 +98,16 @@ func (e *ChannelEvent) WithURNAuthTokens(tokens map[string]string) courier.Chann
 	return e
 }
 
-func (e *ChannelEvent) WithExtra(extra map[string]any) courier.ChannelEvent {
-	optInID, ok := extra["optin_id"]
-	if ok {
-		asStr, _ := optInID.(string)
-		asInt, _ := strconv.Atoi(asStr)
-		e.OptInID_ = null.Int(asInt)
+func (e *ChannelEvent) WithExtra(extra map[string]string) courier.ChannelEvent {
+	if e.EventType_ == courier.EventTypeOptIn || e.EventType_ == courier.EventTypeOptOut {
+		optInID := extra["payload"]
+		if optInID != "" {
+			asInt, _ := strconv.Atoi(optInID)
+			e.OptInID_ = null.Int(asInt)
+		}
 	}
 
-	e.Extra_ = null.Map[any](extra)
+	e.Extra_ = null.Map[string](extra)
 	return e
 }
 

--- a/backends/rapidpro/schema.sql
+++ b/backends/rapidpro/schema.sql
@@ -56,6 +56,14 @@ CREATE TABLE contacts_contacturn (
     UNIQUE (org_id, identity)
 );
 
+DROP TABLE IF EXISTS msgs_optin CASCADE;
+CREATE TABLE msgs_optin (
+    id serial primary key,
+    uuid uuid NOT NULL,
+    org_id integer NOT NULL references orgs_org(id) on delete cascade,
+    name character varying(64)
+);
+
 DROP TABLE IF EXISTS msgs_msg CASCADE;
 CREATE TABLE msgs_msg (
     id bigserial primary key,
@@ -83,7 +91,7 @@ CREATE TABLE msgs_msg (
     contact_urn_id integer NOT NULL references contacts_contacturn(id) on delete cascade,
     org_id integer NOT NULL references orgs_org(id) on delete cascade,
     metadata text,
-    topup_id integer,
+    optin_id integer references msgs_optin(id) on delete cascade,
     delete_from_counts boolean,
     log_uuids uuid[]
 );
@@ -111,6 +119,7 @@ CREATE TABLE channels_channelevent (
     channel_id integer NOT NULL references channels_channel(id) on delete cascade,
     contact_id integer NOT NULL references contacts_contact(id) on delete cascade,
     contact_urn_id integer NOT NULL references contacts_contacturn(id) on delete cascade,
+    optin_id integer references msgs_optin(id) on delete cascade,
     org_id integer NOT NULL references orgs_org(id) on delete cascade,
     log_uuids uuid[]
 );

--- a/backends/rapidpro/testdata.sql
+++ b/backends/rapidpro/testdata.sql
@@ -36,8 +36,14 @@ DELETE FROM contacts_contacturn;
 INSERT INTO contacts_contacturn("id", "identity", "path", "scheme", "priority", "channel_id", "contact_id", "org_id")
                          VALUES(1000, 'tel:+12067799192', '+12067799192', 'tel', 50, 10, 100, 1);
 
-/** Msg with id 10,000 */
-DELETE from msgs_msg;
+/* Msg optins with ids 1, 2 */
+DELETE FROM msgs_optin;
+INSERT INTO msgs_optin(id, uuid, org_id, name) VALUES
+                      (1, 'fc1cef6e-b5b1-452d-9528-a4b24db28eb0', 1, 'Polls'),
+                      (2, '2b1eba23-4a97-46ac-9022-11304412b32f', 1, 'Jokes');
+
+/** Msg with id 10000 */
+DELETE FROM msgs_msg;
 INSERT INTO msgs_msg("id", "text", "high_priority", "created_on", "modified_on", "sent_on", "queued_on", "direction", "status", "visibility", "msg_type",
                         "msg_count", "error_count", "next_attempt", "external_id", "channel_id", "contact_id", "contact_urn_id", "org_id")
               VALUES(10000, 'test message', True, now(), now(), now(), now(), 'O', 'W', 'V', 'T',

--- a/channel_event.go
+++ b/channel_event.go
@@ -30,12 +30,12 @@ type ChannelEvent interface {
 	ChannelUUID() ChannelUUID
 	URN() urns.URN
 	EventType() ChannelEventType
-	Extra() map[string]any
+	Extra() map[string]string
 	CreatedOn() time.Time
 	OccurredOn() time.Time
 
 	WithContactName(name string) ChannelEvent
 	WithURNAuthTokens(tokens map[string]string) ChannelEvent
-	WithExtra(extra map[string]any) ChannelEvent
+	WithExtra(extra map[string]string) ChannelEvent
 	WithOccurredOn(time.Time) ChannelEvent
 }

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -273,9 +273,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 			event := h.Backend().NewChannelEvent(channel, courier.EventTypeReferral, urn, clog).WithOccurredOn(date)
 
 			// build our extra
-			extra := map[string]any{
-				referrerIDKey: msg.OptIn.Ref,
-			}
+			extra := map[string]string{referrerIDKey: msg.OptIn.Ref}
 			event = event.WithExtra(extra)
 
 			err := h.Backend().WriteChannelEvent(ctx, event, clog)
@@ -295,7 +293,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 			event := h.Backend().NewChannelEvent(channel, eventType, urn, clog).WithOccurredOn(date)
 
 			// build our extra
-			extra := map[string]any{
+			extra := map[string]string{
 				titleKey:   msg.Postback.Title,
 				payloadKey: msg.Postback.Payload,
 			}
@@ -326,10 +324,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 			event := h.Backend().NewChannelEvent(channel, courier.EventTypeReferral, urn, clog).WithOccurredOn(date)
 
 			// build our extra
-			extra := map[string]any{
-				sourceKey: msg.Referral.Source,
-				typeKey:   msg.Referral.Type,
-			}
+			extra := map[string]string{sourceKey: msg.Referral.Source, typeKey: msg.Referral.Type}
 
 			// add referrer id if present
 			if msg.Referral.Ref != "" {

--- a/handlers/facebook_legacy/handler_test.go
+++ b/handlers/facebook_legacy/handler_test.go
@@ -482,7 +482,7 @@ var testCases = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeReferral, URN: "facebook:ref:optin_user_ref", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"referrer_id": "optin_ref"}},
+			{Type: courier.EventTypeReferral, URN: "facebook:ref:optin_user_ref", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"referrer_id": "optin_ref"}},
 		},
 	},
 	{
@@ -492,7 +492,7 @@ var testCases = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"referrer_id": "optin_ref"}},
+			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"referrer_id": "optin_ref"}},
 		},
 	},
 	{
@@ -502,7 +502,7 @@ var testCases = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeNewConversation, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"title": "postback title", "payload": "get_started"}},
+			{Type: courier.EventTypeNewConversation, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"title": "postback title", "payload": "get_started"}},
 		},
 	},
 	{
@@ -512,7 +512,7 @@ var testCases = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"title": "postback title", "payload": "postback payload", "referrer_id": "postback ref", "source": "postback source", "type": "postback type"}},
+			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"title": "postback title", "payload": "postback payload", "referrer_id": "postback ref", "source": "postback source", "type": "postback type"}},
 		},
 	},
 	{
@@ -522,7 +522,7 @@ var testCases = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"title": "postback title", "payload": "get_started", "referrer_id": "postback ref", "source": "postback source", "type": "postback type", "ad_id": "ad id"}},
+			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"title": "postback title", "payload": "get_started", "referrer_id": "postback ref", "source": "postback source", "type": "postback type", "ad_id": "ad id"}},
 		},
 	},
 	{
@@ -532,7 +532,7 @@ var testCases = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: `"referrer_id":"referral id"`,
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"referrer_id": "referral id", "source": "referral source", "type": "referral type", "ad_id": "ad id"}},
+			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"referrer_id": "referral id", "source": "referral source", "type": "referral type", "ad_id": "ad id"}},
 		},
 	},
 	{

--- a/handlers/meta/facebook_test.go
+++ b/handlers/meta/facebook_test.go
@@ -122,7 +122,7 @@ var facebookIncomingTests = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeOptIn, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"optin_id": 3456, "optin_name": "Bird Facts"}},
+			{Type: courier.EventTypeOptIn, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"optin_id": "3456", "optin_name": "Bird Facts"}},
 		},
 		ExpectedURNAuthTokens: map[urns.URN]map[string]string{"facebook:5678": {"optin:3456": "12345678901234567890"}},
 		PrepRequest:           addValidSignature,
@@ -134,7 +134,7 @@ var facebookIncomingTests = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeOptOut, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"optin_id": 3456, "optin_name": "Bird Facts"}},
+			{Type: courier.EventTypeOptOut, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"optin_id": "3456", "optin_name": "Bird Facts"}},
 		},
 		ExpectedURNAuthTokens: map[urns.URN]map[string]string{"facebook:5678": {}},
 		PrepRequest:           addValidSignature,

--- a/handlers/meta/facebook_test.go
+++ b/handlers/meta/facebook_test.go
@@ -100,7 +100,7 @@ var facebookIncomingTests = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeReferral, URN: "facebook:ref:optin_user_ref", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"referrer_id": "optin_ref"}},
+			{Type: courier.EventTypeReferral, URN: "facebook:ref:optin_user_ref", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"referrer_id": "optin_ref"}},
 		},
 		PrepRequest: addValidSignature,
 	},
@@ -111,7 +111,7 @@ var facebookIncomingTests = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"referrer_id": "optin_ref"}},
+			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"referrer_id": "optin_ref"}},
 		},
 		PrepRequest: addValidSignature,
 	},
@@ -122,7 +122,7 @@ var facebookIncomingTests = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeOptIn, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"optin_id": "3456", "optin_name": "Bird Facts"}},
+			{Type: courier.EventTypeOptIn, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"title": "Bird Facts", "payload": "3456"}},
 		},
 		ExpectedURNAuthTokens: map[urns.URN]map[string]string{"facebook:5678": {"optin:3456": "12345678901234567890"}},
 		PrepRequest:           addValidSignature,
@@ -134,7 +134,7 @@ var facebookIncomingTests = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeOptOut, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"optin_id": "3456", "optin_name": "Bird Facts"}},
+			{Type: courier.EventTypeOptOut, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"title": "Bird Facts", "payload": "3456"}},
 		},
 		ExpectedURNAuthTokens: map[urns.URN]map[string]string{"facebook:5678": {}},
 		PrepRequest:           addValidSignature,
@@ -146,7 +146,7 @@ var facebookIncomingTests = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeNewConversation, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"title": "postback title", "payload": "get_started"}},
+			{Type: courier.EventTypeNewConversation, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"title": "postback title", "payload": "get_started"}},
 		},
 		PrepRequest: addValidSignature,
 	},
@@ -157,7 +157,7 @@ var facebookIncomingTests = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"title": "postback title", "payload": "postback payload", "referrer_id": "postback ref", "source": "postback source", "type": "postback type"}},
+			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"title": "postback title", "payload": "postback payload", "referrer_id": "postback ref", "source": "postback source", "type": "postback type"}},
 		},
 		PrepRequest: addValidSignature,
 	},
@@ -168,7 +168,7 @@ var facebookIncomingTests = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"title": "postback title", "payload": "get_started", "referrer_id": "postback ref", "source": "postback source", "type": "postback type", "ad_id": "ad id"}},
+			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"title": "postback title", "payload": "get_started", "referrer_id": "postback ref", "source": "postback source", "type": "postback type", "ad_id": "ad id"}},
 		},
 		PrepRequest: addValidSignature,
 	},
@@ -179,7 +179,7 @@ var facebookIncomingTests = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: `"referrer_id":"referral id"`,
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"referrer_id": "referral id", "source": "referral source", "type": "referral type", "ad_id": "ad id"}},
+			{Type: courier.EventTypeReferral, URN: "facebook:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"referrer_id": "referral id", "source": "referral source", "type": "referral type", "ad_id": "ad id"}},
 		},
 		PrepRequest: addValidSignature,
 	},

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -438,11 +438,8 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel c
 			if msg.OptIn.Type == "notification_messages" {
 				eventType := courier.EventTypeOptIn
 				authToken := msg.OptIn.NotificationMessagesToken
+				optInID := msg.OptIn.Payload
 				optInName := msg.OptIn.Title
-				optInID, err := strconv.Atoi(msg.OptIn.Payload)
-				if err != nil {
-					return nil, nil, err
-				}
 
 				if msg.OptIn.NotificationMessagesStatus == "STOP_NOTIFICATIONS" {
 					eventType = courier.EventTypeOptOut
@@ -452,7 +449,7 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel c
 				event = h.Backend().NewChannelEvent(channel, eventType, urn, clog).
 					WithOccurredOn(date).
 					WithExtra(map[string]any{"optin_id": optInID, "optin_name": optInName}).
-					WithURNAuthTokens(map[string]string{fmt.Sprintf("optin:%d", optInID): authToken})
+					WithURNAuthTokens(map[string]string{fmt.Sprintf("optin:%s", optInID): authToken})
 			} else {
 
 				// this is an opt in, if we have a user_ref, use that as our URN (this is a checkbox plugin)

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -438,8 +438,6 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel c
 			if msg.OptIn.Type == "notification_messages" {
 				eventType := courier.EventTypeOptIn
 				authToken := msg.OptIn.NotificationMessagesToken
-				optInID := msg.OptIn.Payload
-				optInName := msg.OptIn.Title
 
 				if msg.OptIn.NotificationMessagesStatus == "STOP_NOTIFICATIONS" {
 					eventType = courier.EventTypeOptOut
@@ -448,8 +446,8 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel c
 
 				event = h.Backend().NewChannelEvent(channel, eventType, urn, clog).
 					WithOccurredOn(date).
-					WithExtra(map[string]any{"optin_id": optInID, "optin_name": optInName}).
-					WithURNAuthTokens(map[string]string{fmt.Sprintf("optin:%s", optInID): authToken})
+					WithExtra(map[string]string{titleKey: msg.OptIn.Title, payloadKey: msg.OptIn.Payload}).
+					WithURNAuthTokens(map[string]string{fmt.Sprintf("optin:%s", msg.OptIn.Payload): authToken})
 			} else {
 
 				// this is an opt in, if we have a user_ref, use that as our URN (this is a checkbox plugin)
@@ -467,9 +465,7 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel c
 
 				event = h.Backend().NewChannelEvent(channel, courier.EventTypeReferral, urn, clog).
 					WithOccurredOn(date).
-					WithExtra(map[string]any{
-						referrerIDKey: msg.OptIn.Ref,
-					})
+					WithExtra(map[string]string{referrerIDKey: msg.OptIn.Ref})
 			}
 
 			err := h.Backend().WriteChannelEvent(ctx, event, clog)
@@ -489,10 +485,7 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel c
 			event := h.Backend().NewChannelEvent(channel, eventType, urn, clog).WithOccurredOn(date)
 
 			// build our extra
-			extra := map[string]any{
-				titleKey:   msg.Postback.Title,
-				payloadKey: msg.Postback.Payload,
-			}
+			extra := map[string]string{titleKey: msg.Postback.Title, payloadKey: msg.Postback.Payload}
 
 			// add in referral information if we have it
 			if eventType == courier.EventTypeReferral {
@@ -520,10 +513,7 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel c
 			event := h.Backend().NewChannelEvent(channel, courier.EventTypeReferral, urn, clog).WithOccurredOn(date)
 
 			// build our extra
-			extra := map[string]any{
-				sourceKey: msg.Referral.Source,
-				typeKey:   msg.Referral.Type,
-			}
+			extra := map[string]string{sourceKey: msg.Referral.Source, typeKey: msg.Referral.Type}
 
 			// add referrer id if present
 			if msg.Referral.Ref != "" {

--- a/handlers/meta/instagram_test.go
+++ b/handlers/meta/instagram_test.go
@@ -86,7 +86,7 @@ var instagramIncomingTests = []IncomingTestCase{
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "Handled",
 		ExpectedEvents: []ExpectedEvent{
-			{Type: courier.EventTypeNewConversation, URN: "instagram:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]any{"title": "icebreaker question", "payload": "get_started"}},
+			{Type: courier.EventTypeNewConversation, URN: "instagram:5678", Time: time.Date(2016, 4, 7, 1, 11, 27, 970000000, time.UTC), Extra: map[string]string{"title": "icebreaker question", "payload": "get_started"}},
 		},
 		PrepRequest: addValidSignature,
 	},

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -40,7 +40,7 @@ type ExpectedEvent struct {
 	Type  courier.ChannelEventType
 	URN   urns.URN
 	Time  time.Time
-	Extra map[string]any
+	Extra map[string]string
 }
 
 // IncomingTestCase defines the test values for a particular test case

--- a/responses.go
+++ b/responses.go
@@ -100,12 +100,12 @@ func NewMsgReceiveData(msg MsgIn) MsgReceiveData {
 
 // EventReceiveData is our response payload for a channel event
 type EventReceiveData struct {
-	Type        string           `json:"type"`
-	ChannelUUID ChannelUUID      `json:"channel_uuid"`
-	EventType   ChannelEventType `json:"event_type"`
-	URN         urns.URN         `json:"urn"`
-	ReceivedOn  time.Time        `json:"received_on"`
-	Extra       map[string]any   `json:"extra,omitempty"`
+	Type        string            `json:"type"`
+	ChannelUUID ChannelUUID       `json:"channel_uuid"`
+	EventType   ChannelEventType  `json:"event_type"`
+	URN         urns.URN          `json:"urn"`
+	ReceivedOn  time.Time         `json:"received_on"`
+	Extra       map[string]string `json:"extra,omitempty"`
 }
 
 // NewEventReceiveData creates a new receive data for the passed in event

--- a/test/channel_event.go
+++ b/test/channel_event.go
@@ -16,7 +16,7 @@ type mockChannelEvent struct {
 
 	contactName   string
 	urnAuthTokens map[string]string
-	extra         map[string]any
+	extra         map[string]string
 }
 
 func (e *mockChannelEvent) EventID() int64                      { return 0 }
@@ -24,11 +24,11 @@ func (e *mockChannelEvent) ChannelUUID() courier.ChannelUUID    { return e.chann
 func (e *mockChannelEvent) EventType() courier.ChannelEventType { return e.eventType }
 func (e *mockChannelEvent) CreatedOn() time.Time                { return e.createdOn }
 func (e *mockChannelEvent) OccurredOn() time.Time               { return e.occurredOn }
-func (e *mockChannelEvent) Extra() map[string]any               { return e.extra }
+func (e *mockChannelEvent) Extra() map[string]string            { return e.extra }
 func (e *mockChannelEvent) ContactName() string                 { return e.contactName }
 func (e *mockChannelEvent) URN() urns.URN                       { return e.urn }
 
-func (e *mockChannelEvent) WithExtra(extra map[string]any) courier.ChannelEvent {
+func (e *mockChannelEvent) WithExtra(extra map[string]string) courier.ChannelEvent {
 	e.extra = extra
 	return e
 }


### PR DESCRIPTION
* RP backend now extracts optin id from extra and saves as actual id in the database
* Change `extra` fields on optin/optout events to be more consistent with other FB/IG events
* Enforce `extra` being map[string]string as this avoids problems if an event is spooled to JSON and reloaded (ints become floats) 