### PR TITLE
Expose internal endpoint on separate listener port, add /ping

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -22,9 +22,11 @@ type Config struct {
 	SpoolDir  string `help:"the local directory where courier will write statuses or msgs that need to be retried (needs to be writable)"`
 	SentryDSN string `help:"the DSN used for logging errors to Sentry"`
 
-	Domain  string `help:"the domain courier is exposed on"`
-	Address string `help:"the network interface address courier will bind to"`
-	Port    int    `help:"the port courier will listen on"`
+	Domain          string `help:"the domain courier is exposed on"`
+	PublicAddress   string `help:"the network interface address our public web server will bind to"`
+	PublicPort      int    `help:"the port our public web server will listen on"`
+	InternalAddress string `help:"the network interface address our internal web server will bind to"`
+	InternalPort    int    `help:"the port our internal web server will listen on"`
 
 	AWSAccessKeyID     string `help:"access key ID to use for AWS services"`
 	AWSSecretAccessKey string `help:"secret access key to use for AWS services"`
@@ -70,9 +72,11 @@ func NewDefaultConfig() *Config {
 		Valkey:   "valkey://valkey:6379/15",
 		SpoolDir: "/var/spool/courier",
 
-		Domain:  "localhost",
-		Address: "",
-		Port:    8080,
+		Domain:          "localhost",
+		PublicAddress:   "",
+		PublicPort:      8080,
+		InternalAddress: "localhost",
+		InternalPort:    8081,
 
 		AWSAccessKeyID:     "",
 		AWSSecretAccessKey: "",

--- a/server.go
+++ b/server.go
@@ -46,23 +46,21 @@ func NewServer(config *runtime.Config, backend Backend) *Server {
 // NewServerWithLogger creates a new Server for the passed in configuration. The server will have to be started
 // afterwards, which is when configuration options are checked.
 func NewServerWithLogger(config *runtime.Config, backend Backend, logger *slog.Logger) *Server {
-	router := chi.NewRouter()
-	router.Use(middleware.Compress(flate.DefaultCompression))
-	router.Use(middleware.StripSlashes)
-	router.Use(middleware.RequestID)
-	router.Use(middleware.RealIP)
-	router.Use(middleware.Recoverer)
-	router.Use(middleware.Timeout(30 * time.Second))
+	// channelRouter holds the dynamically-registered channel handler routes - mounted at /c/ on the public listener
+	channelRouter := chi.NewRouter()
 
-	publicRouter := chi.NewRouter()
-	router.Mount("/c/", publicRouter)
+	// testRouter mounts channelRouter at /c/ so handler tests can dispatch requests via Router() without
+	// having to spin up the full public listener stack
+	testRouter := chi.NewRouter()
+	testRouter.Use(middleware.StripSlashes)
+	testRouter.Mount("/c/", channelRouter)
 
 	return &Server{
 		config:  config,
 		backend: backend,
 
-		router:       router,
-		publicRouter: publicRouter,
+		channelRouter: channelRouter,
+		testRouter:    testRouter,
 
 		stopChan:  make(chan bool),
 		waitGroup: &sync.WaitGroup{},
@@ -83,42 +81,77 @@ func (s *Server) Start() error {
 	// start our spool flushers
 	startSpoolFlushers(s)
 
-	// wire up our main pages
-	s.router.NotFound(s.handle404)
-	s.router.MethodNotAllowed(s.handle405)
-	s.router.Get("/", s.handleIndex)
-	s.router.Get("/status", s.basicAuthRequired(s.handleStatus))
-	s.router.Post("/ci/attachment/fetch", s.tokenAuthRequired(s.handleFetchAttachment))
-
-	// initialize our handlers
+	// initialize our handlers (wires routes into channelRouter)
 	s.initializeChannelHandlers()
 
-	// configure timeouts on our server
-	s.httpServer = &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", s.config.Address, s.config.Port),
-		Handler:      s.router,
+	// public listener — exposes /, /status, /c/*, /ping, and (during transition) /ci/* as well
+	publicRouter := chi.NewRouter()
+	publicRouter.Use(middleware.Compress(flate.DefaultCompression))
+	publicRouter.Use(middleware.StripSlashes)
+	publicRouter.Use(middleware.RequestID)
+	publicRouter.Use(middleware.RealIP)
+	publicRouter.Use(middleware.Recoverer)
+	publicRouter.Use(middleware.Timeout(30 * time.Second))
+	publicRouter.NotFound(s.handle404("public"))
+	publicRouter.MethodNotAllowed(s.handle405("public"))
+	publicRouter.Get("/", s.handleIndex)
+	publicRouter.Get("/ping", handlePing)
+	publicRouter.Get("/status", s.basicAuthRequired(s.handleStatus))
+	publicRouter.Post("/ci/attachment/fetch", s.tokenAuthRequired(s.handleFetchAttachment))
+	publicRouter.Mount("/c/", s.channelRouter)
+
+	// internal listener — only /ci/* routes and /ping, no public-facing concerns
+	internalRouter := chi.NewRouter()
+	internalRouter.Use(middleware.Compress(flate.DefaultCompression))
+	internalRouter.Use(middleware.StripSlashes)
+	internalRouter.Use(middleware.RequestID)
+	internalRouter.Use(middleware.Recoverer)
+	internalRouter.Use(middleware.Timeout(30 * time.Second))
+	internalRouter.NotFound(s.handle404("internal"))
+	internalRouter.MethodNotAllowed(s.handle405("internal"))
+	internalRouter.Get("/ping", handlePing)
+	internalRouter.Post("/ci/attachment/fetch", s.tokenAuthRequired(s.handleFetchAttachment))
+
+	s.publicServer = &http.Server{
+		Addr:         fmt.Sprintf("%s:%d", s.config.PublicAddress, s.config.PublicPort),
+		Handler:      publicRouter,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 45 * time.Second,
+		IdleTimeout:  90 * time.Second,
+	}
+	s.internalServer = &http.Server{
+		Addr:         fmt.Sprintf("%s:%d", s.config.InternalAddress, s.config.InternalPort),
+		Handler:      internalRouter,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 45 * time.Second,
 		IdleTimeout:  90 * time.Second,
 	}
 
-	s.waitGroup.Add(1)
+	s.waitGroup.Add(2)
 
-	// and start serving HTTP
 	go func() {
 		defer s.waitGroup.Done()
-		err := s.httpServer.ListenAndServe()
+
+		log := slog.With("comp", "server", "listener", "public", "address", s.publicServer.Addr)
+		log.Info("server started", "version", s.config.Version)
+
+		err := s.publicServer.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
-			slog.Error("failed to start server", "error", err, "comp", "server", "state", "stopping")
+			log.Error("error listening", "error", err)
 		}
 	}()
 
-	slog.Info(fmt.Sprintf("server listening on %d", s.config.Port),
-		"comp", "server",
-		"port", s.config.Port,
-		"state", "started",
-		"version", s.config.Version,
-	)
+	go func() {
+		defer s.waitGroup.Done()
+
+		log := slog.With("comp", "server", "listener", "internal", "address", s.internalServer.Addr)
+		log.Info("server started", "version", s.config.Version)
+
+		err := s.internalServer.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			log.Error("error listening", "error", err)
+		}
+	}()
 
 	// start our foreman for outgoing messages
 	s.foreman = NewForeman(s, s.config.MaxWorkers)
@@ -135,9 +168,12 @@ func (s *Server) Stop() error {
 	// stop our foreman
 	s.foreman.Stop()
 
-	// shut down our HTTP server
-	if err := s.httpServer.Shutdown(context.Background()); err != nil {
-		log.Error("error shutting down server", "error", err, "state", "stopping")
+	// shut down both HTTP servers
+	if err := s.publicServer.Shutdown(context.Background()); err != nil {
+		log.Error("error shutting down server", "listener", "public", "error", err, "state", "stopping")
+	}
+	if err := s.internalServer.Shutdown(context.Background()); err != nil {
+		log.Error("error shutting down server", "listener", "internal", "error", err, "state", "stopping")
 	}
 
 	// stop everything
@@ -164,14 +200,15 @@ func (s *Server) Config() *runtime.Config    { return s.config }
 func (s *Server) Stopped() bool              { return s.stopped }
 
 func (s *Server) Backend() Backend   { return s.backend }
-func (s *Server) Router() chi.Router { return s.router }
+func (s *Server) Router() chi.Router { return s.testRouter }
 
 type Server struct {
 	backend Backend
 
-	httpServer   *http.Server
-	router       *chi.Mux
-	publicRouter *chi.Mux
+	publicServer   *http.Server
+	internalServer *http.Server
+	channelRouter  *chi.Mux
+	testRouter     *chi.Mux
 
 	foreman *Foreman
 
@@ -299,7 +336,7 @@ func (s *Server) AddHandlerRoute(handler ChannelHandler, method string, action s
 	if action != "" {
 		path = fmt.Sprintf("%s/%s", path, action)
 	}
-	s.publicRouter.Method(method, path, s.channelHandleWrapper(handler, handlerFunc, logType))
+	s.channelRouter.Method(method, path, s.channelHandleWrapper(handler, handlerFunc, logType))
 	s.chanRoutes = append(s.chanRoutes, fmt.Sprintf("%-20s - %s %s", "/c"+path, handler.ChannelName(), action))
 }
 
@@ -349,23 +386,45 @@ func (s *Server) handleFetchAttachment(w http.ResponseWriter, r *http.Request) {
 	w.Write(jsonx.MustMarshal(resp))
 }
 
-func (s *Server) handle404(w http.ResponseWriter, r *http.Request) {
-	slog.Info("not found", "url", r.URL.String(), "method", r.Method, "resp_status", "404")
-	errors := []any{NewErrorData(fmt.Sprintf("not found: %s", r.URL.String()))}
-	err := WriteDataResponse(w, http.StatusNotFound, "Not Found", errors)
-	if err != nil {
-		slog.Error("error writing response", "error", err)
+// handle404 returns a 404 handler. The internal listener logs at Error level (sentry-routed via slog-sentry)
+// so we alert on caller-side bugs in rapidpro/mailroom that hit unknown internal paths.
+func (s *Server) handle404(listener string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if listener == "internal" {
+			slog.Error("not found", "listener", listener, "url", r.URL.String(), "method", r.Method, "resp_status", "404")
+		} else {
+			slog.Info("not found", "listener", listener, "url", r.URL.String(), "method", r.Method, "resp_status", "404")
+		}
+		errors := []any{NewErrorData(fmt.Sprintf("not found: %s", r.URL.String()))}
+		err := WriteDataResponse(w, http.StatusNotFound, "Not Found", errors)
+		if err != nil {
+			slog.Error("error writing response", "error", err)
+		}
 	}
 }
 
-func (s *Server) handle405(w http.ResponseWriter, r *http.Request) {
-	slog.Info("invalid method", "url", r.URL.String(), "method", r.Method, "resp_status", "405")
-	errors := []any{NewErrorData(fmt.Sprintf("method not allowed: %s", r.Method))}
-	err := WriteDataResponse(w, http.StatusMethodNotAllowed, "Method Not Allowed", errors)
-	if err != nil {
-		slog.Error("error writing response", "error", err)
-
+func (s *Server) handle405(listener string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if listener == "internal" {
+			slog.Error("invalid method", "listener", listener, "url", r.URL.String(), "method", r.Method, "resp_status", "405")
+		} else {
+			slog.Info("invalid method", "listener", listener, "url", r.URL.String(), "method", r.Method, "resp_status", "405")
+		}
+		errors := []any{NewErrorData(fmt.Sprintf("method not allowed: %s", r.Method))}
+		err := WriteDataResponse(w, http.StatusMethodNotAllowed, "Method Not Allowed", errors)
+		if err != nil {
+			slog.Error("error writing response", "error", err)
+		}
 	}
+}
+
+// handlePing is a lightweight liveness probe used by ALB health checks. Registered at the root of
+// both listeners and not under any /c or /ci prefix, so no ALB listener rule routes client traffic
+// to it — only direct ALB→target health probes reach it.
+func handlePing(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status":"ok"}`))
 }
 
 // wraps a handler to make it use basic auth

--- a/server.go
+++ b/server.go
@@ -50,9 +50,15 @@ func NewServerWithLogger(config *runtime.Config, backend Backend, logger *slog.L
 	channelRouter := chi.NewRouter()
 
 	// testRouter mounts channelRouter at /c/ so handler tests can dispatch requests via Router() without
-	// having to spin up the full public listener stack
+	// spinning up the listener. It mirrors the public listener's middleware stack so tests exercise the
+	// same chain that /c/* traffic hits in production.
 	testRouter := chi.NewRouter()
+	testRouter.Use(middleware.Compress(flate.DefaultCompression))
 	testRouter.Use(middleware.StripSlashes)
+	testRouter.Use(middleware.RequestID)
+	testRouter.Use(middleware.RealIP)
+	testRouter.Use(middleware.Recoverer)
+	testRouter.Use(middleware.Timeout(30 * time.Second))
 	testRouter.Mount("/c/", channelRouter)
 
 	return &Server{

--- a/server_test.go
+++ b/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -26,7 +27,8 @@ func testConfig() *runtime.Config {
 	cfg := runtime.NewDefaultConfig()
 	cfg.DB = "postgres://courier_test:temba@postgres:5432/courier_test?sslmode=disable"
 	cfg.Valkey = "valkey://valkey:6379/0"
-	cfg.Port = 8081
+	cfg.PublicPort = 8180
+	cfg.InternalPort = 8181
 	return cfg
 }
 
@@ -57,27 +59,27 @@ func TestServerURLs(t *testing.T) {
 	}
 
 	// route listing at the / root
-	statusCode, respBody := request("GET", "http://localhost:8081/", "", "")
+	statusCode, respBody := request("GET", "http://localhost:8180/", "", "")
 	assert.Equal(t, 200, statusCode)
 	assert.Contains(t, respBody, "/c/mck/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/receive - Mock Handler receive")
 
 	// can't access status page without auth
-	statusCode, respBody = request("GET", "http://localhost:8081/status", "", "")
+	statusCode, respBody = request("GET", "http://localhost:8180/status", "", "")
 	assert.Equal(t, 401, statusCode)
 	assert.Equal(t, respBody, "Unauthorized")
 
 	// can access status page without auth
-	statusCode, respBody = request("GET", "http://localhost:8081/status", "admin", "password123")
+	statusCode, respBody = request("GET", "http://localhost:8180/status", "admin", "password123")
 	assert.Equal(t, 200, statusCode)
 	assert.Contains(t, respBody, "ALL GOOD")
 
 	// can't access status page with wrong method
-	statusCode, respBody = request("POST", "http://localhost:8081/status", "admin", "password123")
+	statusCode, respBody = request("POST", "http://localhost:8180/status", "admin", "password123")
 	assert.Equal(t, 405, statusCode)
 	assert.Equal(t, respBody, "{\"message\":\"Method Not Allowed\",\"data\":[{\"type\":\"error\",\"error\":\"method not allowed: POST\"}]}\n")
 
 	// can't access non-existent page
-	statusCode, respBody = request("POST", "http://localhost:8081/nothere", "admin", "password123")
+	statusCode, respBody = request("POST", "http://localhost:8180/nothere", "admin", "password123")
 	assert.Equal(t, 404, statusCode)
 	assert.Equal(t, respBody, "{\"message\":\"Not Found\",\"data\":[{\"type\":\"error\",\"error\":\"not found: /nothere\"}]}\n")
 }
@@ -90,7 +92,7 @@ func TestIncoming(t *testing.T) {
 	s.Start()
 	defer s.Stop()
 
-	resp, err := http.Get("http://localhost:8081/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive")
+	resp, err := http.Get("http://localhost:8180/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive")
 	assert.NoError(t, err)
 	assert.Equal(t, 400, resp.StatusCode)
 	defer resp.Body.Close()
@@ -101,7 +103,7 @@ func TestIncoming(t *testing.T) {
 	clog := mb.WrittenChannelLogs()[0]
 	assert.Len(t, clog.HttpLogs, 1)
 
-	req, _ := http.NewRequest("GET", "http://localhost:8081/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive?from=2065551212&text=hello", nil)
+	req, _ := http.NewRequest("GET", "http://localhost:8180/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive?from=2065551212&text=hello", nil)
 	req.Header.Set("Cookie", "secret")
 	resp, err = http.DefaultClient.Do(req)
 	assert.NoError(t, err)
@@ -249,7 +251,8 @@ func TestFetchAttachment(t *testing.T) {
 	logger := slog.Default()
 	cfg := runtime.NewDefaultConfig()
 	cfg.AuthToken = "sesame"
-	cfg.Port = 8081
+	cfg.PublicPort = 8180
+	cfg.InternalPort = 8181
 
 	mb := test.NewMockBackend()
 	mockChannel := test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
@@ -263,7 +266,7 @@ func TestFetchAttachment(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	submit := func(body, authToken string) (int, []byte) {
-		req, _ := http.NewRequest("POST", "http://localhost:8081/ci/attachment/fetch", strings.NewReader(body))
+		req, _ := http.NewRequest("POST", "http://localhost:8180/ci/attachment/fetch", strings.NewReader(body))
 		if authToken != "" {
 			req.Header.Set("Authorization", "Bearer "+authToken)
 		}
@@ -311,6 +314,76 @@ func TestFetchAttachment(t *testing.T) {
 	statusCode, respBody = submit(`{"channel_uuid": "e4bb1578-29da-4fa5-a214-9da19dd24230", "channel_type": "MCK", "url": "http://mock.com/media/hello.pdf"}`, "sesame")
 	assert.Equal(t, 200, statusCode)
 	assert.JSONEq(t, `{"attachment": {"content_type": "unavailable", "url": "http://mock.com/media/hello.pdf", "size": 0}, "log_uuid": "0191e180-8530-7000-8ef6-384876655d1b"}`, string(respBody))
+}
+
+// TestListeners verifies that public and internal endpoints are correctly split between
+// the two listener ports during the dual-exposure phase.
+func TestListeners(t *testing.T) {
+	cfg := testConfig()
+	cfg.AuthToken = "sesame"
+	cfg.StatusUsername = "admin"
+	cfg.StatusPassword = "password123"
+
+	mb := test.NewMockBackend()
+	mb.AddChannel(test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, nil))
+
+	server := courier.NewServerWithLogger(cfg, mb, slog.Default())
+	server.Start()
+	defer server.Stop()
+
+	// wait for both listeners to come up
+	for _, addr := range []string{"localhost:8180", "localhost:8181"} {
+		require.Eventually(t, func() bool {
+			c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+			if err != nil {
+				return false
+			}
+			c.Close()
+			return true
+		}, 5*time.Second, 10*time.Millisecond, "listener at %s never came up", addr)
+	}
+
+	const publicURL = "http://localhost:8180"
+	const internalURL = "http://localhost:8181"
+
+	// don't follow redirects so we can observe StripSlashes redirects directly
+	client := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+
+	tcs := []struct {
+		label  string
+		method string
+		url    string
+		status int
+	}{
+		// public listener: index, ping, status, channel routes, and (during transition) /ci/*
+		{"public: index", "GET", publicURL + "/", 200},
+		{"public: ping", "GET", publicURL + "/ping", 200},
+		{"public: status (no auth)", "GET", publicURL + "/status", 401},
+		{"public: channel route (bad params)", "GET", publicURL + "/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive", 400},
+		{"public: internal route (during transition, no auth)", "POST", publicURL + "/ci/attachment/fetch", 401},
+		{"public: unknown path", "GET", publicURL + "/nope", 404},
+
+		// internal listener: only /ci/* and /ping, no index, no /c/*, no /status
+		{"internal: index", "GET", internalURL + "/", 404},
+		{"internal: ping", "GET", internalURL + "/ping", 200},
+		{"internal: internal route (no auth)", "POST", internalURL + "/ci/attachment/fetch", 401},
+		{"internal: channel route not exposed", "GET", internalURL + "/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive", 404},
+		{"internal: status not exposed", "GET", internalURL + "/status", 404},
+		{"internal: unknown path", "GET", internalURL + "/nope", 404},
+	}
+
+	for _, tc := range tcs {
+		req, err := http.NewRequest(tc.method, tc.url, nil)
+		require.NoError(t, err, tc.label)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err, tc.label)
+		resp.Body.Close()
+
+		assert.Equal(t, tc.status, resp.StatusCode, tc.label)
+	}
 }
 
 // utility to send a message on a mocked backend and block until it's marked as sent


### PR DESCRIPTION
## Summary

Ports [mailroom#1078](https://github.com/nyaruka/mailroom/pull/1078) and [mailroom#1080](https://github.com/nyaruka/mailroom/pull/1080) to courier.

- Splits the single HTTP listener into two `http.Server` instances:
  - **Public** (`:8080`) — serves `/`, `/status`, `/c/*`, `/ping`, and (during transition) `/ci/*`
  - **Internal** (`:8081`) — serves only `/ci/*` and `/ping`
- The public listener continues to serve `/ci/*` during the transition so internal callers (rapidpro, mailroom) can be migrated to `:8081` via ALB/SG changes without downtime. A phase-3 PR will drop `/ci/*` from the public router.
- Adds a no-auth `GET /ping` handler at the root of both listeners as an ALB target-group health-check target. Registered without a `/c` or `/ci` prefix, so no ALB listener rule routes client traffic to it — only direct ALB→target health probes can reach it.

## What's different on the internal listener

- No `RealIP` middleware — there's no proxy in front and trusting `X-Forwarded-For` from internal callers is a small hardening regression.
- No index handler at `/` (returns 404 — nothing useful at the root).
- 404/405 responses logged at `slog.Error` (sentry-routed) — these indicate caller-side bugs in rapidpro/mailroom worth alerting on.

## Breaking config change

Renames `Address`/`Port` → `PublicAddress`/`PublicPort`, adds `InternalAddress`/`InternalPort`. Deployment configs that set `COURIER_ADDRESS` / `COURIER_PORT` need updating to `COURIER_PUBLIC_ADDRESS` / `COURIER_PUBLIC_PORT`.

Defaults:

|       | public               | internal              |
|-------|----------------------|-----------------------|
| prod  | `:8080` (unchanged)  | `localhost:8081` (new)|
| tests | `localhost:8180`     | `localhost:8181`      |

Test ports renumbered off `8081` to avoid colliding with the new prod-internal default — matches mailroom's 80xx prod / 81xx test scheme.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] New `TestListeners` passes — asserts the public listener serves `/`, `/ping`, `/status`, `/c/*`, and (transition) `/ci/*`, while the internal listener serves only `/ci/*` and `/ping`
- [x] Full suite (`go test -p=1 ./...`) green
- [ ] After release: flip TG health-check path to `/ping` on staging first, then prod
- [ ] Phase 3 (separate PR): drop `/ci/*` from the public router once internal-listener traffic has stabilized