### PR TITLE
Bind listener sockets synchronously in Server.Start

### DIFF
--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"net"
 	"net/http"
 	"runtime/debug"
 	"slices"
@@ -130,6 +131,18 @@ func (s *Server) Start() error {
 		IdleTimeout:  90 * time.Second,
 	}
 
+	// bind both listener sockets synchronously so callers know we're accepting connections
+	// by the time Start returns — avoids races where the first request hits a not-yet-bound port
+	publicLn, err := net.Listen("tcp", s.publicServer.Addr)
+	if err != nil {
+		return fmt.Errorf("error binding public listener on %s: %w", s.publicServer.Addr, err)
+	}
+	internalLn, err := net.Listen("tcp", s.internalServer.Addr)
+	if err != nil {
+		publicLn.Close()
+		return fmt.Errorf("error binding internal listener on %s: %w", s.internalServer.Addr, err)
+	}
+
 	s.waitGroup.Add(2)
 
 	go func() {
@@ -138,7 +151,7 @@ func (s *Server) Start() error {
 		log := slog.With("comp", "server", "listener", "public", "address", s.publicServer.Addr)
 		log.Info("server started", "version", s.config.Version)
 
-		err := s.publicServer.ListenAndServe()
+		err := s.publicServer.Serve(publicLn)
 		if err != nil && err != http.ErrServerClosed {
 			log.Error("error listening", "error", err)
 		}
@@ -150,7 +163,7 @@ func (s *Server) Start() error {
 		log := slog.With("comp", "server", "listener", "internal", "address", s.internalServer.Addr)
 		log.Info("server started", "version", s.config.Version)
 
-		err := s.internalServer.ListenAndServe()
+		err := s.internalServer.Serve(internalLn)
 		if err != nil && err != http.ErrServerClosed {
 			log.Error("error listening", "error", err)
 		}

--- a/server.go
+++ b/server.go
@@ -77,9 +77,25 @@ func NewServerWithLogger(config *runtime.Config, backend Backend, logger *slog.L
 // if it encounters any unrecoverable (or ignorable) error, though its bias is to move forward despite
 // connection errors
 func (s *Server) Start() error {
-	// start our backend
-	err := s.backend.Start()
+	// bind both listener sockets up front so callers know we're accepting connections by the
+	// time Start returns, and so a bind failure fails fast before we've started the backend,
+	// spool flushers, or anything else that would need to be unwound
+	publicAddr := fmt.Sprintf("%s:%d", s.config.PublicAddress, s.config.PublicPort)
+	publicLn, err := net.Listen("tcp", publicAddr)
 	if err != nil {
+		return fmt.Errorf("error binding public listener on %s: %w", publicAddr, err)
+	}
+	internalAddr := fmt.Sprintf("%s:%d", s.config.InternalAddress, s.config.InternalPort)
+	internalLn, err := net.Listen("tcp", internalAddr)
+	if err != nil {
+		publicLn.Close()
+		return fmt.Errorf("error binding internal listener on %s: %w", internalAddr, err)
+	}
+
+	// start our backend
+	if err := s.backend.Start(); err != nil {
+		publicLn.Close()
+		internalLn.Close()
 		return err
 	}
 
@@ -117,30 +133,18 @@ func (s *Server) Start() error {
 	internalRouter.Post("/ci/attachment/fetch", s.tokenAuthRequired(s.handleFetchAttachment))
 
 	s.publicServer = &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", s.config.PublicAddress, s.config.PublicPort),
+		Addr:         publicAddr,
 		Handler:      publicRouter,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 45 * time.Second,
 		IdleTimeout:  90 * time.Second,
 	}
 	s.internalServer = &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", s.config.InternalAddress, s.config.InternalPort),
+		Addr:         internalAddr,
 		Handler:      internalRouter,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 45 * time.Second,
 		IdleTimeout:  90 * time.Second,
-	}
-
-	// bind both listener sockets synchronously so callers know we're accepting connections
-	// by the time Start returns — avoids races where the first request hits a not-yet-bound port
-	publicLn, err := net.Listen("tcp", s.publicServer.Addr)
-	if err != nil {
-		return fmt.Errorf("error binding public listener on %s: %w", s.publicServer.Addr, err)
-	}
-	internalLn, err := net.Listen("tcp", s.internalServer.Addr)
-	if err != nil {
-		publicLn.Close()
-		return fmt.Errorf("error binding internal listener on %s: %w", s.internalServer.Addr, err)
 	}
 
 	s.waitGroup.Add(2)

--- a/server_test.go
+++ b/server_test.go
@@ -36,7 +36,7 @@ func TestIncoming(t *testing.T) {
 	mb := test.NewMockBackend()
 	s := courier.NewServer(testConfig(), mb)
 
-	s.Start()
+	require.NoError(t, s.Start())
 	defer s.Stop()
 
 	resp, err := http.Get("http://localhost:8180/c/mck/e4bb1578-29da-4fa5-a214-9da19dd24230/receive")
@@ -81,7 +81,7 @@ func TestOutgoing(t *testing.T) {
 	mb := test.NewMockBackend()
 	s := courier.NewServer(testConfig(), mb)
 
-	s.Start()
+	require.NoError(t, s.Start())
 	defer s.Stop()
 
 	// create two channels but only register one of them
@@ -206,7 +206,7 @@ func TestFetchAttachment(t *testing.T) {
 	mb.AddChannel(mockChannel)
 
 	server := courier.NewServerWithLogger(cfg, mb, logger)
-	server.Start()
+	require.NoError(t, server.Start())
 	defer server.Stop()
 
 	submit := func(body, authToken string) (int, []byte) {
@@ -270,7 +270,7 @@ func TestListeners(t *testing.T) {
 	mb.AddChannel(test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, nil))
 
 	server := courier.NewServerWithLogger(cfg, mb, slog.Default())
-	server.Start()
+	require.NoError(t, server.Start())
 	defer server.Stop()
 
 	const publicURL = "http://localhost:8180"

--- a/server_test.go
+++ b/server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -210,9 +209,6 @@ func TestFetchAttachment(t *testing.T) {
 	server.Start()
 	defer server.Stop()
 
-	// wait for server to come up
-	time.Sleep(100 * time.Millisecond)
-
 	submit := func(body, authToken string) (int, []byte) {
 		req, _ := http.NewRequest("POST", "http://localhost:8181/ci/attachment/fetch", strings.NewReader(body))
 		if authToken != "" {
@@ -276,18 +272,6 @@ func TestListeners(t *testing.T) {
 	server := courier.NewServerWithLogger(cfg, mb, slog.Default())
 	server.Start()
 	defer server.Stop()
-
-	// wait for both listeners to come up
-	for _, addr := range []string{"localhost:8180", "localhost:8181"} {
-		require.Eventually(t, func() bool {
-			c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
-			if err != nil {
-				return false
-			}
-			c.Close()
-			return true
-		}, 5*time.Second, 10*time.Millisecond, "listener at %s never came up", addr)
-	}
 
 	const publicURL = "http://localhost:8180"
 	const internalURL = "http://localhost:8181"


### PR DESCRIPTION
## Summary

`Server.Start` previously spawned `srv.ListenAndServe` in goroutines, so callers had no guarantee the port was actually accepting connections by the time `Start` returned. Tests worked around this — `TestListeners` dial-polled the listener, `TestFetchAttachment` slept 100ms — and `TestIncoming` flaked when its first request beat the bind.

This change calls `net.Listen` synchronously for both listeners, then hands each `net.Listener` to `srv.Serve` inside the goroutine. `Start` now returns an error if either bind fails, and on success both ports are accepting before it returns. The dial-loop and sleep workarounds in the tests are removed.

## Test plan

- [x] `go test -p=1 -count=5 -run 'TestIncoming|TestOutgoing|TestFetchAttachment|TestListeners' .` passes (previously flaked on the first run)