### PR TITLE
Reorganize command modules

### DIFF
--- a/cmd/base.go
+++ b/cmd/base.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Run logs the given error and exits with a non-zero status code if err is not nil.
+func Run(err error) {
+	if err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
+}

--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -1,16 +1,10 @@
 package main
 
 import (
-	"log/slog"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
+	"github.com/nyaruka/courier/cmd"
 
-	"github.com/getsentry/sentry-go"
-	"github.com/nyaruka/courier"
-	slogmulti "github.com/samber/slog-multi"
-	slogsentry "github.com/samber/slog-sentry/v2"
+	// load available backends
+	_ "github.com/nyaruka/courier/backends/rapidpro"
 
 	// load channel handler packages
 	_ "github.com/nyaruka/courier/handlers/africastalking"
@@ -71,11 +65,6 @@ import (
 	_ "github.com/nyaruka/courier/handlers/whatsapp_legacy"
 	_ "github.com/nyaruka/courier/handlers/yo"
 	_ "github.com/nyaruka/courier/handlers/zenvia"
-	"github.com/nyaruka/courier/runtime"
-
-	// load available backends
-	"github.com/nyaruka/courier/backends/rapidpro"
-	_ "github.com/nyaruka/courier/backends/rapidpro"
 )
 
 var (
@@ -85,51 +74,5 @@ var (
 )
 
 func main() {
-	cfg := runtime.LoadConfig()
-	cfg.Version = version
-
-	// configure our logger
-	logHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: cfg.LogLevel})
-	slog.SetDefault(slog.New(logHandler))
-
-	// if we have a DSN entry, try to initialize it
-	if cfg.SentryDSN != "" {
-		err := sentry.Init(sentry.ClientOptions{Dsn: cfg.SentryDSN, ServerName: cfg.InstanceID, Release: version, AttachStacktrace: true})
-		if err != nil {
-			slog.Error("error initiating sentry client", "error", err, "dsn", cfg.SentryDSN)
-			os.Exit(1)
-		}
-
-		defer sentry.Flush(2 * time.Second)
-
-		slog.SetDefault(slog.New(
-			slogmulti.Fanout(
-				logHandler,
-				slogsentry.Option{Level: slog.LevelError}.NewSentryHandler(),
-			),
-		))
-	}
-
-	log := slog.With("comp", "main")
-	log.Info("starting courier", "version", version, "released", date)
-
-	rt, err := runtime.NewRuntime(cfg)
-	if err != nil {
-		slog.Error("error creating runtime", "error", err)
-		os.Exit(1)
-	}
-
-	backend := rapidpro.NewBackend(rt)
-
-	server := courier.NewServer(cfg, backend)
-	if err := server.Start(); err != nil {
-		log.Error("unable to start server", "error", err)
-		os.Exit(1)
-	}
-
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-	log.Info("stopping", "comp", "main", "signal", <-ch)
-
-	server.Stop()
+	cmd.Run(cmd.Service(version, date))
 }

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -58,8 +58,7 @@ func Service(version, date string) error {
 
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-	log.Info("stopping", "comp", "main", "signal", <-ch)
+	log.Info("stopping", "signal", <-ch)
 
-	server.Stop()
-	return nil
+	return server.Stop()
 }

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/nyaruka/courier"
+	"github.com/nyaruka/courier/backends/rapidpro"
+	"github.com/nyaruka/courier/runtime"
+	slogmulti "github.com/samber/slog-multi"
+	slogsentry "github.com/samber/slog-sentry/v2"
+)
+
+// Service starts the courier service, blocks until a termination signal is received, then stops it.
+func Service(version, date string) error {
+	cfg := runtime.LoadConfig()
+	cfg.Version = version
+
+	// configure our logger
+	logHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: cfg.LogLevel})
+	slog.SetDefault(slog.New(logHandler))
+
+	// if we have a DSN entry, try to initialize it
+	if cfg.SentryDSN != "" {
+		err := sentry.Init(sentry.ClientOptions{Dsn: cfg.SentryDSN, ServerName: cfg.InstanceID, Release: version, AttachStacktrace: true})
+		if err != nil {
+			return err
+		}
+
+		defer sentry.Flush(2 * time.Second)
+
+		slog.SetDefault(slog.New(
+			slogmulti.Fanout(
+				logHandler,
+				slogsentry.Option{Level: slog.LevelError}.NewSentryHandler(),
+			),
+		))
+	}
+
+	log := slog.With("comp", "main")
+	log.Info("starting courier", "version", version, "released", date)
+
+	rt, err := runtime.NewRuntime(cfg)
+	if err != nil {
+		return err
+	}
+
+	backend := rapidpro.NewBackend(rt)
+
+	server := courier.NewServer(cfg, backend)
+	if err := server.Start(); err != nil {
+		return err
+	}
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	log.Info("stopping", "comp", "main", "signal", <-ch)
+
+	server.Stop()
+	return nil
+}


### PR DESCRIPTION
## Summary
- Move service start/stop logic out of `cmd/courier/main.go` into a reusable `cmd.Service(version, date) error` in `cmd/service.go`
- Add a small `cmd.Run(err)` helper in `cmd/base.go` so command entry points are one-liners
- `cmd/courier/main.go` is now just blank handler/backend imports plus `cmd.Run(cmd.Service(version, date))`

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/...`