### PR TITLE
Refactor sending to do less retrying and let handlers be dumber

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -27,12 +27,21 @@ type ChannelHandler interface {
 	UseChannelRouteUUID() bool
 	RedactValues(Channel) []string
 	GetChannel(context.Context, *http.Request) (Channel, error)
-	Send(context.Context, MsgOut, *ChannelLog) (StatusUpdate, error)
 
 	WriteStatusSuccessResponse(context.Context, http.ResponseWriter, []StatusUpdate) error
 	WriteMsgSuccessResponse(context.Context, http.ResponseWriter, []MsgIn) error
 	WriteRequestError(context.Context, http.ResponseWriter, error) error
 	WriteRequestIgnored(context.Context, http.ResponseWriter, string) error
+}
+
+type ChannelLegacyHandler interface {
+	ChannelHandler
+	Send(context.Context, MsgOut, *ChannelLog) (StatusUpdate, error)
+}
+
+type ChannelStdHandler interface {
+	ChannelHandler
+	Send(context.Context, MsgOut, *SendResult, *ChannelLog) error
 }
 
 // URNDescriber is the interface handlers which can look up URN metadata for new contacts should satisfy.

--- a/handler_test.go
+++ b/handler_test.go
@@ -69,7 +69,7 @@ func TestHandling(t *testing.T) {
 	assert.Len(mb.WrittenMsgStatuses(), 1)
 	status := mb.WrittenMsgStatuses()[0]
 	assert.Equal(msg.ID(), status.MsgID())
-	assert.Equal(courier.MsgStatusSent, status.Status())
+	assert.Equal(courier.MsgStatusWired, status.Status())
 
 	assert.Len(mb.WrittenChannelLogs(), 1)
 	clog := mb.WrittenChannelLogs()[0]

--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -114,21 +114,16 @@ func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w 
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.SendResult, clog *courier.ChannelLog) error {
 	isSharedStr := msg.Channel().ConfigForKey(configIsShared, false)
 	isShared, _ := isSharedStr.(bool)
 
 	username := msg.Channel().StringConfigForKey(courier.ConfigUsername, "")
-	if username == "" {
-		return nil, fmt.Errorf("no username set for AT channel")
-	}
-
 	apiKey := msg.Channel().StringConfigForKey(courier.ConfigAPIKey, "")
-	if apiKey == "" {
-		return nil, fmt.Errorf("no API key set for AT channel")
-	}
 
-	status := h.Backend().NewStatusUpdate(msg.Channel(), msg.ID(), courier.MsgStatusErrored, clog)
+	if username == "" || apiKey == "" {
+		return courier.ErrSendChannelConfig
+	}
 
 	// build our request
 	form := url.Values{
@@ -144,28 +139,28 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.Ch
 
 	req, err := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("apikey", apiKey)
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 != 2 {
-		return status, nil
+	if err != nil || resp.StatusCode/100 == 5 {
+		return courier.ErrSendConnection
 	}
 
 	// was this request successful?
 	msgStatus, _ := jsonparser.GetString(respBody, "SMSMessageData", "Recipients", "[0]", "status")
 	if msgStatus != "Success" {
-		status.SetStatus(courier.MsgStatusErrored)
-		return status, nil
+		return courier.ErrSendResponseUnexpected
 	}
 
 	// grab the external id if we can
 	externalID, _ := jsonparser.GetString(respBody, "SMSMessageData", "Recipients", "[0]", "messageId")
-	status.SetStatus(courier.MsgStatusWired)
-	status.SetExternalID(externalID)
+	if externalID != "" {
+		res.AddExternalID(externalID)
+	}
 
-	return status, nil
+	return nil
 }

--- a/handlers/africastalking/handler_test.go
+++ b/handlers/africastalking/handler_test.go
@@ -127,7 +127,6 @@ var outgoingTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"message": {"Simple Message ☺"}, "username": {"Username"}, "to": {"+250788383383"}, "from": {"2020"}}},
 		},
-		ExpectedMsgStatus:  "W",
 		ExpectedExternalID: "1002",
 		SendPrep:           setSendURL,
 	},
@@ -141,24 +140,23 @@ var outgoingTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"message": {"My pic!\nhttps://foo.bar/image.jpg"}, "username": {"Username"}, "to": {"+250788383383"}, "from": {"2020"}}},
 		},
-		ExpectedMsgStatus:  "W",
 		ExpectedExternalID: "1002",
 		SendPrep:           setSendURL,
 	},
 	{
-		Label:              "No External Id",
-		MsgText:            "No External ID",
+		Label:              "Explicit failed status",
+		MsgText:            "Hi",
 		MsgURN:             "tel:+250788383383",
 		MockResponseBody:   `{ "SMSMessageData": {"Recipients": [{"status": "Failed" }] } }`,
 		MockResponseStatus: 200,
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"message": {`No External ID`}, "username": {"Username"}, "to": {"+250788383383"}, "from": {"2020"}}},
+			{Form: url.Values{"message": {`Hi`}, "username": {"Username"}, "to": {"+250788383383"}, "from": {"2020"}}},
 		},
-		ExpectedMsgStatus: "E",
-		SendPrep:          setSendURL,
+		ExpectedError: courier.ErrSendResponseUnexpected,
+		SendPrep:      setSendURL,
 	},
 	{
-		Label:              "Error Sending",
+		Label:              "Missing status value",
 		MsgText:            "Error Message",
 		MsgURN:             "tel:+250788383383",
 		MockResponseBody:   `{ "error": "failed" }`,
@@ -166,8 +164,8 @@ var outgoingTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"message": {`Error Message`}, "username": {"Username"}, "to": {"+250788383383"}, "from": {"2020"}}},
 		},
-		ExpectedMsgStatus: "E",
-		SendPrep:          setSendURL,
+		ExpectedError: courier.ErrSendResponseUnexpected,
+		SendPrep:      setSendURL,
 	},
 }
 
@@ -182,7 +180,6 @@ var sharedSendTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"message": {"Simple Message ☺"}, "username": {"Username"}, "to": {"+250788383383"}}},
 		},
-		ExpectedMsgStatus:  "W",
 		ExpectedExternalID: "1002",
 		SendPrep:           setSendURL,
 	},

--- a/handlers/arabiacell/handler_test.go
+++ b/handlers/arabiacell/handler_test.go
@@ -74,7 +74,6 @@ var defaultSendTestCases = []OutgoingTestCase{
 				},
 			},
 		},
-		ExpectedMsgStatus:  "W",
 		ExpectedExternalID: "external1",
 		SendPrep:           setSendURL,
 	},
@@ -84,8 +83,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		MsgURN:             "tel:+250788383383",
 		MockResponseBody:   `not xml`,
 		MockResponseStatus: 200,
-		ExpectedMsgStatus:  "E",
-		ExpectedErrors:     []*courier.ChannelError{courier.ErrorResponseUnparseable("XML")},
+		ExpectedError:      courier.ErrSendResponseUnparseable,
 		SendPrep:           setSendURL,
 	},
 	{
@@ -94,8 +92,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		MsgURN:             "tel:+250788383383",
 		MockResponseBody:   `<response><code>501</code><text>failure</text><message_id></message_id></response>`,
 		MockResponseStatus: 200,
-		ExpectedMsgStatus:  "F",
-		ExpectedErrors:     []*courier.ChannelError{courier.ErrorResponseStatusCode()},
+		ExpectedError:      courier.ErrSendResponseUnexpected,
 		SendPrep:           setSendURL,
 	},
 	{
@@ -104,7 +101,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		MsgURN:             "tel:+250788383383",
 		MockResponseBody:   `Bad Gateway`,
 		MockResponseStatus: 501,
-		ExpectedMsgStatus:  "E",
+		ExpectedError:      courier.ErrSendConnection,
 		SendPrep:           setSendURL,
 	},
 }

--- a/handlers/tembachat/handler_test.go
+++ b/handlers/tembachat/handler_test.go
@@ -91,8 +91,7 @@ var outgoingCases = []OutgoingTestCase{
 				Body:   `{"chat_id":"65vbbDAQCdPdEWlEhDGy4utO","secret":"sesame","msg":{"id":10,"text":"Simple message ☺","origin":"flow"}}`,
 			},
 		},
-		ExpectedMsgStatus: "W",
-		SendPrep:          setSendURL,
+		SendPrep: setSendURL,
 	},
 	{
 		Label:              "Chat message",
@@ -107,14 +106,13 @@ var outgoingCases = []OutgoingTestCase{
 				Body:   `{"chat_id":"65vbbDAQCdPdEWlEhDGy4utO","secret":"sesame","msg":{"id":10,"text":"Simple message ☺","origin":"flow","user_id":123}}`,
 			},
 		},
-		ExpectedMsgStatus: "W",
-		SendPrep:          setSendURL,
+		SendPrep: setSendURL,
 	},
 	{
-		Label:              "Error sending",
+		Label:              "400 response",
 		MsgText:            "Error message",
 		MsgURN:             "webchat:65vbbDAQCdPdEWlEhDGy4utO",
-		MockResponseBody:   `{"error": "boom"}`,
+		MockResponseBody:   `{"error": "invalid"}`,
 		MockResponseStatus: 400,
 		ExpectedRequests: []ExpectedRequest{
 			{
@@ -122,8 +120,23 @@ var outgoingCases = []OutgoingTestCase{
 				Body:   `{"chat_id":"65vbbDAQCdPdEWlEhDGy4utO","secret":"sesame","msg":{"id":10,"text":"Error message","origin":"flow"}}`,
 			},
 		},
-		ExpectedMsgStatus: "E",
-		SendPrep:          setSendURL,
+		ExpectedError: courier.ErrSendResponseUnexpected,
+		SendPrep:      setSendURL,
+	},
+	{
+		Label:              "500 response",
+		MsgText:            "Error message",
+		MsgURN:             "webchat:65vbbDAQCdPdEWlEhDGy4utO",
+		MockResponseBody:   `Gateway Error`,
+		MockResponseStatus: 500,
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Params: url.Values{"channel": []string{"8eb23e93-5ecb-45ba-b726-3b064e0c56ab"}},
+				Body:   `{"chat_id":"65vbbDAQCdPdEWlEhDGy4utO","secret":"sesame","msg":{"id":10,"text":"Error message","origin":"flow"}}`,
+			},
+		},
+		ExpectedError: courier.ErrSendConnection,
+		SendPrep:      setSendURL,
 	},
 }
 

--- a/test/handler.go
+++ b/test/handler.go
@@ -44,7 +44,7 @@ func (h *mockHandler) Initialize(s courier.Server) error {
 }
 
 // Send sends the given message, logging any HTTP calls or errors
-func (h *mockHandler) Send(ctx context.Context, msg courier.MsgOut, clog *courier.ChannelLog) (courier.StatusUpdate, error) {
+func (h *mockHandler) Send(ctx context.Context, msg courier.MsgOut, res *courier.SendResult, clog *courier.ChannelLog) error {
 	// log a request that contains a header value that should be redacted
 	req, _ := httpx.NewRequest("GET", "http://mock.com/send", nil, map[string]string{"Authorization": "Token sesame"})
 	trace, _ := httpx.DoTrace(http.DefaultClient, req, nil, nil, 1024)
@@ -53,7 +53,7 @@ func (h *mockHandler) Send(ctx context.Context, msg courier.MsgOut, clog *courie
 	// log an error than contains a value that should be redacted
 	clog.Error(courier.NewChannelError("seeds", "", "contains sesame seeds"))
 
-	return h.backend.NewStatusUpdate(msg.Channel(), msg.ID(), courier.MsgStatusSent, clog), nil
+	return nil
 }
 
 func (h *mockHandler) WriteStatusSuccessResponse(ctx context.Context, w http.ResponseWriter, statuses []courier.StatusUpdate) error {


### PR DESCRIPTION
See #653 

 * Allows handlers to implement one of two interfaces that differ by send method to allow handlers to be rewritten piece meal.
 * New `Send` contract takes away need for handlers creating `StatusUpdate` objects - they return different error singletons and then sender determines whether message should be be retried.
 * Or for things like db errors.. they can return a regular `error` and that is treated as a logged, retryable internal error
 * Have send errors become channel log errors to avoid duplicating those.