### PR TITLE
Add additional stopped condition for Telegram

### DIFF
--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -167,7 +167,7 @@ func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.V
 	err = json.Unmarshal(respBody, response)
 
 	if err != nil || resp.StatusCode/100 != 2 || !response.Ok {
-		if response.ErrorCode == 403 && response.Description == "Forbidden: bot was blocked by the user" {
+		if response.ErrorCode == 403 && (response.Description == "Forbidden: bot was blocked by the user" || response.Description == "Forbidden: user is deactivated") {
 			return "", courier.ErrContactStopped
 		} else if response.ErrorCode > 0 {
 			return "", courier.ErrFailedWithReason(strconv.Itoa(response.ErrorCode), response.Description)


### PR DESCRIPTION
Currently a 403 with a description of `Forbidden: bot was blocked by the user` will generate a stopped contact event, this also will handle a 403 with a description of `Forbidden: user is deactivated`
