### PR TITLE
Change the `Event` interface to use UUIDs

### DIFF
--- a/backends/rapidpro/channel_event.go
+++ b/backends/rapidpro/channel_event.go
@@ -61,7 +61,7 @@ func newChannelEvent(channel courier.Channel, eventType models.ChannelEventType,
 	}
 }
 
-func (e *ChannelEvent) EventID() int64                     { return int64(e.ID_) }
+func (e *ChannelEvent) EventUUID() uuids.UUID              { return uuids.UUID(e.UUID_) }
 func (e *ChannelEvent) UUID() models.ChannelEventUUID      { return e.UUID_ }
 func (e *ChannelEvent) ChannelID() models.ChannelID        { return e.ChannelID_ }
 func (e *ChannelEvent) ChannelUUID() models.ChannelUUID    { return e.ChannelUUID_ }

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -104,7 +104,7 @@ func newMsg(direction models.MsgDirection, channel courier.Channel, urn urns.URN
 	}
 }
 
-func (m *Msg) EventID() int64           { return int64(m.ID_) }
+func (m *Msg) EventUUID() uuids.UUID    { return uuids.UUID(m.UUID_) }
 func (m *Msg) ID() models.MsgID         { return m.ID_ }
 func (m *Msg) UUID() models.MsgUUID     { return m.UUID_ }
 func (m *Msg) ExternalID() string       { return string(m.ExternalID_) }

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -21,10 +21,12 @@ import (
 	"github.com/nyaruka/courier/runtime"
 	"github.com/nyaruka/courier/test"
 	"github.com/nyaruka/courier/utils/clogs"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/gocommon/uuids"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -159,6 +161,14 @@ func RunIncomingTestCases(t *testing.T, channels []courier.Channel, handler cour
 		mb.AddChannel(ch)
 	}
 	handler.Initialize(s)
+
+	mockNow := dates.NewSequentialNow(time.Date(2025, 10, 13, 11, 20, 0, 0, time.UTC), time.Second)
+
+	uuids.SetGenerator(uuids.NewSeededGenerator(1234, mockNow))
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
+
+	dates.SetNowFunc(mockNow)
+	defer dates.SetNowFunc(time.Now)
 
 	for _, tc := range testCases {
 		t.Run(tc.Label, func(t *testing.T) {

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -282,7 +282,7 @@ func writeWelcomeMessageResponse(w http.ResponseWriter, channel courier.Channel,
 		AuthToken:    authToken,
 		Text:         msgText,
 		Type:         "text",
-		TrackingData: fmt.Sprintf("%d", event.EventID()),
+		TrackingData: string(event.EventUUID()),
 	}
 
 	responseBody := &bytes.Buffer{}

--- a/handlers/viber/handler_test.go
+++ b/handlers/viber/handler_test.go
@@ -633,8 +633,12 @@ var testCases = []IncomingTestCase{
 		},
 		PrepRequest: addValidSignature,
 	},
-	{Label: "Unsubcribe Invalid URN", URL: receiveURL, Data: invalidURNUnsubscribed, ExpectedRespStatus: 400, ExpectedBodyContains: "invalid viber id", PrepRequest: addValidSignature},
-	{Label: "Conversation Started", URL: receiveURL, Data: validConversationStarted, ExpectedRespStatus: 200, ExpectedBodyContains: "ignored conversation start", PrepRequest: addValidSignature},
+	{
+		Label: "Unsubcribe Invalid URN", URL: receiveURL, Data: invalidURNUnsubscribed, ExpectedRespStatus: 400, ExpectedBodyContains: "invalid viber id", PrepRequest: addValidSignature,
+	},
+	{
+		Label: "Conversation Started", URL: receiveURL, Data: validConversationStarted, ExpectedRespStatus: 200, ExpectedBodyContains: "ignored conversation start", PrepRequest: addValidSignature,
+	},
 	{Label: "Unexpected event", URL: receiveURL, Data: unexpectedEvent, ExpectedRespStatus: 400,
 		ExpectedBodyContains: "not handled, unknown event: unexpected", PrepRequest: addValidSignature},
 	{Label: "Message missing text", URL: receiveURL, Data: rejectedMessage, ExpectedRespStatus: 400, ExpectedBodyContains: "missing text or media in message in request body", PrepRequest: addValidSignature},
@@ -672,7 +676,7 @@ var testWelcomeMessageCases = []IncomingTestCase{
 		URL:                  receiveURL,
 		Data:                 validConversationStarted,
 		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `{"auth_token":"Token","text":"Welcome to VP, Please subscribe here for more.","type":"text","tracking_data":"0"}`,
+		ExpectedBodyContains: `{"auth_token":"Token","text":"Welcome to VP, Please subscribe here for more.","type":"text","tracking_data":"0199dd4c-8a88-7000-95b3-58675999c4b7"}`,
 		ExpectedEvents: []ExpectedEvent{
 			{Type: models.EventTypeWelcomeMessage, URN: "viber:xy5/5y6O81+/kbWHpLhBoA=="},
 		},

--- a/interfaces.go
+++ b/interfaces.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nyaruka/courier/core/models"
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/gocommon/uuids"
 )
 
 // Channel defines the general interface backend Channel implementations must adhere to
@@ -40,7 +41,7 @@ type Contact interface {
 
 // Event is our interface for the types of things a ChannelHandleFunc can return.
 type Event interface {
-	EventID() int64
+	EventUUID() uuids.UUID
 }
 
 // Msg is our interface for common methods for an incoming or outgoing message

--- a/test/backend.go
+++ b/test/backend.go
@@ -249,6 +249,7 @@ func (mb *MockBackend) WriteStatusUpdate(ctx context.Context, status courier.Sta
 // NewChannelEvent creates a new channel event with the passed in parameters
 func (mb *MockBackend) NewChannelEvent(channel courier.Channel, eventType models.ChannelEventType, urn urns.URN, clog *courier.ChannelLog) courier.ChannelEvent {
 	return &mockChannelEvent{
+		uuid:      models.ChannelEventUUID(uuids.NewV7()),
 		channel:   channel,
 		eventType: eventType,
 		urn:       urn,

--- a/test/channel_event.go
+++ b/test/channel_event.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nyaruka/courier"
 	"github.com/nyaruka/courier/core/models"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/gocommon/uuids"
 )
 
 type mockChannelEvent struct {
@@ -21,7 +22,7 @@ type mockChannelEvent struct {
 	extra         map[string]string
 }
 
-func (e *mockChannelEvent) EventID() int64                     { return 0 }
+func (e *mockChannelEvent) EventUUID() uuids.UUID              { return uuids.UUID(e.uuid) }
 func (e *mockChannelEvent) UUID() models.ChannelEventUUID      { return e.uuid }
 func (e *mockChannelEvent) ChannelUUID() models.ChannelUUID    { return e.channel.UUID() }
 func (e *mockChannelEvent) EventType() models.ChannelEventType { return e.eventType }

--- a/test/msg.go
+++ b/test/msg.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nyaruka/courier/core/models"
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/gocommon/uuids"
 )
 
 type MockMsg struct {
@@ -50,7 +51,7 @@ func NewMockMsg(id models.MsgID, uuid models.MsgUUID, channel courier.Channel, u
 	}
 }
 
-func (m *MockMsg) EventID() int64           { return int64(m.id) }
+func (m *MockMsg) EventUUID() uuids.UUID    { return uuids.UUID(m.uuid) }
 func (m *MockMsg) ID() models.MsgID         { return m.id }
 func (m *MockMsg) UUID() models.MsgUUID     { return m.uuid }
 func (m *MockMsg) ExternalID() string       { return m.externalID }

--- a/test/status.go
+++ b/test/status.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nyaruka/courier"
 	"github.com/nyaruka/courier/core/models"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/gocommon/uuids"
 )
 
 type MockStatusUpdate struct {
@@ -18,7 +19,7 @@ type MockStatusUpdate struct {
 	createdOn  time.Time
 }
 
-func (m *MockStatusUpdate) EventID() int64                  { return int64(m.msgID) }
+func (m *MockStatusUpdate) EventUUID() uuids.UUID           { return uuids.NewV4() } // TODO should become message UUID
 func (m *MockStatusUpdate) ChannelUUID() models.ChannelUUID { return m.channel.UUID() }
 func (m *MockStatusUpdate) MsgID() models.MsgID             { return m.msgID }
 


### PR DESCRIPTION
This is only used to limit the types returnable from handler functions.. so it's ok that for now status updates return a nonsense UUID and we'll soon update those to be message UUID based.