### PR TITLE
Add user email and name to queued messages

### DIFF
--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -74,7 +74,6 @@ type Msg struct {
 	ModifiedOn_  time.Time      `                     db:"modified_on"`
 	QueuedOn_    time.Time      `                     db:"queued_on"`
 	SentOn_      *time.Time     `                     db:"sent_on"`
-	CreatedByID_ courier.UserID `json:"created_by_id" db:"created_by_id"`
 	LogUUIDs     pq.StringArray `                     db:"log_uuids"`
 
 	// extra non-model fields that mailroom will include in queued payload
@@ -85,6 +84,7 @@ type Msg struct {
 	IsResend_             bool                    `json:"is_resend"`
 	Flow_                 *courier.FlowReference  `json:"flow"`
 	OptIn_                *courier.OptInReference `json:"optin"`
+	User_                 *courier.UserReference  `json:"user"`
 	Origin_               courier.MsgOrigin       `json:"origin"`
 	ContactLastSeenOn_    *time.Time              `json:"contact_last_seen_on"`
 
@@ -164,7 +164,7 @@ func (m *Msg) SentOn() *time.Time             { return m.SentOn_ }
 func (m *Msg) IsResend() bool                 { return m.IsResend_ }
 func (m *Msg) Flow() *courier.FlowReference   { return m.Flow_ }
 func (m *Msg) OptIn() *courier.OptInReference { return m.OptIn_ }
-func (m *Msg) CreatedByID() courier.UserID    { return m.CreatedByID_ }
+func (m *Msg) User() *courier.UserReference   { return m.User_ }
 func (m *Msg) SessionStatus() string          { return m.SessionStatus_ }
 func (m *Msg) HighPriority() bool             { return m.HighPriority_ }
 

--- a/handlers/tembachat/handler.go
+++ b/handlers/tembachat/handler.go
@@ -72,10 +72,10 @@ func (h *handler) receiveMessage(ctx context.Context, c courier.Channel, w http.
 }
 
 type sendPayload struct {
-	Identifier string         `json:"identifier"`
-	Text       string         `json:"text"`
-	Origin     string         `json:"origin"`
-	UserID     courier.UserID `json:"user_id,omitempty"`
+	Identifier string                 `json:"identifier"`
+	Text       string                 `json:"text"`
+	Origin     string                 `json:"origin"`
+	User       *courier.UserReference `json:"user,omitempty"`
 }
 
 func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
@@ -85,7 +85,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.Ch
 		Identifier: msg.URN().Path(),
 		Text:       msg.Text(),
 		Origin:     string(msg.Origin()),
-		UserID:     msg.CreatedByID(),
+		User:       msg.User(),
 	}
 	req, _ := http.NewRequest("POST", sendURL, bytes.NewReader(jsonx.MustMarshal(payload)))
 

--- a/handlers/tembachat/handler_test.go
+++ b/handlers/tembachat/handler_test.go
@@ -79,11 +79,11 @@ var outgoingCases = []OutgoingTestCase{
 		Label:              "Chat message",
 		MsgText:            "Simple message ☺",
 		MsgURN:             "webchat:65vbbDAQCdPdEWlEhDGy4utO",
-		MsgCreatedByID:     7,
+		MsgUser:            &courier.UserReference{Email: "bob@nyaruka.com", Name: "Bob"},
 		MockResponseBody:   `{"status": "queued"}`,
 		MockResponseStatus: 200,
 		ExpectedRequests: []ExpectedRequest{
-			{Body: `{"identifier":"65vbbDAQCdPdEWlEhDGy4utO","text":"Simple message ☺","origin":"flow","user_id":7}`},
+			{Body: `{"identifier":"65vbbDAQCdPdEWlEhDGy4utO","text":"Simple message ☺","origin":"flow","user":{"email":"bob@nyaruka.com","name":"Bob"}}`},
 		},
 		ExpectedMsgStatus: "W",
 		SendPrep:          setSendURL,

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -315,8 +315,8 @@ type OutgoingTestCase struct {
 	MsgMetadata             json.RawMessage
 	MsgFlow                 *courier.FlowReference
 	MsgOptIn                *courier.OptInReference
+	MsgUser                 *courier.UserReference
 	MsgOrigin               courier.MsgOrigin
-	MsgCreatedByID          courier.UserID
 	MsgContactLastSeenOn    *time.Time
 
 	MockResponseStatus int
@@ -363,7 +363,6 @@ func RunOutgoingTestCases(t *testing.T, channel courier.Channel, handler courier
 
 			msg := mb.NewOutgoingMsg(channel, 10, urns.URN(tc.MsgURN), tc.MsgText, tc.MsgHighPriority, tc.MsgQuickReplies, tc.MsgTopic, tc.MsgResponseToExternalID, msgOrigin, tc.MsgContactLastSeenOn).(*test.MockMsg)
 			msg.WithLocale(tc.MsgLocale)
-			msg.WithCreatedByID(tc.MsgCreatedByID)
 
 			for _, a := range tc.MsgAttachments {
 				msg.WithAttachment(a)
@@ -379,6 +378,9 @@ func RunOutgoingTestCases(t *testing.T, channel courier.Channel, handler courier
 			}
 			if tc.MsgOptIn != nil {
 				msg.WithOptIn(tc.MsgOptIn)
+			}
+			if tc.MsgUser != nil {
+				msg.WithUser(tc.MsgUser)
 			}
 
 			actualRequests := make([]*http.Request, 0, 1)

--- a/msg.go
+++ b/msg.go
@@ -42,6 +42,11 @@ type OptInReference struct {
 	Name string `json:"name" validate:"required"`
 }
 
+type UserReference struct {
+	Email string `json:"email" validate:"required"`
+	Name  string `json:"name"`
+}
+
 type MsgOrigin string
 
 const (
@@ -50,10 +55,6 @@ const (
 	MsgOriginTicket    MsgOrigin = "ticket"
 	MsgOriginChat      MsgOrigin = "chat"
 )
-
-type UserID null.Int64
-
-var NilUserID = UserID(0)
 
 //-----------------------------------------------------------------------------
 // Msg interface
@@ -89,7 +90,7 @@ type MsgOut interface {
 	IsResend() bool
 	Flow() *FlowReference
 	OptIn() *OptInReference
-	CreatedByID() UserID
+	User() *UserReference
 	SessionStatus() string
 	HighPriority() bool
 }

--- a/test/msg.go
+++ b/test/msg.go
@@ -31,9 +31,9 @@ type MockMsg struct {
 	alreadyWritten       bool
 	isResend             bool
 
-	flow        *courier.FlowReference
-	optIn       *courier.OptInReference
-	createdByID courier.UserID
+	flow  *courier.FlowReference
+	optIn *courier.OptInReference
+	user  *courier.UserReference
 
 	receivedOn *time.Time
 	sentOn     *time.Time
@@ -72,7 +72,7 @@ func (m *MockMsg) SentOn() *time.Time             { return m.sentOn }
 func (m *MockMsg) IsResend() bool                 { return m.isResend }
 func (m *MockMsg) Flow() *courier.FlowReference   { return m.flow }
 func (m *MockMsg) OptIn() *courier.OptInReference { return m.optIn }
-func (m *MockMsg) CreatedByID() courier.UserID    { return m.createdByID }
+func (m *MockMsg) User() *courier.UserReference   { return m.user }
 func (m *MockMsg) SessionStatus() string          { return "" }
 func (m *MockMsg) HighPriority() bool             { return m.highPriority }
 
@@ -98,6 +98,6 @@ func (m *MockMsg) WithMetadata(metadata json.RawMessage) courier.MsgOut {
 }
 func (m *MockMsg) WithFlow(f *courier.FlowReference) courier.MsgOut   { m.flow = f; return m }
 func (m *MockMsg) WithOptIn(o *courier.OptInReference) courier.MsgOut { m.optIn = o; return m }
-func (m *MockMsg) WithCreatedByID(u courier.UserID) courier.MsgOut    { m.createdByID = u; return m }
+func (m *MockMsg) WithUser(u *courier.UserReference) courier.MsgOut   { m.user = u; return m }
 func (m *MockMsg) WithLocale(lc i18n.Locale) courier.MsgOut           { m.locale = lc; return m }
 func (m *MockMsg) WithURNAuth(token string) courier.MsgOut            { m.urnAuth = token; return m }


### PR DESCRIPTION
Just using user id worked with temba-chat because it can look up users, but we also want the new mailgun handler to know about who sent a message.. without courier having to look up users from the database.