### PR TITLE
Log warning when /c/* webhook arrives over plaintext HTTP

### DIFF
--- a/server.go
+++ b/server.go
@@ -55,6 +55,7 @@ func NewServerWithLogger(config *runtime.Config, backend Backend, logger *slog.L
 	router.Use(middleware.Timeout(30 * time.Second))
 
 	publicRouter := chi.NewRouter()
+	publicRouter.Use(logPlaintextWebhook)
 	router.Mount("/c/", publicRouter)
 
 	return &Server{
@@ -366,6 +367,20 @@ func (s *Server) handle405(w http.ResponseWriter, r *http.Request) {
 		slog.Error("error writing response", "error", err)
 
 	}
+}
+
+func logPlaintextWebhook(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Forwarded-Proto") == "http" {
+			slog.Warn("plaintext webhook",
+				"path", r.URL.Path,
+				"method", r.Method,
+				"ua", r.UserAgent(),
+				"from", r.Header.Get("X-Forwarded-For"),
+			)
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // wraps a handler to make it use basic auth


### PR DESCRIPTION
## Summary
- Adds a small chi middleware on `publicRouter` that emits a `WARN` slog line whenever an incoming `/c/*` request has `X-Forwarded-Proto: http`.
- Captures path, method, user-agent, and `X-Forwarded-For` so we can identify which provider sent it.
- Scoped to `/c/*` only — `/status` and `/ci/*` are unaffected.

## Why
We're about to flip the ALBs' `:80` default action from `forward` to a 301 redirect to HTTPS. Before doing that on the production ALBs, we want telemetry that tells us if any channel provider is still hitting plaintext on `/c/*` (which would break for any client that doesn't follow 301s).

## Test plan
- [x] `docker exec dev-courier go test -p=1 ./...` — full suite green.
- [ ] After deploy, send a plaintext request to `/c/<type>/<uuid>` on a staging-internet ALB and confirm a `plaintext webhook` warn line appears in the courier logs.
- [ ] Confirm normal `https` `/c/*` traffic does not log anything.