### PR TITLE
Remove support for HSM template support

### DIFF
--- a/handlers/whatsapp_legacy/handler.go
+++ b/handlers/whatsapp_legacy/handler.go
@@ -724,39 +724,24 @@ func buildPayloads(msg courier.MsgOut, h *handler, clog *courier.ChannelLog) ([]
 				return nil, errors.Errorf("cannot send template message without Facebook namespace for channel: %s", msg.Channel().UUID())
 			}
 
-			if msg.Channel().BoolConfigForKey(configHSMSupport, false) {
-				payload := hsmPayload{
-					To:   msg.URN().Path(),
-					Type: "hsm",
-				}
-				payload.HSM.Namespace = namespace
-				payload.HSM.ElementName = templating.Template.Name
-				payload.HSM.Language.Policy = "deterministic"
-				payload.HSM.Language.Code = langCode
-				for _, v := range templating.Variables {
-					payload.HSM.LocalizableParams = append(payload.HSM.LocalizableParams, LocalizableParam{Default: v})
-				}
-				payloads = append(payloads, payload)
-			} else {
-
-				payload := templatePayload{
-					To:   msg.URN().Path(),
-					Type: "template",
-				}
-				payload.Template.Namespace = namespace
-				payload.Template.Name = templating.Template.Name
-				payload.Template.Language.Policy = "deterministic"
-				payload.Template.Language.Code = langCode
-
-				component := &Component{Type: "body"}
-
-				for _, v := range templating.Variables {
-					component.Parameters = append(component.Parameters, Param{Type: "text", Text: v})
-				}
-				payload.Template.Components = append(payload.Template.Components, *component)
-
-				payloads = append(payloads, payload)
+			payload := templatePayload{
+				To:   msg.URN().Path(),
+				Type: "template",
 			}
+			payload.Template.Namespace = namespace
+			payload.Template.Name = templating.Template.Name
+			payload.Template.Language.Policy = "deterministic"
+			payload.Template.Language.Code = langCode
+
+			component := &Component{Type: "body"}
+
+			for _, v := range templating.Variables {
+				component.Parameters = append(component.Parameters, Param{Type: "text", Text: v})
+			}
+			payload.Template.Components = append(payload.Template.Components, *component)
+
+			payloads = append(payloads, payload)
+
 		} else {
 
 			if isInteractiveMsg {

--- a/handlers/whatsapp_legacy/handler_test.go
+++ b/handlers/whatsapp_legacy/handler_test.go
@@ -1070,21 +1070,6 @@ var mediaCacheSendTestCases = []OutgoingTestCase{
 	},
 }
 
-var hsmSupportSendTestCases = []OutgoingTestCase{
-	{
-		Label:               "Template Send",
-		MsgText:             "templated message",
-		MsgURN:              "whatsapp:250788123123",
-		MsgMetadata:         json.RawMessage(`{ "templating": { "template": { "name": "revive_issue", "uuid": "171f8a4d-f725-46d7-85a6-11aceff0bfe3" }, "language": "eng", "variables": ["Chef", "tomorrow"]}}`),
-		MockResponseBody:    `{ "messages": [{"id": "157b5e14568e8"}] }`,
-		MockResponseStatus:  200,
-		ExpectedRequestBody: `{"to":"250788123123","type":"hsm","hsm":{"namespace":"waba_namespace","element_name":"revive_issue","language":{"policy":"deterministic","code":"en"},"localizable_params":[{"default":"Chef"},{"default":"tomorrow"}]}}`,
-		ExpectedMsgStatus:   "W",
-		ExpectedExternalID:  "157b5e14568e8",
-		SendPrep:            setSendURL,
-	},
-}
-
 func mockAttachmentURLs(mediaServer *httptest.Server, testCases []OutgoingTestCase) []OutgoingTestCase {
 	casesWithMockedUrls := make([]OutgoingTestCase, len(testCases))
 
@@ -1108,15 +1093,6 @@ func TestOutgoing(t *testing.T) {
 			"version":      "v2.35.2",
 		})
 
-	var hsmSupportChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WA", "250788383383", "US",
-		map[string]any{
-			"auth_token":   "token123",
-			"base_url":     "https://foo.bar/",
-			"fb_namespace": "waba_namespace",
-			"hsm_support":  true,
-			"version":      "v2.35.2",
-		})
-
 	var d3Channel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "D3", "250788383383", "US",
 		map[string]any{
 			"auth_token":   "token123",
@@ -1134,7 +1110,6 @@ func TestOutgoing(t *testing.T) {
 		})
 
 	RunOutgoingTestCases(t, defaultChannel, newWAHandler(courier.ChannelType("WA"), "WhatsApp"), defaultSendTestCases, []string{"token123"}, nil)
-	RunOutgoingTestCases(t, hsmSupportChannel, newWAHandler(courier.ChannelType("WA"), "WhatsApp"), hsmSupportSendTestCases, []string{"token123"}, nil)
 	RunOutgoingTestCases(t, d3Channel, newWAHandler(courier.ChannelType("D3"), "360Dialog"), defaultSendTestCases, []string{"token123"}, nil)
 	RunOutgoingTestCases(t, txwChannel, newWAHandler(courier.ChannelType("TXW"), "TextIt"), defaultSendTestCases, []string{"token123"}, nil)
 


### PR DESCRIPTION
HSM templates were used in old docker API clients that are not longer supported, now we use template

And this is to prepare to support more complex templates components