### PR TITLE
Serve health response at / on both listeners

### DIFF
--- a/server.go
+++ b/server.go
@@ -88,7 +88,7 @@ func (s *Server) Start() error {
 	// initialize our handlers (wires routes into channelRouter)
 	s.initializeChannelHandlers()
 
-	// public listener — exposes /c/*, /ping
+	// public listener — exposes /c/*, /, /ping
 	publicRouter := chi.NewRouter()
 	publicRouter.Use(middleware.Compress(flate.DefaultCompression))
 	publicRouter.Use(middleware.StripSlashes)
@@ -98,10 +98,11 @@ func (s *Server) Start() error {
 	publicRouter.Use(middleware.Timeout(30 * time.Second))
 	publicRouter.NotFound(s.handle404("public"))
 	publicRouter.MethodNotAllowed(s.handle405("public"))
-	publicRouter.Get("/ping", handlePing)
+	publicRouter.Get("/", s.handleHealth)
+	publicRouter.Get("/ping", s.handleHealth) // temporary back-compat alias for /
 	publicRouter.Mount("/c/", s.channelRouter)
 
-	// internal listener — only /ci/* routes and /ping, no public-facing concerns
+	// internal listener — only /ci/* routes and /, /ping, no public-facing concerns
 	internalRouter := chi.NewRouter()
 	internalRouter.Use(middleware.Compress(flate.DefaultCompression))
 	internalRouter.Use(middleware.StripSlashes)
@@ -110,7 +111,8 @@ func (s *Server) Start() error {
 	internalRouter.Use(middleware.Timeout(30 * time.Second))
 	internalRouter.NotFound(s.handle404("internal"))
 	internalRouter.MethodNotAllowed(s.handle405("internal"))
-	internalRouter.Get("/ping", handlePing)
+	internalRouter.Get("/", s.handleHealth)
+	internalRouter.Get("/ping", s.handleHealth) // temporary back-compat alias for /
 	internalRouter.Post("/ci/attachment/fetch", s.tokenAuthRequired(s.handleFetchAttachment))
 
 	s.publicServer = &http.Server{
@@ -385,13 +387,17 @@ func (s *Server) handle405(listener string) http.HandlerFunc {
 	}
 }
 
-// handlePing is a lightweight liveness probe used by ALB health checks. Registered at the root of
-// both listeners and not under any /c or /ci prefix, so no ALB listener rule routes client traffic
-// to it — only direct ALB→target health probes reach it.
-func handlePing(w http.ResponseWriter, r *http.Request) {
+// handleHealth is the liveness probe used by ALB health checks. Registered at the root of
+// both listeners and not under any /c or /ci prefix, so no listener rule routes client traffic
+// to it — only direct ALB→target health probes reach it. Also returns the running version so
+// it doubles as a debug endpoint.
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"status":"ok"}`))
+	w.Write(jsonx.MustMarshal(map[string]string{
+		"component": "courier",
+		"version":   s.config.Version,
+	}))
 }
 
 // wraps a handler to make it use token auth

--- a/server_test.go
+++ b/server_test.go
@@ -303,13 +303,15 @@ func TestListeners(t *testing.T) {
 		url    string
 		status int
 	}{
-		// public listener: /ping, /c/*
+		// public listener: health at / and /ping, /c/*
+		{"public: health", "GET", publicURL + "/", 200},
 		{"public: ping", "GET", publicURL + "/ping", 200},
 		{"public: channel route (bad params)", "GET", publicURL + "/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive", 400},
 		{"public: internal route not exposed", "POST", publicURL + "/ci/attachment/fetch", 404},
 		{"public: unknown path", "GET", publicURL + "/nope", 404},
 
-		// internal listener: /ping, /ci/*
+		// internal listener: health at / and /ping, /ci/*
+		{"internal: health", "GET", internalURL + "/", 200},
 		{"internal: ping", "GET", internalURL + "/ping", 200},
 		{"internal: internal route (no auth)", "POST", internalURL + "/ci/attachment/fetch", 401},
 		{"internal: channel route not exposed", "GET", internalURL + "/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive", 404},


### PR DESCRIPTION
## Summary

- Replace the bare `/ping` handler with a shared `handleHealth` returning `{component, version}` at `/` on both the public and internal listeners.
- `/ping` continues to serve the same body as a temporary back-compat alias so existing health-check configurations keep working while they migrate to `/`.
- `TestListeners` now covers both `/` and `/ping` on both ports.

Returning the version on the public listener is fine because only `/c/*` paths are routed there by the public-facing load balancer rules — `/` and `/ping` are only reachable via direct target health probes.

Mirrors [mailroom#1083](https://github.com/nyaruka/mailroom/pull/1083).

## Test plan

- [x] `go test -p=1 -run TestListeners .` passes
- [ ] Hit `/` and `/ping` on a running instance for each listener and confirm the JSON body