### PR TITLE
Replace variables with quotes

### DIFF
--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -429,6 +429,8 @@ func encodeVariables(variables map[string]string, contentType string) map[string
 
 func replaceVariables(text string, variables map[string]string) string {
 	for k, v := range variables {
+		text = strings.Replace(text, fmt.Sprintf("\"{{%s}}\"", k), v, -1)
+		text = strings.Replace(text, fmt.Sprintf("'{{%s}}'", k), v, -1)
 		text = strings.Replace(text, fmt.Sprintf("{{%s}}", k), v, -1)
 	}
 	return text

--- a/handlers/external/handler_test.go
+++ b/handlers/external/handler_test.go
@@ -936,6 +936,16 @@ func TestOutgoing(t *testing.T) {
 			courier.ConfigSendHeaders: map[string]any{"Authorization": "Token ABCDEF", "foo": "bar"},
 		})
 
+	var jsonQuotedVariablesChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
+		[]string{urns.Phone.Prefix},
+		map[string]any{
+			courier.ConfigSendURL:     "http://example.com/send",
+			courier.ConfigSendBody:    `{ "to":"{{to}}", "text":"{{text}}", "from":'{{from}}', "quick_replies":"{{quick_replies}}" }`,
+			courier.ConfigContentType: contentJSON,
+			courier.ConfigSendMethod:  http.MethodPost,
+			courier.ConfigSendHeaders: map[string]any{"Authorization": "Token ABCDEF", "foo": "bar"},
+		})
+
 	var xmlChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
@@ -963,6 +973,7 @@ func TestOutgoing(t *testing.T) {
 	RunOutgoingTestCases(t, postSmartChannel, newHandler(), postSendTestCases, nil, nil)
 	RunOutgoingTestCases(t, postSmartChannel, newHandler(), postSendSmartEncodingTestCases, nil, nil)
 	RunOutgoingTestCases(t, jsonChannel, newHandler(), jsonSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, jsonQuotedVariablesChannel, newHandler(), jsonSendTestCases, nil, nil)
 	RunOutgoingTestCases(t, xmlChannel, newHandler(), xmlSendTestCases, nil, nil)
 	RunOutgoingTestCases(t, xmlChannelWithResponseContent, newHandler(), xmlSendWithResponseContentTestCases, nil, nil)
 


### PR DESCRIPTION
This will allow support both 

The current expected config format for variables
`{'body': '{"from":{{from_no_plus}},"to":{{to_no_plus}},"text":{{text}} }', 'method': 'POST', 'encoding': 'D', 'send_url': 'XXXXXXXXX', 'max_length': 160, 'content_type': 'json', 'mt_response_check': '', 'send_authorization': ''}`

And not generate the wrong JSON for the following with quotes around variables as below
`{'body': '{"from":"{{from_no_plus}}","to":"{{to_no_plus}}","text":"{{text}}" }', 'method': 'POST', 'encoding': 'D', 'send_url': 'XXXXXXXXX', 'max_length': 160, 'content_type': 'json', 'mt_response_check': '', 'send_authorization': ''}`

Or even 
`{'body': '{"from":'{{from_no_plus}}',"to":'{{to_no_plus}}',"text":"{{text}}" }', 'method': 'POST', 'encoding': 'D', 'send_url': 'XXXXXXXXX', 'max_length': 160, 'content_type': 'json', 'mt_response_check': '', 'send_authorization': ''}`