### PR TITLE
Drop deprecated /c/_fetch-attachment endpoint

### DIFF
--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -65,7 +65,7 @@ func writeMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLo
 	channel := m.Channel()
 
 	// check for data: attachment URLs which need to be fetched now - fetching of other URLs can be deferred until
-	// message handling and performed by calling the /c/_fetch-attachment endpoint
+	// message handling and performed by calling the /ci/attachment/fetch endpoint
 	for i, attURL := range m.Attachments_ {
 		if strings.HasPrefix(attURL, "data:") {
 			attData, err := base64.StdEncoding.DecodeString(attURL[5:])

--- a/server.go
+++ b/server.go
@@ -90,9 +90,6 @@ func (s *Server) Start() error {
 	s.router.Get("/status", s.basicAuthRequired(s.handleStatus))
 	s.router.Post("/ci/attachment/fetch", s.tokenAuthRequired(s.handleFetchAttachment))
 
-	// deprecated - kept for backwards compatibility
-	s.publicRouter.Post("/_fetch-attachment", s.tokenAuthRequired(s.handleFetchAttachment)) // becomes /c/_fetch-attachment
-
 	// initialize our handlers
 	s.initializeChannelHandlers()
 


### PR DESCRIPTION
Removes the deprecated `/c/_fetch-attachment` route which was kept for backwards compatibility. The replacement `/ci/attachment/fetch` has been in place for a while and mailroom is the only known caller — it was switched over in nyaruka/mailroom#1071.

Also updates a stale comment in `backends/rapidpro/msg.go` to reference the new path.

**Deploy ordering:** the mailroom PR needs to ship before/with this one, otherwise attachment fetching breaks.

## Test plan
- [x] `go build ./...`
- [x] `go test -p=1 .` (server tests, which already hit `/ci/attachment/fetch`)