### PR TITLE
Remove plaintext HTTP webhook logging

### DIFF
--- a/server.go
+++ b/server.go
@@ -55,7 +55,6 @@ func NewServerWithLogger(config *runtime.Config, backend Backend, logger *slog.L
 	router.Use(middleware.Timeout(30 * time.Second))
 
 	publicRouter := chi.NewRouter()
-	publicRouter.Use(logPlaintextWebhook)
 	router.Mount("/c/", publicRouter)
 
 	return &Server{
@@ -367,20 +366,6 @@ func (s *Server) handle405(w http.ResponseWriter, r *http.Request) {
 		slog.Error("error writing response", "error", err)
 
 	}
-}
-
-func logPlaintextWebhook(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-Forwarded-Proto") == "http" {
-			slog.Warn("plaintext webhook",
-				"path", r.URL.Path,
-				"method", r.Method,
-				"ua", r.UserAgent(),
-				"from", r.Header.Get("X-Forwarded-For"),
-			)
-		}
-		next.ServeHTTP(w, r)
-	})
 }
 
 // wraps a handler to make it use basic auth


### PR DESCRIPTION
## Summary
- Removes the temporary `logPlaintextWebhook` middleware added in 348735a8 and its registration on the `/c/` router.
- The warning was only added to confirm whether any provider still hits the ALB's :80 listener; it's no longer needed.

## Test plan
- [x] `go build ./...` passes