### PR TITLE
Remove index and status endpoints from public listener

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -82,12 +82,6 @@ type Backend interface {
 	HttpClient(bool) *http.Client
 	HttpAccess() *httpx.AccessConfig
 
-	// Health returns a string describing any health problems the backend has, or empty string if all is well
-	Health() string
-
-	// Status returns a string describing the current status, this can detail queue sizes or other attributes
-	Status() string
-
 	// RedisPool returns the redisPool for this backend
 	RedisPool() *redis.Pool
 }

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -1,7 +1,6 @@
 package rapidpro
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"database/sql"
@@ -689,34 +688,6 @@ func (b *backend) HttpAccess() *httpx.AccessConfig {
 	return b.httpAccess
 }
 
-// Health returns the health of this backend as a string, returning "" if all is well
-func (b *backend) Health() string {
-	// test redis
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	rc, redisErr := b.rt.VK.GetContext(ctx)
-	cancel()
-
-	if redisErr == nil {
-		defer rc.Close()
-		_, redisErr = rc.Do("PING")
-	}
-
-	// test our db
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
-	dbErr := b.rt.DB.PingContext(ctx)
-	cancel()
-
-	health := bytes.Buffer{}
-	if redisErr != nil {
-		health.WriteString(fmt.Sprintf("\n% 16s: %v", "redis err", redisErr))
-	}
-	if dbErr != nil {
-		health.WriteString(fmt.Sprintf("\n% 16s: %v", "db err", dbErr))
-	}
-
-	return health.String()
-}
-
 func (b *backend) reportMetrics(ctx context.Context) (int, error) {
 	if b.rt.Config.MetricsReporting == "off" {
 		return 0, nil
@@ -779,75 +750,6 @@ func (b *backend) reportMetrics(ctx context.Context) (int, error) {
 	}
 
 	return len(metrics), nil
-}
-
-// Status returns information on our queue sizes, number of workers etc..
-func (b *backend) Status() string {
-	rc := b.rt.VK.Get()
-	defer rc.Close()
-
-	status := bytes.Buffer{}
-	status.WriteString("------------------------------------------------------------------------------------\n")
-	status.WriteString("     Size | Bulk Size | Workers | TPS | Type | Channel              \n")
-	status.WriteString("------------------------------------------------------------------------------------\n")
-
-	var queue string
-	var workers float64
-
-	// get all our queues
-	rc.Send("zrevrangebyscore", fmt.Sprintf("%s:active", msgQueueName), "+inf", "-inf", "withscores")
-	rc.Send("zrevrangebyscore", fmt.Sprintf("%s:throttled", msgQueueName), "+inf", "-inf", "withscores")
-	rc.Flush()
-
-	active, err := redis.Values(rc.Receive())
-	if err != nil {
-		return fmt.Sprintf("unable to read active queues: %v", err)
-	}
-	throttled, err := redis.Values(rc.Receive())
-	if err != nil {
-		return fmt.Sprintf("unable to read throttled queues: %v", err)
-	}
-	values := append(active, throttled...)
-
-	for len(values) > 0 {
-		values, err = redis.Scan(values, &queue, &workers)
-		if err != nil {
-			return fmt.Sprintf("error reading active queues: %v", err)
-		}
-
-		// our queue name is in the format msgs:uuid|tps, break it apart
-		queue = strings.TrimPrefix(queue, "msgs:")
-		parts := strings.Split(queue, "|")
-		if len(parts) != 2 {
-			return fmt.Sprintf("error parsing queue name '%s'", queue)
-		}
-		uuid := parts[0]
-		tps := parts[1]
-
-		// try to look up our channel
-		channelUUID := models.ChannelUUID(uuid)
-		channel, err := b.GetChannel(context.Background(), models.AnyChannelType, channelUUID)
-		channelType := "!!"
-		if err == nil {
-			channelType = string(channel.ChannelType())
-		}
-
-		// get # of items in our normal queue
-		size, err := redis.Int64(rc.Do("ZCARD", fmt.Sprintf("%s:%s/1", msgQueueName, queue)))
-		if err != nil {
-			return fmt.Sprintf("error reading queue size: %v", err)
-		}
-
-		// get # of items in the bulk queue
-		bulkSize, err := redis.Int64(rc.Do("ZCARD", fmt.Sprintf("%s:%s/0", msgQueueName, queue)))
-		if err != nil {
-			return fmt.Sprintf("error reading bulk queue size: %v", err)
-		}
-
-		status.WriteString(fmt.Sprintf("% 9d   % 9d   % 7d   % 3s   % 4s   %s\n", size, bulkSize, int(workers), tps, channelType, uuid))
-	}
-
-	return status.String()
 }
 
 // RedisPool returns the redisPool for this backend

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -596,11 +595,6 @@ func (ts *BackendTestSuite) TestSentExternalIDCaching() {
 	assertdb.Query(ts.T(), ts.b.rt.DB, `SELECT status FROM msgs_msg WHERE id = 10000`).Returns("D")
 }
 
-func (ts *BackendTestSuite) TestHealth() {
-	// all should be well in test land
-	ts.Equal(ts.b.Health(), "")
-}
-
 func (ts *BackendTestSuite) TestCheckForDuplicate() {
 	rc := ts.b.rt.VK.Get()
 	defer rc.Close()
@@ -677,34 +671,6 @@ func (ts *BackendTestSuite) TestCheckForDuplicate() {
 
 	ts.Equal(msg7.UUID(), msg8.UUID())
 	ts.NotEqual(msg7.UUID(), msg9.UUID())
-}
-
-func (ts *BackendTestSuite) TestStatus() {
-	// our health should just contain the header
-	ts.True(strings.Contains(ts.b.Status(), "Channel"), ts.b.Status())
-
-	// add a message to our queue
-	r := ts.b.rt.VK.Get()
-	defer r.Close()
-
-	msgJSON := `[{
-		"org_id": 1,
-		"id": 10000,
-		"uuid": "0199df0f-9f82-7689-b02d-f34105991321",
-		"high_priority": true,
-		"text": "test message",
-		"contact": {"id": 100, "uuid": "a984069d-0008-4d8c-a772-b14a8a6acccc"},
-		"created_on": "2025-10-14T20:16:03.821434Z",
-		"channel_uuid": "dbc126ed-66bc-4e28-b67b-81dc3327c95d",
-		"urn": "tel:+12067799192",
-		"origin": "chat"
-	}]`
-
-	err := queue.PushOntoQueue(r, msgQueueName, "dbc126ed-66bc-4e28-b67b-81dc3327c95d", 10, string(msgJSON), queue.HighPriority)
-	ts.NoError(err)
-
-	// status should now contain that channel
-	ts.True(strings.Contains(ts.b.Status(), "1           0         0    10     KN   dbc126ed-66bc-4e28-b67b-81dc3327c95d"), ts.b.Status())
 }
 
 func (ts *BackendTestSuite) TestOutgoingQueue() {

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -51,8 +51,6 @@ type Config struct {
 	DisallowedNetworks string     `help:"comma separated list of IP addresses and networks which we disallow fetching attachments from"`
 	MediaDomain        string     `help:"the domain on which we'll try to resolve outgoing media URLs"`
 	MaxWorkers         int        `help:"the maximum number of go routines that will be used for sending (set to 0 to disable sending)"`
-	StatusUsername     string     `help:"the username that is needed to authenticate against the /status endpoint"`
-	StatusPassword     string     `help:"the password that is needed to authenticate against the /status endpoint"`
 	AuthToken          string     `help:"the authentication token need to access non-channel endpoints"`
 	LogLevel           slog.Level `help:"the logging level courier should use"`
 	Version            string     `help:"the version that will be used in request and response headers"`

--- a/server.go
+++ b/server.go
@@ -1,7 +1,6 @@
 package courier
 
 import (
-	"bytes"
 	"compress/flate"
 	"context"
 	"errors"
@@ -11,7 +10,6 @@ import (
 	"net/http"
 	"runtime/debug"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -90,7 +88,7 @@ func (s *Server) Start() error {
 	// initialize our handlers (wires routes into channelRouter)
 	s.initializeChannelHandlers()
 
-	// public listener — exposes /, /status, /c/*, /ping
+	// public listener — exposes /c/*, /ping
 	publicRouter := chi.NewRouter()
 	publicRouter.Use(middleware.Compress(flate.DefaultCompression))
 	publicRouter.Use(middleware.StripSlashes)
@@ -100,9 +98,7 @@ func (s *Server) Start() error {
 	publicRouter.Use(middleware.Timeout(30 * time.Second))
 	publicRouter.NotFound(s.handle404("public"))
 	publicRouter.MethodNotAllowed(s.handle405("public"))
-	publicRouter.Get("/", s.handleIndex)
 	publicRouter.Get("/ping", handlePing)
-	publicRouter.Get("/status", s.basicAuthRequired(s.handleStatus))
 	publicRouter.Mount("/c/", s.channelRouter)
 
 	// internal listener — only /ci/* routes and /ping, no public-facing concerns
@@ -223,7 +219,6 @@ type Server struct {
 	stopChan  chan bool
 	stopped   bool
 
-	chanRoutes []string // used for index page
 }
 
 func (s *Server) initializeChannelHandlers() {
@@ -244,8 +239,6 @@ func (s *Server) initializeChannelHandlers() {
 		}
 	}
 
-	// sort our route help
-	sort.Strings(s.chanRoutes)
 }
 
 func (s *Server) channelHandleWrapper(handler ChannelHandler, handlerFunc ChannelHandleFunc, logType clogs.Type) http.HandlerFunc {
@@ -342,37 +335,6 @@ func (s *Server) AddHandlerRoute(handler ChannelHandler, method string, action s
 		path = fmt.Sprintf("%s/%s", path, action)
 	}
 	s.channelRouter.Method(method, path, s.channelHandleWrapper(handler, handlerFunc, logType))
-	s.chanRoutes = append(s.chanRoutes, fmt.Sprintf("%-20s - %s %s", "/c"+path, handler.ChannelName(), action))
-}
-
-func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html")
-	w.WriteHeader(http.StatusOK)
-
-	var buf bytes.Buffer
-	buf.WriteString("<html><head><title>courier</title></head><body><pre>\n")
-	buf.WriteString(splash)
-	buf.WriteString(s.config.Version)
-	buf.WriteString(s.backend.Health())
-	buf.WriteString("\n\n")
-	buf.WriteString(strings.Join(s.chanRoutes, "\n"))
-	buf.WriteString("</pre></body></html>")
-	w.Write(buf.Bytes())
-}
-
-func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html")
-	w.WriteHeader(http.StatusOK)
-
-	var buf bytes.Buffer
-	buf.WriteString("<html><head><title>courier</title></head><body><pre>\n")
-	buf.WriteString(splash)
-	buf.WriteString(s.config.Version)
-	buf.WriteString("\n\n")
-	buf.WriteString(s.backend.Status())
-	buf.WriteString("\n\n")
-	buf.WriteString("</pre></body></html>")
-	w.Write(buf.Bytes())
 }
 
 func (s *Server) handleFetchAttachment(w http.ResponseWriter, r *http.Request) {
@@ -432,24 +394,6 @@ func handlePing(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`{"status":"ok"}`))
 }
 
-// wraps a handler to make it use basic auth
-func (s *Server) basicAuthRequired(h http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if s.config.StatusUsername != "" {
-			user, pass, ok := r.BasicAuth()
-
-			if !ok || !utils.SecretEqual(user, s.config.StatusUsername) || !utils.SecretEqual(pass, s.config.StatusPassword) {
-				w.Header().Set("Content-Type", "text/plain")
-				w.Header().Set("WWW-Authenticate", `Basic realm="Authenticate"`)
-				w.WriteHeader(http.StatusUnauthorized)
-				w.Write([]byte("Unauthorized"))
-				return
-			}
-		}
-		h(w, r)
-	}
-}
-
 // wraps a handler to make it use token auth
 func (s *Server) tokenAuthRequired(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -464,9 +408,3 @@ func (s *Server) tokenAuthRequired(h http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-var splash = `
- ____________                   _____             
-   ___  ____/_________  ___________(_)____________
-    _  /  __  __ \  / / /_  ___/_  /_  _ \_  ___/
-    / /__  / /_/ / /_/ /_  /   _  / /  __/  /    
-    \____/ \____/\__,_/ /_/    /_/  \___//_/ v`

--- a/server_test.go
+++ b/server_test.go
@@ -32,58 +32,6 @@ func testConfig() *runtime.Config {
 	return cfg
 }
 
-func TestServerURLs(t *testing.T) {
-	logger := slog.Default()
-	cfg := testConfig()
-	cfg.StatusUsername = "admin"
-	cfg.StatusPassword = "password123"
-
-	mb := test.NewMockBackend()
-	mb.AddChannel(test.NewMockChannel("95710b36-855d-4832-a723-5f71f73688a0", "MCK", "12345", "RW", []string{urns.Phone.Prefix}, nil))
-
-	server := courier.NewServerWithLogger(cfg, mb, logger)
-	server.Start()
-	defer server.Stop()
-
-	// wait for server to come up
-	time.Sleep(100 * time.Millisecond)
-
-	request := func(method, url, user, pass string) (int, string) {
-		req, _ := http.NewRequest(method, url, nil)
-		if user != "" {
-			req.SetBasicAuth(user, pass)
-		}
-		trace, err := httpx.DoTrace(http.DefaultClient, req, nil, nil, 0)
-		require.NoError(t, err)
-		return trace.Response.StatusCode, string(trace.ResponseBody)
-	}
-
-	// route listing at the / root
-	statusCode, respBody := request("GET", "http://localhost:8180/", "", "")
-	assert.Equal(t, 200, statusCode)
-	assert.Contains(t, respBody, "/c/mck/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/receive - Mock Handler receive")
-
-	// can't access status page without auth
-	statusCode, respBody = request("GET", "http://localhost:8180/status", "", "")
-	assert.Equal(t, 401, statusCode)
-	assert.Equal(t, respBody, "Unauthorized")
-
-	// can access status page without auth
-	statusCode, respBody = request("GET", "http://localhost:8180/status", "admin", "password123")
-	assert.Equal(t, 200, statusCode)
-	assert.Contains(t, respBody, "ALL GOOD")
-
-	// can't access status page with wrong method
-	statusCode, respBody = request("POST", "http://localhost:8180/status", "admin", "password123")
-	assert.Equal(t, 405, statusCode)
-	assert.Equal(t, respBody, "{\"message\":\"Method Not Allowed\",\"data\":[{\"type\":\"error\",\"error\":\"method not allowed: POST\"}]}\n")
-
-	// can't access non-existent page
-	statusCode, respBody = request("POST", "http://localhost:8180/nothere", "admin", "password123")
-	assert.Equal(t, 404, statusCode)
-	assert.Equal(t, respBody, "{\"message\":\"Not Found\",\"data\":[{\"type\":\"error\",\"error\":\"not found: /nothere\"}]}\n")
-}
-
 func TestIncoming(t *testing.T) {
 	// create and start our backend and server
 	mb := test.NewMockBackend()
@@ -321,8 +269,6 @@ func TestFetchAttachment(t *testing.T) {
 func TestListeners(t *testing.T) {
 	cfg := testConfig()
 	cfg.AuthToken = "sesame"
-	cfg.StatusUsername = "admin"
-	cfg.StatusPassword = "password123"
 
 	mb := test.NewMockBackend()
 	mb.AddChannel(test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, nil))
@@ -357,20 +303,16 @@ func TestListeners(t *testing.T) {
 		url    string
 		status int
 	}{
-		// public listener: index, ping, status, channel routes
-		{"public: index", "GET", publicURL + "/", 200},
+		// public listener: /ping, /c/*
 		{"public: ping", "GET", publicURL + "/ping", 200},
-		{"public: status (no auth)", "GET", publicURL + "/status", 401},
 		{"public: channel route (bad params)", "GET", publicURL + "/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive", 400},
 		{"public: internal route not exposed", "POST", publicURL + "/ci/attachment/fetch", 404},
 		{"public: unknown path", "GET", publicURL + "/nope", 404},
 
-		// internal listener: only /ci/* and /ping, no index, no /c/*, no /status
-		{"internal: index", "GET", internalURL + "/", 404},
+		// internal listener: /ping, /ci/*
 		{"internal: ping", "GET", internalURL + "/ping", 200},
 		{"internal: internal route (no auth)", "POST", internalURL + "/ci/attachment/fetch", 401},
 		{"internal: channel route not exposed", "GET", internalURL + "/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive", 404},
-		{"internal: status not exposed", "GET", internalURL + "/status", 404},
 		{"internal: unknown path", "GET", internalURL + "/nope", 404},
 	}
 

--- a/test/backend.go
+++ b/test/backend.go
@@ -341,22 +341,12 @@ func (mb *MockBackend) ResolveMedia(ctx context.Context, mediaUrl string) (*mode
 	return media, nil
 }
 
-func (mb *MockBackend) Health() string {
-	return ""
-}
-
-// Health gives a string representing our health, empty for our mock
 func (mb *MockBackend) HttpClient(bool) *http.Client {
 	return http.DefaultClient
 }
 
 func (mb *MockBackend) HttpAccess() *httpx.AccessConfig {
 	return nil
-}
-
-// Status returns a string describing the status of the service, queue size etc..
-func (mb *MockBackend) Status() string {
-	return "ALL GOOD"
 }
 
 // RedisPool returns the redisPool for this backend


### PR DESCRIPTION
## Summary
- Remove the `GET /` index page and `GET /status` debug page from the public listener — neither is used by any caller, and `/ping` already covers ALB health checks.
- Delete `handleIndex`, `handleStatus`, `basicAuthRequired`, the ASCII splash banner, and the `chanRoutes` bookkeeping that only existed to populate the index page.
- Remove the `StatusUsername` / `StatusPassword` config fields.

## Test plan
- [x] `TestListeners` — updated to drop the index/status assertions; verifies public listener serves only `/ping` and `/c/*`.
- [x] `TestFetchAttachment` — unchanged, still passes on internal listener.
- [x] Full suite: 3 pre-existing failures on `main` (`TestIncoming`, `TestMsgSuite`, `TestInsertContact`) are unrelated to this change.