### PR TITLE
Do not log response check error after 200 status

### DIFF
--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -156,7 +156,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	// was this request successful?
 	msgStatus, _ := jsonparser.GetString(respBody, "SMSMessageData", "Recipients", "[0]", "status")
 	if msgStatus != "Success" {
-		return courier.ErrResponseUnexpectedUnlogged
+		return courier.ErrResponseContent
 	}
 
 	// grab the external id if we can

--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -156,7 +156,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	// was this request successful?
 	msgStatus, _ := jsonparser.GetString(respBody, "SMSMessageData", "Recipients", "[0]", "status")
 	if msgStatus != "Success" {
-		return courier.ErrResponseUnexpected
+		return courier.ErrResponseUnexpectedUnlogged
 	}
 
 	// grab the external id if we can

--- a/handlers/africastalking/handler_test.go
+++ b/handlers/africastalking/handler_test.go
@@ -153,7 +153,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"message": {`Hi`}, "username": {"Username"}, "to": {"+250788383383"}, "from": {"2020"}}},
 		},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:   "Missing status value",

--- a/handlers/africastalking/handler_test.go
+++ b/handlers/africastalking/handler_test.go
@@ -153,7 +153,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"message": {`Hi`}, "username": {"Username"}, "to": {"+250788383383"}, "from": {"2020"}}},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Missing status value",

--- a/handlers/arabiacell/handler.go
+++ b/handlers/arabiacell/handler.go
@@ -100,7 +100,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		if response.Code == "204" {
 			res.AddExternalID(response.MessageID)
 		} else {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 	}
 

--- a/handlers/arabiacell/handler.go
+++ b/handlers/arabiacell/handler.go
@@ -100,7 +100,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		if response.Code == "204" {
 			res.AddExternalID(response.MessageID)
 		} else {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 	}
 

--- a/handlers/arabiacell/handler_test.go
+++ b/handlers/arabiacell/handler_test.go
@@ -88,7 +88,7 @@ var outgoingCases = []OutgoingTestCase{
 				httpx.NewMockResponse(200, nil, []byte(`<response><code>501</code><text>failure</text><message_id></message_id></response>`)),
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:   "Error Sending",

--- a/handlers/arabiacell/handler_test.go
+++ b/handlers/arabiacell/handler_test.go
@@ -88,7 +88,7 @@ var outgoingCases = []OutgoingTestCase{
 				httpx.NewMockResponse(200, nil, []byte(`<response><code>501</code><text>failure</text><message_id></message_id></response>`)),
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Error Sending",

--- a/handlers/bongolive/handler.go
+++ b/handlers/bongolive/handler.go
@@ -166,7 +166,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		msgStatus, _ := jsonparser.GetString(respBody, "results", "[0]", "status")
 		if msgStatus != "0" {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 
 		// grab the external id if we can

--- a/handlers/bongolive/handler.go
+++ b/handlers/bongolive/handler.go
@@ -166,7 +166,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		msgStatus, _ := jsonparser.GetString(respBody, "results", "[0]", "status")
 		if msgStatus != "0" {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 
 		// grab the external id if we can

--- a/handlers/bongolive/handler_test.go
+++ b/handlers/bongolive/handler_test.go
@@ -128,7 +128,7 @@ var outgoingCases = []OutgoingTestCase{
 				},
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Error status 403",

--- a/handlers/bongolive/handler_test.go
+++ b/handlers/bongolive/handler_test.go
@@ -128,7 +128,7 @@ var outgoingCases = []OutgoingTestCase{
 				},
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:   "Error status 403",

--- a/handlers/burstsms/handler.go
+++ b/handlers/burstsms/handler.go
@@ -94,7 +94,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		if response.MessageID != 0 {
 			res.AddExternalID(fmt.Sprintf("%d", response.MessageID))
 		} else {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 	}
 

--- a/handlers/burstsms/handler.go
+++ b/handlers/burstsms/handler.go
@@ -94,7 +94,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		if response.MessageID != 0 {
 			res.AddExternalID(fmt.Sprintf("%d", response.MessageID))
 		} else {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 	}
 

--- a/handlers/burstsms/handler_test.go
+++ b/handlers/burstsms/handler_test.go
@@ -114,7 +114,7 @@ var outgoingCases = []OutgoingTestCase{
 				},
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:   "Error Sending",

--- a/handlers/burstsms/handler_test.go
+++ b/handlers/burstsms/handler_test.go
@@ -114,7 +114,7 @@ var outgoingCases = []OutgoingTestCase{
 				},
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Error Sending",

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -188,7 +188,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		if externalID != "" {
 			res.AddExternalID(externalID)
 		} else {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 	}
 

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -188,7 +188,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		if externalID != "" {
 			res.AddExternalID(externalID)
 		} else {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 	}
 

--- a/handlers/clickatell/handler_test.go
+++ b/handlers/clickatell/handler_test.go
@@ -224,7 +224,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Params: url.Values{"content": {"Error Message"}, "to": {"250788383383"}, "from": {"2020"}, "apiKey": {"API-KEY"}}},
 		},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 }
 

--- a/handlers/clickatell/handler_test.go
+++ b/handlers/clickatell/handler_test.go
@@ -224,7 +224,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Params: url.Values{"content": {"Error Message"}, "to": {"250788383383"}, "from": {"2020"}, "apiKey": {"API-KEY"}}},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 }
 

--- a/handlers/clickmobile/handler.go
+++ b/handlers/clickmobile/handler.go
@@ -146,7 +146,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		responseCode, _ := jsonparser.GetString(respBody, "code")
 		if responseCode != "000" {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 	}
 

--- a/handlers/clickmobile/handler.go
+++ b/handlers/clickmobile/handler.go
@@ -146,7 +146,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		responseCode, _ := jsonparser.GetString(respBody, "code")
 		if responseCode != "000" {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 	}
 

--- a/handlers/clickmobile/handler_test.go
+++ b/handlers/clickmobile/handler_test.go
@@ -221,7 +221,7 @@ var outgoingCases = []OutgoingTestCase{
 				Body:    `{"app_id":"001-app","org_id":"001-org","user_id":"Username","timestamp":"20180411182430","auth_key":"3e1347ddb444d13aa23d11e097602be0","operation":"send","reference":"10","message_type":"1","src_address":"2020","dst_address":"+250788383383","message":"Simple Message"}`,
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 }
 

--- a/handlers/clickmobile/handler_test.go
+++ b/handlers/clickmobile/handler_test.go
@@ -206,6 +206,23 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 	},
+	{
+		Label:   "Response unexpected",
+		MsgText: "Simple Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://example.com/send": {
+				httpx.NewMockResponse(200, nil, []byte(`{"code":"001","desc":"Database SQL Error"}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Headers: map[string]string{"Content-Type": "application/json"},
+				Body:    `{"app_id":"001-app","org_id":"001-org","user_id":"Username","timestamp":"20180411182430","auth_key":"3e1347ddb444d13aa23d11e097602be0","operation":"send","reference":"10","message_type":"1","src_address":"2020","dst_address":"+250788383383","message":"Simple Message"}`,
+			},
+		},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/clicksend/handler.go
+++ b/handlers/clicksend/handler.go
@@ -93,14 +93,14 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		s, _ := jsonparser.GetString(respBody, "data", "messages", "[0]", "status")
 		if s != "SUCCESS" {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 
 		id, _ := jsonparser.GetString(respBody, "data", "messages", "[0]", "message_id")
 		if id != "" {
 			res.AddExternalID(id)
 		} else {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 	}
 

--- a/handlers/clicksend/handler.go
+++ b/handlers/clicksend/handler.go
@@ -93,14 +93,14 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		s, _ := jsonparser.GetString(respBody, "data", "messages", "[0]", "status")
 		if s != "SUCCESS" {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 
 		id, _ := jsonparser.GetString(respBody, "data", "messages", "[0]", "message_id")
 		if id != "" {
 			res.AddExternalID(id)
 		} else {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 	}
 

--- a/handlers/clicksend/handler_test.go
+++ b/handlers/clicksend/handler_test.go
@@ -186,7 +186,7 @@ var outgoingCases = []OutgoingTestCase{
 				Body:    `{"messages":[{"to":"+250788383383","from":"2020","body":"Error Sending","source":"courier"}]}`,
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 }
 

--- a/handlers/clicksend/handler_test.go
+++ b/handlers/clicksend/handler_test.go
@@ -215,7 +215,7 @@ var outgoingCases = []OutgoingTestCase{
 				Body:    `{"messages":[{"to":"+250788383383","from":"2020","body":"Error Sending","source":"courier"}]}`,
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Failure Response",
@@ -232,7 +232,7 @@ var outgoingCases = []OutgoingTestCase{
 				Body:    `{"messages":[{"to":"+250788383383","from":"2020","body":"Error Sending","source":"courier"}]}`,
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 }
 

--- a/handlers/clicksend/handler_test.go
+++ b/handlers/clicksend/handler_test.go
@@ -72,6 +72,35 @@ const successResponse = `{
 	]
 }`
 
+const successResponseMissingMessageID = `{
+	"http_code": 200,
+	"response_code": "SUCCESS",
+	"response_msg": "Here are your data.",
+	"data": {
+	  "total_price": 0.28,
+	  "total_count": 2,
+	  "queued_count": 2,
+	  "messages": [
+		{
+		  "direction": "out",
+		  "date": 1436871253,
+		  "to": "+61411111111",
+		  "body": "Jelly liquorice marshmallow candy carrot cake 4Eyffjs1vL.",
+		  "from": "sendmobile",
+		  "schedule": 1436874701,
+		  "message_id": "",
+		  "message_parts": 1,
+		  "message_price": 0.07,
+		  "custom_string": "this is a test",
+		  "user_id": 1,
+		  "subaccount_id": 1,
+		  "country": "AU",
+		  "carrier": "Telstra",
+		  "status": "SUCCESS"
+		}
+	]
+}`
+
 const failureResponse = `{
 	"http_code": 200,
 	"response_code": "SUCCESS",
@@ -178,6 +207,23 @@ var outgoingCases = []OutgoingTestCase{
 		MockResponses: map[string][]*httpx.MockResponse{
 			"https://rest.clicksend.com/v3/sms/send": {
 				httpx.NewMockResponse(200, nil, []byte(failureResponse)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Headers: map[string]string{"Authorization": "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="},
+				Body:    `{"messages":[{"to":"+250788383383","from":"2020","body":"Error Sending","source":"courier"}]}`,
+			},
+		},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+	},
+	{
+		Label:   "Failure Response",
+		MsgText: "Error Sending",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://rest.clicksend.com/v3/sms/send": {
+				httpx.NewMockResponse(200, nil, []byte(successResponseMissingMessageID)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -142,7 +142,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		// grab the external id
 		externalID, err := jsonparser.GetString(respBody, "sms_id")
 		if err != nil {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 
 		res.AddExternalID(externalID)

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -142,7 +142,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		// grab the external id
 		externalID, err := jsonparser.GetString(respBody, "sms_id")
 		if err != nil {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 
 		res.AddExternalID(externalID)

--- a/handlers/dmark/handler_test.go
+++ b/handlers/dmark/handler_test.go
@@ -131,7 +131,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 				"dlr_url":  {"https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&status=%s"},
 			},
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Error Sending",

--- a/handlers/dmark/handler_test.go
+++ b/handlers/dmark/handler_test.go
@@ -131,7 +131,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 				"dlr_url":  {"https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?id=10&status=%s"},
 			},
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:   "Error Sending",

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -366,7 +366,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 
 		if responseCheck != "" && !strings.Contains(string(respBody), responseCheck) {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 	}
 

--- a/handlers/external/handler_test.go
+++ b/handlers/external/handler_test.go
@@ -834,7 +834,7 @@ var xmlSendWithResponseContentTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
 			Body:    `<msg><to>+250788383383</to><text>Error Message</text><from>2020</from><quick_replies></quick_replies></msg>`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:          "Send Attachment",

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -238,12 +238,12 @@ func (h *handler) sendWithAPIKey(msg courier.MsgOut, res *courier.SendResult, cl
 		// was this successful
 		success, _ := jsonparser.GetInt(respBody, "success")
 		if success != 1 {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 
 		externalID, err := jsonparser.GetInt(respBody, "multicast_id")
 		if err != nil {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 		res.AddExternalID(fmt.Sprintf("%d", externalID))
 
@@ -319,15 +319,15 @@ func (h *handler) sendWithCredsJSON(msg courier.MsgOut, res *courier.SendResult,
 
 		responseName, err := jsonparser.GetString(respBody, "name")
 		if err != nil {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 
 		if !strings.Contains(responseName, fmt.Sprintf("projects/%s/messages/", projectID)) {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 		externalID := strings.TrimLeft(responseName, fmt.Sprintf("projects/%s/messages/", projectID))
 		if externalID == "" {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 
 		res.AddExternalID(externalID)

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -238,12 +238,12 @@ func (h *handler) sendWithAPIKey(msg courier.MsgOut, res *courier.SendResult, cl
 		// was this successful
 		success, _ := jsonparser.GetInt(respBody, "success")
 		if success != 1 {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 
 		externalID, err := jsonparser.GetInt(respBody, "multicast_id")
 		if err != nil {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 		res.AddExternalID(fmt.Sprintf("%d", externalID))
 
@@ -319,15 +319,15 @@ func (h *handler) sendWithCredsJSON(msg courier.MsgOut, res *courier.SendResult,
 
 		responseName, err := jsonparser.GetString(respBody, "name")
 		if err != nil {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 
 		if !strings.Contains(responseName, fmt.Sprintf("projects/%s/messages/", projectID)) {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 		externalID := strings.TrimLeft(responseName, fmt.Sprintf("projects/%s/messages/", projectID))
 		if externalID == "" {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 
 		res.AddExternalID(externalID)

--- a/handlers/firebase/handler_test.go
+++ b/handlers/firebase/handler_test.go
@@ -226,7 +226,7 @@ var sendAPIkeyTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Authorization": "key=FCMKey"},
 			Body:    `{"data":{"type":"rapidpro","title":"FCMTitle","message":"Error","message_id":10,"session_status":""},"content_available":false,"to":"auth1","priority":"high"}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:      "No Multicast ID",
@@ -242,7 +242,7 @@ var sendAPIkeyTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Authorization": "key=FCMKey"},
 			Body:    `{"data":{"type":"rapidpro","title":"FCMTitle","message":"Error","message_id":10,"session_status":""},"content_available":false,"to":"auth1","priority":"high"}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:      "Request Error",
@@ -353,7 +353,7 @@ var sendTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Authorization": "Bearer FCMToken"},
 			Body:    `{"message":{"data":{"type":"rapidpro","title":"FCMTitle","message":"Error","message_id":"10","session_status":""},"token":"auth1","android":{"priority":"high"}}}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:      "No Multicast ID",
@@ -369,7 +369,7 @@ var sendTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Authorization": "Bearer FCMToken"},
 			Body:    `{"message":{"data":{"type":"rapidpro","title":"FCMTitle","message":"Error","message_id":"10","session_status":""},"token":"auth1","android":{"priority":"high"}}}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:      "Request Error",

--- a/handlers/firebase/handler_test.go
+++ b/handlers/firebase/handler_test.go
@@ -387,6 +387,54 @@ var sendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrConnectionFailed,
 	},
+	{
+		Label:      "Response Unexpected",
+		MsgText:    "Simple Message",
+		MsgURN:     "fcm:250788123123",
+		MsgURNAuth: "auth1",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://fcm.googleapis.com/v1/projects/foo-project-id/messages:send": {
+				httpx.NewMockResponse(200, nil, []byte(`{"missing_name":"projects/foo-project-id/messages/123456-a"}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Authorization": "Bearer FCMToken"},
+			Body:    `{"message":{"data":{"type":"rapidpro","title":"FCMTitle","message":"Simple Message","message_id":"10","session_status":""},"token":"auth1","android":{"priority":"high"}}}`,
+		}},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+	},
+	{
+		Label:      "Response Unexpected",
+		MsgText:    "Simple Message",
+		MsgURN:     "fcm:250788123123",
+		MsgURNAuth: "auth1",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://fcm.googleapis.com/v1/projects/foo-project-id/messages:send": {
+				httpx.NewMockResponse(200, nil, []byte(`{"name":"projects/not-our-project-id/messages/123456-a"}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Authorization": "Bearer FCMToken"},
+			Body:    `{"message":{"data":{"type":"rapidpro","title":"FCMTitle","message":"Simple Message","message_id":"10","session_status":""},"token":"auth1","android":{"priority":"high"}}}`,
+		}},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+	},
+	{
+		Label:      "Response Unexpected",
+		MsgText:    "Simple Message",
+		MsgURN:     "fcm:250788123123",
+		MsgURNAuth: "auth1",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://fcm.googleapis.com/v1/projects/foo-project-id/messages:send": {
+				httpx.NewMockResponse(200, nil, []byte(`{"name":"projects/foo-project-id/messages/"}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Authorization": "Bearer FCMToken"},
+			Body:    `{"message":{"data":{"type":"rapidpro","title":"FCMTitle","message":"Simple Message","message_id":"10","session_status":""},"token":"auth1","android":{"priority":"high"}}}`,
+		}},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+	},
 }
 
 func setupBackend(mb *test.MockBackend) {

--- a/handlers/firebase/handler_test.go
+++ b/handlers/firebase/handler_test.go
@@ -226,7 +226,7 @@ var sendAPIkeyTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Authorization": "key=FCMKey"},
 			Body:    `{"data":{"type":"rapidpro","title":"FCMTitle","message":"Error","message_id":10,"session_status":""},"content_available":false,"to":"auth1","priority":"high"}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:      "No Multicast ID",
@@ -242,7 +242,7 @@ var sendAPIkeyTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Authorization": "key=FCMKey"},
 			Body:    `{"data":{"type":"rapidpro","title":"FCMTitle","message":"Error","message_id":10,"session_status":""},"content_available":false,"to":"auth1","priority":"high"}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:      "Request Error",
@@ -353,7 +353,7 @@ var sendTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Authorization": "Bearer FCMToken"},
 			Body:    `{"message":{"data":{"type":"rapidpro","title":"FCMTitle","message":"Error","message_id":"10","session_status":""},"token":"auth1","android":{"priority":"high"}}}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:      "No Multicast ID",
@@ -369,7 +369,7 @@ var sendTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Authorization": "Bearer FCMToken"},
 			Body:    `{"message":{"data":{"type":"rapidpro","title":"FCMTitle","message":"Error","message_id":"10","session_status":""},"token":"auth1","android":{"priority":"high"}}}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:      "Request Error",
@@ -401,7 +401,7 @@ var sendTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Authorization": "Bearer FCMToken"},
 			Body:    `{"message":{"data":{"type":"rapidpro","title":"FCMTitle","message":"Simple Message","message_id":"10","session_status":""},"token":"auth1","android":{"priority":"high"}}}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:      "Response Unexpected",
@@ -417,7 +417,7 @@ var sendTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Authorization": "Bearer FCMToken"},
 			Body:    `{"message":{"data":{"type":"rapidpro","title":"FCMTitle","message":"Simple Message","message_id":"10","session_status":""},"token":"auth1","android":{"priority":"high"}}}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:      "Response Unexpected",
@@ -433,7 +433,7 @@ var sendTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Authorization": "Bearer FCMToken"},
 			Body:    `{"message":{"data":{"type":"rapidpro","title":"FCMTitle","message":"Simple Message","message_id":"10","session_status":""},"token":"auth1","android":{"priority":"high"}}}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 }
 

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -214,7 +214,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	groupID, err := jsonparser.GetInt(respBody, "messages", "[0]", "status", "groupId")
 	if err != nil || (groupID != 1 && groupID != 3) {
-		return courier.ErrResponseUnexpected
+		return courier.ErrResponseUnexpectedUnlogged
 	}
 
 	externalID, err := jsonparser.GetString(respBody, "messages", "[0]", "messageId")

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -214,7 +214,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	groupID, err := jsonparser.GetInt(respBody, "messages", "[0]", "status", "groupId")
 	if err != nil || (groupID != 1 && groupID != 3) {
-		return courier.ErrResponseUnexpectedUnlogged
+		return courier.ErrResponseContent
 	}
 
 	externalID, err := jsonparser.GetString(respBody, "messages", "[0]", "messageId")

--- a/handlers/infobip/handler_test.go
+++ b/handlers/infobip/handler_test.go
@@ -393,7 +393,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			},
 			Body: `{"messages":[{"from":"2020","destinations":[{"to":"250788383383","messageId":"10"}],"text":"Simple Message","notifyContentType":"application/json","intermediateReport":true,"notifyUrl":"https://localhost/c/ib/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered"}]}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 }
 

--- a/handlers/infobip/handler_test.go
+++ b/handlers/infobip/handler_test.go
@@ -393,7 +393,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			},
 			Body: `{"messages":[{"from":"2020","destinations":[{"to":"250788383383","messageId":"10"}],"text":"Simple Message","notifyContentType":"application/json","intermediateReport":true,"notifyUrl":"https://localhost/c/ib/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered"}]}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 }
 

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -199,7 +199,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		clog.Error(courier.ErrorResponseValueMissing("status"))
 	}
 	if respStatus != "success" {
-		return courier.ErrResponseUnexpectedUnlogged
+		return courier.ErrResponseContent
 
 	}
 

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -199,7 +199,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		clog.Error(courier.ErrorResponseValueMissing("status"))
 	}
 	if respStatus != "success" {
-		return courier.ErrResponseUnexpected
+		return courier.ErrResponseUnexpectedUnlogged
 
 	}
 

--- a/handlers/justcall/handler_test.go
+++ b/handlers/justcall/handler_test.go
@@ -345,7 +345,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			},
 			Body: `{"from":"2020","to":"+250788383383","body":"Error"}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Error",

--- a/handlers/justcall/handler_test.go
+++ b/handlers/justcall/handler_test.go
@@ -345,7 +345,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			},
 			Body: `{"from":"2020","to":"+250788383383","body":"Error"}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:   "Error",

--- a/handlers/novo/handler.go
+++ b/handlers/novo/handler.go
@@ -115,7 +115,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		// we always get 204 on success
 		if responseMsgStatus != "FINISHED" || err != nil {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 	}
 

--- a/handlers/novo/handler.go
+++ b/handlers/novo/handler.go
@@ -115,7 +115,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		// we always get 204 on success
 		if responseMsgStatus != "FINISHED" || err != nil {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 	}
 

--- a/handlers/novo/handler_test.go
+++ b/handlers/novo/handler_test.go
@@ -120,7 +120,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{{
 			Params: url.Values{"from": {"2020"}, "to": {"18686846481"}, "msg": {"Invalid Parameters"}, "signature": {"4b640a668fd83223e38d429b15ea737ef58e1ab025b756baaca4743f3adb3f77"}},
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Error Response",

--- a/handlers/novo/handler_test.go
+++ b/handlers/novo/handler_test.go
@@ -120,7 +120,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{{
 			Params: url.Values{"from": {"2020"}, "to": {"18686846481"}, "msg": {"Invalid Parameters"}, "signature": {"4b640a668fd83223e38d429b15ea737ef58e1ab025b756baaca4743f3adb3f77"}},
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:   "Error Response",

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -178,7 +178,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		externalID, err := jsonparser.GetString(respBody, "message_uuid", "[0]")
 		if err != nil {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 
 		res.AddExternalID(externalID)

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -178,7 +178,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		externalID, err := jsonparser.GetString(respBody, "message_uuid", "[0]")
 		if err != nil {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 
 		res.AddExternalID(externalID)

--- a/handlers/plivo/handler_test.go
+++ b/handlers/plivo/handler_test.go
@@ -151,7 +151,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			},
 			Body: `{"src":"2020","dst":"250788383383","text":"No External ID","url":"https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status","method":"POST"}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{Label: "Error Sending",
 		MsgText: "Error Message",

--- a/handlers/plivo/handler_test.go
+++ b/handlers/plivo/handler_test.go
@@ -151,7 +151,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			},
 			Body: `{"src":"2020","dst":"250788383383","text":"No External ID","url":"https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status","method":"POST"}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{Label: "Error Sending",
 		MsgText: "Error Message",

--- a/handlers/rocketchat/handler.go
+++ b/handlers/rocketchat/handler.go
@@ -140,7 +140,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	msgID, err := jsonparser.GetString(respBody, "id")
 	if err != nil {
-		return courier.ErrResponseUnexpectedUnlogged
+		return courier.ErrResponseContent
 	}
 	res.AddExternalID(msgID)
 

--- a/handlers/rocketchat/handler.go
+++ b/handlers/rocketchat/handler.go
@@ -140,7 +140,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	msgID, err := jsonparser.GetString(respBody, "id")
 	if err != nil {
-		return courier.ErrResponseUnexpected
+		return courier.ErrResponseUnexpectedUnlogged
 	}
 	res.AddExternalID(msgID)
 

--- a/handlers/rocketchat/handler_test.go
+++ b/handlers/rocketchat/handler_test.go
@@ -178,6 +178,20 @@ var sendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrConnectionFailed,
 	},
+	{
+		Label:   "Response Unexpected",
+		MsgText: "Simple Message",
+		MsgURN:  "rocketchat:direct:john.doe#john.doe",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": {
+				httpx.NewMockResponse(201, nil, []byte(`{"missing":"0"}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"user":"direct:john.doe","bot":"rocket.cat","text":"Simple Message"}`,
+		}},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/rocketchat/handler_test.go
+++ b/handlers/rocketchat/handler_test.go
@@ -190,7 +190,7 @@ var sendTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{{
 			Body: `{"user":"direct:john.doe","bot":"rocket.cat","text":"Simple Message"}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 }
 

--- a/handlers/slack/handler.go
+++ b/handlers/slack/handler.go
@@ -205,13 +205,13 @@ func (h *handler) sendTextMsgPart(msg courier.MsgOut, token string, clog *courie
 
 	ok, err := jsonparser.GetBoolean(respBody, "ok")
 	if err != nil {
-		return courier.ErrResponseUnexpected
+		return courier.ErrResponseUnexpectedUnlogged
 	}
 
 	if !ok {
 		errDescription, err := jsonparser.GetString(respBody, "error")
 		if err != nil {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 		clog.Error(clogs.NewLogError("", "", errDescription))
 		return courier.ErrFailedWithReason("", errDescription)
@@ -284,7 +284,7 @@ func (h *handler) sendFilePart(msg courier.MsgOut, token string, fileParams *Fil
 	}
 
 	if !fr.OK {
-		return courier.ErrResponseUnexpected
+		return courier.ErrResponseUnexpectedUnlogged
 	}
 
 	return nil

--- a/handlers/slack/handler.go
+++ b/handlers/slack/handler.go
@@ -205,13 +205,13 @@ func (h *handler) sendTextMsgPart(msg courier.MsgOut, token string, clog *courie
 
 	ok, err := jsonparser.GetBoolean(respBody, "ok")
 	if err != nil {
-		return courier.ErrResponseUnexpectedUnlogged
+		return courier.ErrResponseContent
 	}
 
 	if !ok {
 		errDescription, err := jsonparser.GetString(respBody, "error")
 		if err != nil {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 		clog.Error(clogs.NewLogError("", "", errDescription))
 		return courier.ErrFailedWithReason("", errDescription)
@@ -284,7 +284,7 @@ func (h *handler) sendFilePart(msg courier.MsgOut, token string, fileParams *Fil
 	}
 
 	if !fr.OK {
-		return courier.ErrResponseUnexpectedUnlogged
+		return courier.ErrResponseContent
 	}
 
 	return nil

--- a/handlers/slack/handler_test.go
+++ b/handlers/slack/handler_test.go
@@ -215,6 +215,28 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError:     courier.ErrFailedWithReason("", "invalid_auth"),
 		ExpectedLogErrors: []*clogs.LogError{clogs.NewLogError("", "", "invalid_auth")},
 	},
+	{
+		Label:   "Response Unexpected",
+		MsgText: "Simple Message",
+		MsgURN:  "slack:U0123ABCDEF",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/chat.postMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{"channel":"U0123ABCDEF"}`)),
+			},
+		},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+	},
+	{
+		Label:   "Response Unexpected",
+		MsgText: "Simple Message",
+		MsgURN:  "slack:U0123ABCDEF",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/chat.postMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{"ok":false,"channel":"U0123ABCDEF"}`)),
+			},
+		},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+	},
 }
 
 var fileSendTestCases = []OutgoingTestCase{
@@ -235,6 +257,25 @@ var fileSendTestCases = []OutgoingTestCase{
 			{},
 			{BodyContains: "image.png"},
 		},
+	},
+	{
+		Label:          "Unexpected Response",
+		MsgText:        "",
+		MsgURN:         "slack:U0123ABCDEF",
+		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.png"},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/image.png": {
+				httpx.NewMockResponse(200, nil, []byte(`filetype... ...file bytes... ...end`)),
+			},
+			"*/files.upload": {
+				httpx.NewMockResponse(200, nil, []byte(`{"ok":false,"file":{"id":"F1L3SL4CK1D"}}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{},
+			{BodyContains: "image.png"},
+		},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 }
 

--- a/handlers/slack/handler_test.go
+++ b/handlers/slack/handler_test.go
@@ -224,7 +224,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 				httpx.NewMockResponse(200, nil, []byte(`{"channel":"U0123ABCDEF"}`)),
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Response Unexpected",
@@ -235,7 +235,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 				httpx.NewMockResponse(200, nil, []byte(`{"ok":false,"channel":"U0123ABCDEF"}`)),
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 }
 
@@ -275,7 +275,7 @@ var fileSendTestCases = []OutgoingTestCase{
 			{},
 			{BodyContains: "image.png"},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 }
 

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -174,7 +174,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 
 		if response.ID == "" {
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 
 		res.AddExternalID(response.ID)

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -174,7 +174,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 
 		if response.ID == "" {
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 
 		res.AddExternalID(response.ID)

--- a/handlers/start/handler_test.go
+++ b/handlers/start/handler_test.go
@@ -260,6 +260,24 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Response Unexpected",
+		MsgText: "Simple Message ☺",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://bulk.startmobile.ua/clients.php": {
+				httpx.NewMockResponse(200, nil, []byte(`<status date='Wed, 25 May 2016 17:29:56 +0300'><id></id><state>Accepted</state></status>`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{
+				"Content-Type":  "application/xml; charset=utf8",
+				"Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
+			},
+			Body: `<message><service id="single" source="2020" validity="+12 hours"></service><to>+250788383383</to><body content-type="plain/text" encoding="plain">Simple Message ☺</body></message>`,
+		}},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/start/handler_test.go
+++ b/handlers/start/handler_test.go
@@ -276,7 +276,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			},
 			Body: `<message><service id="single" source="2020" validity="+12 hours"></service><to>+250788383383</to><body content-type="plain/text" encoding="plain">Simple Message ☺</body></message>`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 }
 

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -179,7 +179,7 @@ func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.V
 	if response.Result.MessageID > 0 {
 		return strconv.FormatInt(response.Result.MessageID, 10), nil
 	}
-	return "", courier.ErrResponseUnexpected
+	return "", courier.ErrResponseUnexpectedUnlogged
 }
 
 func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.SendResult, clog *courier.ChannelLog) error {

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -179,7 +179,7 @@ func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.V
 	if response.Result.MessageID > 0 {
 		return strconv.FormatInt(response.Result.MessageID, 10), nil
 	}
-	return "", courier.ErrResponseUnexpectedUnlogged
+	return "", courier.ErrResponseContent
 }
 
 func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.SendResult, clog *courier.ChannelLog) error {

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -931,7 +931,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"text": {"Simple Message"}, "chat_id": {"12345"}, "parse_mode": []string{"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:             "Unknown attachment type",

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -920,6 +920,20 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
+		Label:   "Response Unexpected",
+		MsgText: "Simple Message",
+		MsgURN:  "telegram:12345",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 0 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Simple Message"}, "chat_id": {"12345"}, "parse_mode": []string{"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+		},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+	},
+	{
 		Label:             "Unknown attachment type",
 		MsgText:           "My foo!",
 		MsgURN:            "telegram:12345",

--- a/handlers/telesom/handler.go
+++ b/handlers/telesom/handler.go
@@ -109,7 +109,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		if !strings.Contains(string(respBody), "Success") {
 			clog.Error(clogs.NewLogError("", "", "Received invalid response content: %s", string(respBody)))
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 	}
 

--- a/handlers/telesom/handler.go
+++ b/handlers/telesom/handler.go
@@ -109,7 +109,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		if !strings.Contains(string(respBody), "Success") {
 			clog.Error(clogs.NewLogError("", "", "Received invalid response content: %s", string(respBody)))
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 	}
 

--- a/handlers/telesom/handler_test.go
+++ b/handlers/telesom/handler_test.go
@@ -173,7 +173,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 		}},
 		ExpectedLogErrors: []*clogs.LogError{clogs.NewLogError("", "", "Received invalid response content: <return>Missing</return>")},
-		ExpectedError:     courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError:     courier.ErrResponseContent,
 	},
 }
 

--- a/handlers/telesom/handler_test.go
+++ b/handlers/telesom/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nyaruka/courier"
 	. "github.com/nyaruka/courier/handlers"
 	"github.com/nyaruka/courier/test"
+	"github.com/nyaruka/courier/utils/clogs"
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
@@ -157,6 +158,22 @@ var defaultSendTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 		}},
 		ExpectedError: courier.ErrConnectionFailed,
+	},
+	{
+		Label:   "Response Unexpected",
+		MsgText: "Simple Message",
+		MsgURN:  "tel:+252788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://telesom.com/sendsms_other*": {
+				httpx.NewMockResponse(200, nil, []byte(`<return>Missing</return>`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Form:    url.Values{"msg": {"Simple Message"}, "to": {"0788383383"}, "from": {"2020"}, "key": {"D69BB824F88F20482B94ECF3822EBD84"}},
+			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+		}},
+		ExpectedLogErrors: []*clogs.LogError{clogs.NewLogError("", "", "Received invalid response content: <return>Missing</return>")},
+		ExpectedError:     courier.ErrResponseUnexpectedUnlogged,
 	},
 }
 

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -173,7 +173,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		externalID, err := jsonparser.GetString(respBody, "guid")
 		if err != nil {
 			clog.Error(courier.ErrorResponseValueMissing("guid"))
-			return courier.ErrResponseUnexpected
+			return courier.ErrResponseUnexpectedUnlogged
 		}
 
 		res.AddExternalID(externalID)
@@ -207,7 +207,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 			externalID, err := jsonparser.GetString(respBody, "guid")
 			if err != nil {
 				clog.Error(courier.ErrorResponseValueMissing("guid"))
-				return courier.ErrResponseUnexpected
+				return courier.ErrResponseUnexpectedUnlogged
 			}
 
 			res.AddExternalID(externalID)

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -173,7 +173,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		externalID, err := jsonparser.GetString(respBody, "guid")
 		if err != nil {
 			clog.Error(courier.ErrorResponseValueMissing("guid"))
-			return courier.ErrResponseUnexpectedUnlogged
+			return courier.ErrResponseContent
 		}
 
 		res.AddExternalID(externalID)
@@ -207,7 +207,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 			externalID, err := jsonparser.GetString(respBody, "guid")
 			if err != nil {
 				clog.Error(courier.ErrorResponseValueMissing("guid"))
-				return courier.ErrResponseUnexpectedUnlogged
+				return courier.ErrResponseContent
 			}
 
 			res.AddExternalID(externalID)

--- a/handlers/thinq/handler_test.go
+++ b/handlers/thinq/handler_test.go
@@ -156,7 +156,7 @@ var sendTestCases = []OutgoingTestCase{
 			Body: `{"from_did":"2065551212","to_did":"2067791234","message":"No External ID"}`,
 		}},
 		ExpectedLogErrors: []*clogs.LogError{courier.ErrorResponseValueMissing("guid")},
-		ExpectedError:     courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError:     courier.ErrResponseContent,
 	},
 	{
 		Label:   "Error Sending",
@@ -200,7 +200,7 @@ var sendTestCases = []OutgoingTestCase{
 			Body:    `{"from_did":"2065551212","to_did":"2067791234","message":"Simple Message ☺"}`,
 		}},
 		ExpectedLogErrors: []*clogs.LogError{courier.ErrorResponseValueMissing("guid")},
-		ExpectedError:     courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError:     courier.ErrResponseContent,
 	},
 }
 

--- a/handlers/thinq/handler_test.go
+++ b/handlers/thinq/handler_test.go
@@ -186,6 +186,22 @@ var sendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrConnectionFailed,
 	},
+	{
+		Label:   "Reponse Unexpected",
+		MsgText: "Simple Message ☺",
+		MsgURN:  "tel:+12067791234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.thinq.com/account/1234/product/origination/sms/send": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "missing": "1002" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Authorization": "Basic dXNlcjE6c2VzYW1l"},
+			Body:    `{"from_did":"2065551212","to_did":"2067791234","message":"Simple Message ☺"}`,
+		}},
+		ExpectedLogErrors: []*clogs.LogError{courier.ErrorResponseValueMissing("guid")},
+		ExpectedError:     courier.ErrResponseUnexpectedUnlogged,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/thinq/handler_test.go
+++ b/handlers/thinq/handler_test.go
@@ -156,7 +156,7 @@ var sendTestCases = []OutgoingTestCase{
 			Body: `{"from_did":"2065551212","to_did":"2067791234","message":"No External ID"}`,
 		}},
 		ExpectedLogErrors: []*clogs.LogError{courier.ErrorResponseValueMissing("guid")},
-		ExpectedError:     courier.ErrResponseUnexpected,
+		ExpectedError:     courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:   "Error Sending",

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -406,7 +406,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	externalMsgId, err := jsonparser.GetInt(respBody, responseOutgoingMessageKey)
 	if err != nil {
-		return courier.ErrResponseUnexpectedUnlogged
+		return courier.ErrResponseContent
 	}
 
 	res.AddExternalID(strconv.FormatInt(externalMsgId, 10))

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -406,7 +406,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	externalMsgId, err := jsonparser.GetInt(respBody, responseOutgoingMessageKey)
 	if err != nil {
-		return courier.ErrResponseUnexpected
+		return courier.ErrResponseUnexpectedUnlogged
 	}
 
 	res.AddExternalID(strconv.FormatInt(externalMsgId, 10))

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -516,7 +516,7 @@ var outgoingCases = []OutgoingTestCase{
 				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "message": {"Simple message"}, "random_id": {"10"}, "user_id": {"123456789"}, "v": {"5.103"}},
 			},
 		},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 }
 

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -502,6 +502,22 @@ var outgoingCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrConnectionFailed,
 	},
+	{
+		Label:   "Response unexpected",
+		MsgText: "Simple message",
+		MsgURN:  "vk:123456789",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.vk.com/method/messages.send.json?*": {
+				httpx.NewMockResponse(200, nil, []byte(`{"missing": 1}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "message": {"Simple message"}, "random_id": {"10"}, "user_id": {"123456789"}, "v": {"5.103"}},
+			},
+		},
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/whatsapp_legacy/handler.go
+++ b/handlers/whatsapp_legacy/handler.go
@@ -1060,7 +1060,7 @@ func getSendWhatsAppMsgId(resp []byte) (string, error) {
 	if externalID, err := jsonparser.GetString(resp, "messages", "[0]", "id"); err == nil {
 		return externalID, nil
 	} else {
-		return "", courier.ErrResponseUnexpected
+		return "", courier.ErrResponseUnexpectedUnlogged
 	}
 }
 

--- a/handlers/whatsapp_legacy/handler.go
+++ b/handlers/whatsapp_legacy/handler.go
@@ -1060,7 +1060,7 @@ func getSendWhatsAppMsgId(resp []byte) (string, error) {
 	if externalID, err := jsonparser.GetString(resp, "messages", "[0]", "id"); err == nil {
 		return externalID, nil
 	} else {
-		return "", courier.ErrResponseUnexpectedUnlogged
+		return "", courier.ErrResponseContent
 	}
 }
 

--- a/handlers/whatsapp_legacy/handler_test.go
+++ b/handlers/whatsapp_legacy/handler_test.go
@@ -628,7 +628,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			Path: "/v1/messages",
 			Body: `{"to":"250788123123","type":"text","text":{"body":"Error"}}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Error Field",

--- a/handlers/whatsapp_legacy/handler_test.go
+++ b/handlers/whatsapp_legacy/handler_test.go
@@ -628,7 +628,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			Path: "/v1/messages",
 			Body: `{"to":"250788123123","type":"text","text":{"body":"Error"}}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:   "Error Field",

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -143,7 +143,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 			if len(createStatus) > 0 && createStatus[0] == "OK" {
 				return nil
 			} else {
-				return courier.ErrResponseUnexpectedUnlogged
+				return courier.ErrResponseContent
 			}
 		}
 	}

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -143,7 +143,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 			if len(createStatus) > 0 && createStatus[0] == "OK" {
 				return nil
 			} else {
-				return courier.ErrResponseUnexpected
+				return courier.ErrResponseUnexpectedUnlogged
 			}
 		}
 	}

--- a/handlers/yo/handler_test.go
+++ b/handlers/yo/handler_test.go
@@ -93,7 +93,7 @@ var getSendTestCases = []OutgoingTestCase{
 			"password":     {"yo-password"},
 			"origin":       {"2020"},
 		}}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{Label: "Unicode Send",
 		MsgText: "☺", MsgURN: "tel:+250788383383",

--- a/handlers/yo/handler_test.go
+++ b/handlers/yo/handler_test.go
@@ -93,7 +93,7 @@ var getSendTestCases = []OutgoingTestCase{
 			"password":     {"yo-password"},
 			"origin":       {"2020"},
 		}}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{Label: "Unicode Send",
 		MsgText: "☺", MsgURN: "tel:+250788383383",

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -242,7 +242,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	externalID, err := jsonparser.GetString(respBody, "id")
 	if err != nil {
-		return courier.ErrResponseUnexpectedUnlogged
+		return courier.ErrResponseContent
 	}
 	res.AddExternalID(externalID)
 	return nil

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -242,7 +242,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	externalID, err := jsonparser.GetString(respBody, "id")
 	if err != nil {
-		return courier.ErrResponseUnexpected
+		return courier.ErrResponseUnexpectedUnlogged
 	}
 	res.AddExternalID(externalID)
 	return nil

--- a/handlers/zenvia/handlers_test.go
+++ b/handlers/zenvia/handlers_test.go
@@ -319,7 +319,7 @@ var defaultWhatsappSendTestCases = []OutgoingTestCase{
 			},
 			Body: `{"from":"2020","to":"250788383383","contents":[{"type":"text","text":"No External ID"}]}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Error Sending",
@@ -427,7 +427,7 @@ var defaultSMSSendTestCases = []OutgoingTestCase{
 			},
 			Body: `{"from":"2020","to":"250788383383","contents":[{"type":"text","text":"No External ID"}]}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
+		ExpectedError: courier.ErrResponseContent,
 	},
 	{
 		Label:   "Error Sending",

--- a/handlers/zenvia/handlers_test.go
+++ b/handlers/zenvia/handlers_test.go
@@ -319,7 +319,7 @@ var defaultWhatsappSendTestCases = []OutgoingTestCase{
 			},
 			Body: `{"from":"2020","to":"250788383383","contents":[{"type":"text","text":"No External ID"}]}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:   "Error Sending",
@@ -427,7 +427,7 @@ var defaultSMSSendTestCases = []OutgoingTestCase{
 			},
 			Body: `{"from":"2020","to":"250788383383","contents":[{"type":"text","text":"No External ID"}]}`,
 		}},
-		ExpectedError: courier.ErrResponseUnexpected,
+		ExpectedError: courier.ErrResponseUnexpectedUnlogged,
 	},
 	{
 		Label:   "Error Sending",

--- a/sender.go
+++ b/sender.go
@@ -110,7 +110,7 @@ var ErrResponseUnexpected error = &SendError{
 	clogMsg:   "Response doesn't match expected values.",
 }
 
-// ErrResponseContent is same as ErrResponseUnexpected without logging so better for channels where response check is user configured.
+// ErrResponseContent is same as ErrResponseUnexpected without logging so better for channels where response check is user configured. We conside this message failed when the response content is unexpected
 var ErrResponseContent error = &SendError{
 	msg:       "response not expected values",
 	retryable: false,

--- a/sender.go
+++ b/sender.go
@@ -110,8 +110,8 @@ var ErrResponseUnexpected error = &SendError{
 	clogMsg:   "Response doesn't match expected values.",
 }
 
-// ErrResponseUnexpectedUnlogged is same as ErrResponseUnexpected without logging so better for channels where response check is user configured.
-var ErrResponseUnexpectedUnlogged error = &SendError{
+// ErrResponseContent is same as ErrResponseUnexpected without logging so better for channels where response check is user configured.
+var ErrResponseContent error = &SendError{
 	msg:       "response not expected values",
 	retryable: false,
 	loggable:  false,


### PR DESCRIPTION
The current behaviour is that the message is failed and we log a report to sentry
This changes to not log to sentry for these issues 