### PR TITLE
Trim handler User-Agent to avoid leaking build details

### DIFF
--- a/handlers/base.go
+++ b/handlers/base.go
@@ -2,8 +2,8 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/courier/v26"
@@ -103,20 +103,30 @@ func (h *BaseHandler) GetChannel(ctx context.Context, r *http.Request) (courier.
 
 // RequestHTTP does the given request, logging the trace, and returns the response
 func (h *BaseHandler) RequestHTTP(req *http.Request, clog *courier.ChannelLog) (*http.Response, []byte, error) {
-	return h.RequestHTTPWithClient(h.backend.HttpClient(true), req, clog)
+	return h.requestHTTPWithClient(h.backend.HttpClient(true), req, clog)
 }
 
 // RequestHTTP does the given request, logging the trace, and returns the response
 func (h *BaseHandler) RequestHTTPInsecure(req *http.Request, clog *courier.ChannelLog) (*http.Response, []byte, error) {
-	return h.RequestHTTPWithClient(h.backend.HttpClient(false), req, clog)
+	return h.requestHTTPWithClient(h.backend.HttpClient(false), req, clog)
+}
+
+// userAgent returns the User-Agent header value for handler HTTP calls. Only the major.minor
+// portion of the version is included to avoid leaking specific build details.
+func userAgent(version string) string {
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) >= 2 {
+		return "Courier/" + parts[0] + "." + parts[1]
+	}
+	return "Courier/" + version
 }
 
 // RequestHTTP does the given request using the given client, logging the trace, and returns the response
-func (h *BaseHandler) RequestHTTPWithClient(client *http.Client, req *http.Request, clog *courier.ChannelLog) (*http.Response, []byte, error) {
+func (h *BaseHandler) requestHTTPWithClient(client *http.Client, req *http.Request, clog *courier.ChannelLog) (*http.Response, []byte, error) {
 	var resp *http.Response
 	var body []byte
 
-	req.Header.Set("User-Agent", fmt.Sprintf("Courier/%s", h.server.Config().Version))
+	req.Header.Set("User-Agent", userAgent(h.server.Config().Version))
 
 	trace, err := httpx.DoTrace(client, req, nil, h.backend.HttpAccess(), 0)
 	if trace != nil {


### PR DESCRIPTION
## Summary

Handler HTTP calls were sending `User-Agent: Courier/<full-version>`, where the version string includes both the patch level and the goreleaser-injected build timestamp — e.g. `Courier/26.1.94-202605202105`. That leaks a deployment-specific build identifier to every channel endpoint we call.

This trims the header to `Courier/<major>.<minor>` (e.g. `Courier/26.1`):

- Strips the patch level and build-date suffix, keeping a single major.minor token so receivers can still coarsely gate on version if they want to.
- Falls back to the raw version when it isn't dotted (so the `Dev` default in tests/local runs stays as `Courier/Dev`).

The format remains a valid single `product = token "/" product-version` per RFC 9110 §10.1.5.

Also unexports `requestHTTPWithClient` since it isn't used outside the handlers package.

Mirrors nyaruka/mailroom#1086.

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./handlers/` — passes
- [ ] After deploy, verify a real outbound call carries `User-Agent: Courier/26.1` (no patch, no build date)