### PR TITLE
Use ordered v7 UUIDs for channel logs

### DIFF
--- a/channel_log.go
+++ b/channel_log.go
@@ -129,7 +129,7 @@ func NewChannelLog(t ChannelLogType, ch Channel, redactVals []string) *ChannelLo
 
 func newChannelLog(t ChannelLogType, ch Channel, r *httpx.Recorder, attached bool, redactVals []string) *ChannelLog {
 	return &ChannelLog{
-		uuid:      ChannelLogUUID(uuids.NewV4()),
+		uuid:      ChannelLogUUID(uuids.NewV7()),
 		type_:     t,
 		channel:   ch,
 		recorder:  r,

--- a/channel_log_test.go
+++ b/channel_log_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nyaruka/courier"
 	"github.com/nyaruka/courier/test"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
@@ -23,7 +24,7 @@ func TestChannelLog(t *testing.T) {
 	}))
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
-	uuids.SetGenerator(uuids.NewSeededGenerator(1234, time.Now))
+	uuids.SetGenerator(uuids.NewSeededGenerator(1234, dates.NewSequentialNow(time.Date(2024, 9, 11, 14, 33, 0, 0, time.UTC), time.Second)))
 	defer uuids.SetGenerator(uuids.DefaultGenerator)
 
 	channel := test.NewMockChannel("fef91e9b-a6ed-44fb-b6ce-feed8af585a8", "NX", "1234", "US", []string{urns.Phone.Prefix}, nil)
@@ -46,7 +47,7 @@ func TestChannelLog(t *testing.T) {
 	clog.RawError(errors.New("this is an error"))
 	clog.End()
 
-	assert.Equal(t, courier.ChannelLogUUID("c00e5d67-c275-4389-aded-7d8b151cbd5b"), clog.UUID())
+	assert.Equal(t, courier.ChannelLogUUID("0191e180-7d60-7000-aded-7d8b151cbd5b"), clog.UUID())
 	assert.Equal(t, courier.ChannelLogTypeTokenRefresh, clog.Type())
 	assert.Equal(t, channel, clog.Channel())
 	assert.False(t, clog.Attached())

--- a/server_test.go
+++ b/server_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nyaruka/courier"
 	"github.com/nyaruka/courier/test"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
@@ -241,7 +242,7 @@ func TestFetchAttachment(t *testing.T) {
 	httpx.SetRequestor(httpMocks)
 
 	defer uuids.SetGenerator(uuids.DefaultGenerator)
-	uuids.SetGenerator(uuids.NewSeededGenerator(1234, time.Now))
+	uuids.SetGenerator(uuids.NewSeededGenerator(1234, dates.NewSequentialNow(time.Date(2024, 9, 11, 14, 33, 0, 0, time.UTC), time.Second)))
 
 	logger := slog.Default()
 	config := courier.NewDefaultConfig()
@@ -291,7 +292,7 @@ func TestFetchAttachment(t *testing.T) {
 
 	statusCode, respBody = submit(`{"channel_uuid": "e4bb1578-29da-4fa5-a214-9da19dd24230", "channel_type": "MCK", "url": "http://mock.com/media/hello.jpg"}`, "sesame")
 	assert.Equal(t, 200, statusCode)
-	assert.JSONEq(t, `{"attachment": {"content_type": "image/jpeg", "url": "https://backend.com/attachments/cdf7ed27-5ad5-4028-b664-880fc7581c77.jpg", "size": 17301}, "log_uuid": "c00e5d67-c275-4389-aded-7d8b151cbd5b"}`, string(respBody))
+	assert.JSONEq(t, `{"attachment": {"content_type": "image/jpeg", "url": "https://backend.com/attachments/cdf7ed27-5ad5-4028-b664-880fc7581c77.jpg", "size": 17301}, "log_uuid": "0191e180-7d60-7000-aded-7d8b151cbd5b"}`, string(respBody))
 
 	assert.Len(t, mb.WrittenChannelLogs(), 1)
 	clog := mb.WrittenChannelLogs()[0]
@@ -302,12 +303,12 @@ func TestFetchAttachment(t *testing.T) {
 	// if fetching attachment from channel returns non-200, return unavailable attachment so caller doesn't retry
 	statusCode, respBody = submit(`{"channel_uuid": "e4bb1578-29da-4fa5-a214-9da19dd24230", "channel_type": "MCK", "url": "http://mock.com/media/hello.mp3"}`, "sesame")
 	assert.Equal(t, 200, statusCode)
-	assert.JSONEq(t, `{"attachment": {"content_type": "unavailable", "url": "http://mock.com/media/hello.mp3", "size": 0}, "log_uuid": "547deaf7-7620-4434-95b3-58675999c4b7"}`, string(respBody))
+	assert.JSONEq(t, `{"attachment": {"content_type": "unavailable", "url": "http://mock.com/media/hello.mp3", "size": 0}, "log_uuid": "0191e180-8148-7000-95b3-58675999c4b7"}`, string(respBody))
 
 	// same if fetching attachment times out
 	statusCode, respBody = submit(`{"channel_uuid": "e4bb1578-29da-4fa5-a214-9da19dd24230", "channel_type": "MCK", "url": "http://mock.com/media/hello.pdf"}`, "sesame")
 	assert.Equal(t, 200, statusCode)
-	assert.JSONEq(t, `{"attachment": {"content_type": "unavailable", "url": "http://mock.com/media/hello.pdf", "size": 0}, "log_uuid": "338ff339-5663-49ed-8ef6-384876655d1b"}`, string(respBody))
+	assert.JSONEq(t, `{"attachment": {"content_type": "unavailable", "url": "http://mock.com/media/hello.pdf", "size": 0}, "log_uuid": "0191e180-8530-7000-8ef6-384876655d1b"}`, string(respBody))
 }
 
 // utility to send a message on a mocked backend and block until it's marked as sent


### PR DESCRIPTION
We currently put logs into S3 "subdirectories" using the first 4 chars of the UUID.. which will now be the same for all logs.. can't easily change that because RP infers it. I think it's only liable to be a problem if trying to browse logs for a big channel on the AWS console.