### PR TITLE
Remove backward-compat /ci/ route from public listener

### DIFF
--- a/server.go
+++ b/server.go
@@ -90,7 +90,7 @@ func (s *Server) Start() error {
 	// initialize our handlers (wires routes into channelRouter)
 	s.initializeChannelHandlers()
 
-	// public listener — exposes /, /status, /c/*, /ping, and (during transition) /ci/* as well
+	// public listener — exposes /, /status, /c/*, /ping
 	publicRouter := chi.NewRouter()
 	publicRouter.Use(middleware.Compress(flate.DefaultCompression))
 	publicRouter.Use(middleware.StripSlashes)
@@ -103,7 +103,6 @@ func (s *Server) Start() error {
 	publicRouter.Get("/", s.handleIndex)
 	publicRouter.Get("/ping", handlePing)
 	publicRouter.Get("/status", s.basicAuthRequired(s.handleStatus))
-	publicRouter.Post("/ci/attachment/fetch", s.tokenAuthRequired(s.handleFetchAttachment))
 	publicRouter.Mount("/c/", s.channelRouter)
 
 	// internal listener — only /ci/* routes and /ping, no public-facing concerns

--- a/server_test.go
+++ b/server_test.go
@@ -266,7 +266,7 @@ func TestFetchAttachment(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	submit := func(body, authToken string) (int, []byte) {
-		req, _ := http.NewRequest("POST", "http://localhost:8180/ci/attachment/fetch", strings.NewReader(body))
+		req, _ := http.NewRequest("POST", "http://localhost:8181/ci/attachment/fetch", strings.NewReader(body))
 		if authToken != "" {
 			req.Header.Set("Authorization", "Bearer "+authToken)
 		}
@@ -317,7 +317,7 @@ func TestFetchAttachment(t *testing.T) {
 }
 
 // TestListeners verifies that public and internal endpoints are correctly split between
-// the two listener ports during the dual-exposure phase.
+// the two listener ports.
 func TestListeners(t *testing.T) {
 	cfg := testConfig()
 	cfg.AuthToken = "sesame"
@@ -357,12 +357,12 @@ func TestListeners(t *testing.T) {
 		url    string
 		status int
 	}{
-		// public listener: index, ping, status, channel routes, and (during transition) /ci/*
+		// public listener: index, ping, status, channel routes
 		{"public: index", "GET", publicURL + "/", 200},
 		{"public: ping", "GET", publicURL + "/ping", 200},
 		{"public: status (no auth)", "GET", publicURL + "/status", 401},
 		{"public: channel route (bad params)", "GET", publicURL + "/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive", 400},
-		{"public: internal route (during transition, no auth)", "POST", publicURL + "/ci/attachment/fetch", 401},
+		{"public: internal route not exposed", "POST", publicURL + "/ci/attachment/fetch", 404},
 		{"public: unknown path", "GET", publicURL + "/nope", 404},
 
 		// internal listener: only /ci/* and /ping, no index, no /c/*, no /status


### PR DESCRIPTION
## Summary
- The HTTP server was previously split into a public listener (`/`, `/ping`, `/status`, `/c/*`) and an internal listener (`/ping`, `/ci/*`). To avoid breaking in-flight callers, the public listener also kept exposing `/ci/attachment/fetch` as a transitional shim.
- That transition is complete, so this PR removes the duplicate route from the public listener. `/ci/*` is now reachable only on the internal listener.

## Changes
- `server.go`: drop the `publicRouter.Post("/ci/attachment/fetch", ...)` line and the "(during transition)" wording in the comment.
- `server_test.go`:
  - `TestFetchAttachment` now hits the internal port (`:8181`) instead of the public port (`:8180`).
  - `TestListeners` asserts the public listener returns **404** on `/ci/attachment/fetch` (was previously **401** because the shim existed); the internal listener still returns **401** there.
  - Drop "during transition / dual-exposure" wording from comments.

## Test plan
- [x] `docker exec dev-courier go test -p=1 ./...` — all packages pass.
- [x] Targeted `TestFetchAttachment` and `TestListeners` pass against the updated routing.