### PR TITLE
Move HTTP infrastructure to Runtime and give handlers direct access

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/h2non/filetype"
 	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/courier/v26/utils/clogs"
 	"github.com/nyaruka/gocommon/httpx"
@@ -42,7 +43,7 @@ type fetchAttachmentResponse struct {
 	LogUUID    clogs.UUID  `json:"log_uuid"`
 }
 
-func fetchAttachment(ctx context.Context, b Backend, r *http.Request) (*fetchAttachmentResponse, error) {
+func fetchAttachment(ctx context.Context, rt *runtime.Runtime, b Backend, r *http.Request) (*fetchAttachmentResponse, error) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading request body: %w", err)
@@ -63,7 +64,7 @@ func fetchAttachment(ctx context.Context, b Backend, r *http.Request) (*fetchAtt
 
 	clog := NewChannelLogForAttachmentFetch(ch, GetHandler(ch.ChannelType()).RedactValues(ch))
 
-	attachment, err := FetchAndStoreAttachment(ctx, b, ch, fa.URL, clog)
+	attachment, err := FetchAndStoreAttachment(ctx, rt, b, ch, fa.URL, clog)
 
 	// try to write channel log even if we have an error
 	clog.End()
@@ -78,7 +79,7 @@ func fetchAttachment(ctx context.Context, b Backend, r *http.Request) (*fetchAtt
 	return &fetchAttachmentResponse{Attachment: attachment, LogUUID: clog.UUID}, nil
 }
 
-func FetchAndStoreAttachment(ctx context.Context, b Backend, channel Channel, attURL string, clog *ChannelLog) (*Attachment, error) {
+func FetchAndStoreAttachment(ctx context.Context, rt *runtime.Runtime, b Backend, channel Channel, attURL string, clog *ChannelLog) (*Attachment, error) {
 	parsedURL, err := url.Parse(attURL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse attachment url '%s': %w", attURL, err)
@@ -97,7 +98,7 @@ func FetchAndStoreAttachment(ctx context.Context, b Backend, channel Channel, at
 		return nil, fmt.Errorf("unable to create attachment request: %w", err)
 	}
 
-	trace, err := httpx.DoTrace(b.HttpClient(), attRequest, nil, b.HttpAccess(), maxAttBodyReadBytes)
+	trace, err := httpx.DoTrace(rt.HttpClient, attRequest, nil, rt.HttpAccess, maxAttBodyReadBytes)
 	if trace != nil {
 		clog.HTTP(trace)
 

--- a/attachments.go
+++ b/attachments.go
@@ -98,7 +98,7 @@ func FetchAndStoreAttachment(ctx context.Context, rt *runtime.Runtime, b Backend
 		return nil, fmt.Errorf("unable to create attachment request: %w", err)
 	}
 
-	trace, err := httpx.DoTrace(rt.HttpClient, attRequest, nil, rt.HttpAccess, maxAttBodyReadBytes)
+	trace, err := httpx.DoTrace(rt.HTTP, attRequest, nil, rt.HTTPAccess, maxAttBodyReadBytes)
 	if trace != nil {
 		clog.HTTP(trace)
 

--- a/attachments.go
+++ b/attachments.go
@@ -90,7 +90,7 @@ func FetchAndStoreAttachment(ctx context.Context, rt *runtime.Runtime, b Backend
 	handler := GetHandler(channel.ChannelType())
 	builder, isBuilder := handler.(AttachmentRequestBuilder)
 	if isBuilder {
-		attRequest, err = builder.BuildAttachmentRequest(ctx, b, channel, parsedURL.String(), clog)
+		attRequest, err = builder.BuildAttachmentRequest(ctx, channel, parsedURL.String(), clog)
 	} else {
 		attRequest, err = http.NewRequest(http.MethodGet, attURL, nil)
 	}

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/nyaruka/courier/v26"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
@@ -46,6 +47,7 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(1234, time.Now))
 
 	ctx := context.Background()
+	rt := runtime.NewTestRuntime(runtime.NewDefaultConfig())
 	mb := test.NewMockBackend()
 
 	mockChannel := test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
@@ -53,7 +55,7 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 
 	clog := courier.NewChannelLogForAttachmentFetch(mockChannel, []string{"sesame"})
 
-	att, err := courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello.jpg", clog)
+	att, err := courier.FetchAndStoreAttachment(ctx, rt, mb, mockChannel, "http://mock.com/media/hello.jpg", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "image/jpeg", att.ContentType)
 	assert.Equal(t, "https://backend.com/attachments/cdf7ed27-5ad5-4028-b664-880fc7581c77.jpg", att.URL)
@@ -64,7 +66,7 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 	assert.Len(t, clog.HttpLogs, 1)
 	assert.Equal(t, "http://mock.com/media/hello.jpg", clog.HttpLogs[0].URL)
 
-	att, err = courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello2", clog)
+	att, err = courier.FetchAndStoreAttachment(ctx, rt, mb, mockChannel, "http://mock.com/media/hello2", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "image/jpeg", att.ContentType)
 	assert.Equal(t, "https://backend.com/attachments/547deaf7-7620-4434-95b3-58675999c4b7.jpg", att.URL)
@@ -76,7 +78,7 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 	assert.Equal(t, "http://mock.com/media/hello2", clog.HttpLogs[1].URL)
 
 	// a non-200 response should return an unavailable attachment
-	att, err = courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello.mp3", clog)
+	att, err = courier.FetchAndStoreAttachment(ctx, rt, mb, mockChannel, "http://mock.com/media/hello.mp3", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, &courier.Attachment{ContentType: "unavailable", URL: "http://mock.com/media/hello.mp3"}, att)
 
@@ -86,17 +88,17 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 	assert.Len(t, mb.SavedAttachments(), 2)
 
 	// same for a connection error
-	att, err = courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello.pdf", clog)
+	att, err = courier.FetchAndStoreAttachment(ctx, rt, mb, mockChannel, "http://mock.com/media/hello.pdf", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, &courier.Attachment{ContentType: "unavailable", URL: "http://mock.com/media/hello.pdf"}, att)
 
-	att, err = courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello3", clog)
+	att, err = courier.FetchAndStoreAttachment(ctx, rt, mb, mockChannel, "http://mock.com/media/hello3", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "image/jpeg", att.ContentType)
 	assert.Equal(t, "https://backend.com/attachments/338ff339-5663-49ed-8ef6-384876655d1b.jpg", att.URL)
 	assert.Equal(t, 17301, att.Size)
 
-	att, err = courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello7", clog)
+	att, err = courier.FetchAndStoreAttachment(ctx, rt, mb, mockChannel, "http://mock.com/media/hello7", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "application/octet-stream", att.ContentType)
 	assert.Equal(t, "https://backend.com/attachments/9b955e36-ac16-4c6b-8ab6-9b9af5cd042a.", att.URL)
@@ -105,7 +107,7 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 	// an actual error on our part should be returned as an error
 	mb.SetStorageError(errors.New("boom"))
 
-	att, err = courier.FetchAndStoreAttachment(ctx, mb, mockChannel, "http://mock.com/media/hello.txt", clog)
+	att, err = courier.FetchAndStoreAttachment(ctx, rt, mb, mockChannel, "http://mock.com/media/hello.txt", clog)
 	assert.EqualError(t, err, "boom")
 	assert.Nil(t, att)
 }

--- a/backend.go
+++ b/backend.go
@@ -2,11 +2,9 @@ package courier
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/courier/v26/core/models"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -77,10 +75,6 @@ type Backend interface {
 
 	// ResolveMedia resolves an outgoing attachment URL to a media object
 	ResolveMedia(context.Context, string) (*models.Media, error)
-
-	// HttpClient returns an HTTP client for making external requests
-	HttpClient() *http.Client
-	HttpAccess() *httpx.AccessConfig
 
 	// RedisPool returns the redisPool for this backend
 	RedisPool() *redis.Pool

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -29,7 +28,6 @@ import (
 	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/gocommon/cache"
 	"github.com/nyaruka/gocommon/dbutil"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/syncx"
 	"github.com/nyaruka/gocommon/urns"
@@ -63,9 +61,6 @@ type backend struct {
 	stopChan  chan bool
 	waitGroup *sync.WaitGroup
 
-	httpClient *http.Client
-	httpAccess *httpx.AccessConfig
-
 	mediaCache   *vkutil.IntervalHash
 	mediaMutexes syncx.HashMutex
 
@@ -89,18 +84,8 @@ type backend struct {
 
 // NewBackend creates a new RapidPro backend
 func NewBackend(rt *runtime.Runtime) courier.Backend {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.MaxIdleConns = 64
-	transport.MaxIdleConnsPerHost = 8
-	transport.IdleConnTimeout = 15 * time.Second
-
-	disallowedIPs, disallowedNets, _ := rt.Config.ParseDisallowedNetworks()
-
 	return &backend{
 		rt: rt,
-
-		httpClient: &http.Client{Transport: transport, Timeout: 30 * time.Second},
-		httpAccess: httpx.NewAccessConfig(10*time.Second, disallowedIPs, disallowedNets),
 
 		stopChan:  make(chan bool),
 		waitGroup: &sync.WaitGroup{},
@@ -666,14 +651,6 @@ func (b *backend) ResolveMedia(ctx context.Context, mediaUrl string) (*models.Me
 	}
 
 	return media, nil
-}
-
-func (b *backend) HttpClient() *http.Client {
-	return b.httpClient
-}
-
-func (b *backend) HttpAccess() *httpx.AccessConfig {
-	return b.httpAccess
 }
 
 func (b *backend) reportMetrics(ctx context.Context) (int, error) {

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -51,7 +51,7 @@ func Service(version, date string) error {
 
 	backend := rapidpro.NewBackend(rt)
 
-	server := courier.NewServer(cfg, backend)
+	server := courier.NewServer(rt, backend)
 	if err := server.Start(); err != nil {
 		return err
 	}

--- a/handler.go
+++ b/handler.go
@@ -40,7 +40,7 @@ type URNDescriber interface {
 
 // AttachmentRequestBuilder is the interface handlers which can allow a custom way to download attachment media for messages should satisfy
 type AttachmentRequestBuilder interface {
-	BuildAttachmentRequest(context.Context, Backend, Channel, string, *ChannelLog) (*http.Request, error)
+	BuildAttachmentRequest(context.Context, Channel, string, *ChannelLog) (*http.Request, error)
 }
 
 // RegisterHandler adds a new handler for a channel type, this is called by individual handlers when they are initialized

--- a/handler.go
+++ b/handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -17,7 +18,8 @@ type ChannelHandleFunc func(context.Context, Channel, http.ResponseWriter, *http
 // ChannelHandler is the interface all handlers must satisfy
 type ChannelHandler interface {
 	Initialize(*Server) error
-	Server() *Server
+	Runtime() *runtime.Runtime
+	Backend() Backend
 	ChannelType() models.ChannelType
 	ChannelName() string
 	UseChannelRouteUUID() bool

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -248,7 +248,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 }
 
 // BuildAttachmentRequest to download media for message attachment with Basic auth set
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	username := channel.StringConfigForKey(models.ConfigUsername, "")
 	if username == "" {
 		return nil, fmt.Errorf("no username set for BW channel")

--- a/handlers/bandwidth/handler_test.go
+++ b/handlers/bandwidth/handler_test.go
@@ -365,14 +365,13 @@ func TestOutgoing(t *testing.T) {
 }
 
 func TestBuildAttachmentRequest(t *testing.T) {
-	mb := test.NewMockBackend()
 	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "BW", "2020", "US",
 		[]string{urns.Phone.Prefix},
 		map[string]any{models.ConfigUsername: "user1", models.ConfigPassword: "pass1", configAccountID: "accound-id", configMsgApplicationID: "application-id"},
 	)
 
 	bwHandler := &handler{NewBaseHandler(models.ChannelType("BW"), "Bandwidth")}
-	req, _ := bwHandler.BuildAttachmentRequest(context.Background(), mb, ch, "https://example.org/v1/media/41", nil)
+	req, _ := bwHandler.BuildAttachmentRequest(context.Background(), ch, "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Basic dXNlcjE6cGFzczE=", req.Header.Get("Authorization"))
 }

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -106,9 +106,10 @@ func (h *BaseHandler) RequestHTTP(req *http.Request, clog *courier.ChannelLog) (
 	var resp *http.Response
 	var body []byte
 
-	req.Header.Set("User-Agent", userAgent(h.server.Config().Version))
+	rt := h.server.Runtime()
+	req.Header.Set("User-Agent", userAgent(rt.Config.Version))
 
-	trace, err := httpx.DoTrace(h.backend.HttpClient(), req, nil, h.backend.HttpAccess(), 0)
+	trace, err := httpx.DoTrace(rt.HttpClient, req, nil, rt.HttpAccess, 0)
 	if trace != nil {
 		clog.HTTP(trace)
 		resp = trace.Response

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -109,7 +109,7 @@ func (h *BaseHandler) RequestHTTP(req *http.Request, clog *courier.ChannelLog) (
 	rt := h.server.Runtime()
 	req.Header.Set("User-Agent", userAgent(rt.Config.Version))
 
-	trace, err := httpx.DoTrace(rt.HttpClient, req, nil, rt.HttpAccess, 0)
+	trace, err := httpx.DoTrace(rt.HTTP, req, nil, rt.HTTPAccess, 0)
 	if trace != nil {
 		clog.HTTP(trace)
 		resp = trace.Response

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -8,16 +8,17 @@ import (
 	"github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/httpx"
 )
 
 var defaultRedactConfigKeys = []string{models.ConfigAuthToken, models.ConfigAPIKey, models.ConfigSecret, models.ConfigPassword, models.ConfigSendAuthorization}
 
-// BaseHandler is the base class for most handlers, it just stored the server, name and channel type for the handler
+// BaseHandler is the base class for most handlers, it just stored the runtime, name and channel type for the handler
 type BaseHandler struct {
 	channelType        models.ChannelType
 	name               string
-	server             *courier.Server
+	rt                 *runtime.Runtime
 	backend            courier.Backend
 	uuidChannelRouting bool
 	redactConfigKeys   []string
@@ -51,13 +52,13 @@ func WithRedactConfigKeys(keys ...string) func(*BaseHandler) {
 
 // SetServer can be used to change the server on a BaseHandler
 func (h *BaseHandler) SetServer(server *courier.Server) {
-	h.server = server
+	h.rt = server.Runtime()
 	h.backend = server.Backend()
 }
 
-// Server returns the server instance on the BaseHandler
-func (h *BaseHandler) Server() *courier.Server {
-	return h.server
+// Runtime returns the runtime instance on the BaseHandler
+func (h *BaseHandler) Runtime() *runtime.Runtime {
+	return h.rt
 }
 
 // Backend returns the backend instance on the BaseHandler
@@ -106,10 +107,9 @@ func (h *BaseHandler) RequestHTTP(req *http.Request, clog *courier.ChannelLog) (
 	var resp *http.Response
 	var body []byte
 
-	rt := h.server.Runtime()
-	req.Header.Set("User-Agent", userAgent(rt.Config.Version))
+	req.Header.Set("User-Agent", userAgent(h.rt.Config.Version))
 
-	trace, err := httpx.DoTrace(rt.HTTP, req, nil, rt.HTTPAccess, 0)
+	trace, err := httpx.DoTrace(h.rt.HTTP, req, nil, h.rt.HTTPAccess, 0)
 	if trace != nil {
 		clog.HTTP(trace)
 		resp = trace.Response

--- a/handlers/base_test.go
+++ b/handlers/base_test.go
@@ -29,8 +29,7 @@ func TestRequestHTTP(t *testing.T) {
 	mm := mb.NewOutgoingMsg(mc, "019a06fa-467d-7fc8-a11e-3ad2d019fd20", cf, urns.URN("tel:+1234"), "Hello World", false, nil, "", models.MsgOriginChat)
 	clog := courier.NewChannelLogForSend(mm, nil)
 
-	cfg := runtime.NewDefaultConfig()
-	server := courier.NewServer(cfg, mb)
+	server := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), mb)
 
 	h := handlers.NewBaseHandler("NX", "Test")
 	h.SetServer(server)

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -212,7 +212,7 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 }
 
 // BuildAttachmentRequest to download media for message attachment with Bearer token set
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	token := channel.StringConfigForKey(models.ConfigAuthToken, "")
 	if token == "" {
 		return nil, fmt.Errorf("missing token for D3C channel")

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -323,10 +323,8 @@ func TestIncoming(t *testing.T) {
 }
 
 func TestBuildAttachmentRequest(t *testing.T) {
-	mb := test.NewMockBackend()
-
 	d3CHandler := &handler{NewBaseHandler(models.ChannelType("D3C"), "360Dialog")}
-	req, _ := d3CHandler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://example.org/v1/media/41", nil)
+	req, _ := d3CHandler.BuildAttachmentRequest(context.Background(), testChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "the-auth-token", req.Header.Get("D360-API-KEY"))
 

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -113,7 +113,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	if auth == "" {
 		return courier.ErrChannelConfig
 	}
-	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
+	callbackDomain := msg.Channel().CallbackDomain(h.Runtime().Config.Domain)
 	dlrURL := fmt.Sprintf("https://%s%s%s/status?uuid=%s&status=%%s", callbackDomain, "/c/dk/", msg.Channel().UUID(), msg.UUID())
 
 	parts := handlers.SplitMsgByChannel(msg.Channel(), msg.Text(), maxMsgLength)

--- a/handlers/facebook_legacy/handler_test.go
+++ b/handlers/facebook_legacy/handler_test.go
@@ -696,7 +696,7 @@ func TestDescribeURN(t *testing.T) {
 
 	channel := testChannels[0]
 	handler := newHandler()
-	handler.Initialize(courier.NewServer(runtime.NewDefaultConfig(), test.NewMockBackend()))
+	handler.Initialize(courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), test.NewMockBackend()))
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, channel, handler.RedactValues(channel))
 
 	tcs := []struct {

--- a/handlers/generic.go
+++ b/handlers/generic.go
@@ -30,7 +30,7 @@ func NewTelReceiveHandler(h courier.ChannelHandler, fromField string, bodyField 
 			return nil, WriteAndLogRequestError(ctx, h, c, w, r, err)
 		}
 		// build our msg
-		msg := h.Server().Backend().NewIncomingMsg(ctx, c, urn, body, "", clog).WithReceivedOn(time.Now().UTC())
+		msg := h.Backend().NewIncomingMsg(ctx, c, urn, body, "", clog).WithReceivedOn(time.Now().UTC())
 		return WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 	}
 }
@@ -55,7 +55,7 @@ func NewExternalIDStatusHandler(h courier.ChannelHandler, statuses map[string]mo
 		}
 
 		// create our status
-		status := h.Server().Backend().NewStatusUpdateByExternalID(c, externalID, sValue, clog)
+		status := h.Backend().NewStatusUpdateByExternalID(c, externalID, sValue, clog)
 		return WriteMsgStatusAndResponse(ctx, h, c, status, w, r)
 	}
 }

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -130,7 +130,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		return courier.ErrChannelConfig
 	}
 
-	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
+	callbackDomain := msg.Channel().CallbackDomain(h.Runtime().Config.Domain)
 	statusURL := fmt.Sprintf("https://%s/c/hx/%s/status", callbackDomain, msg.Channel().UUID())
 	receiveURL := fmt.Sprintf("https://%s/c/hx/%s/receive", callbackDomain, msg.Channel().UUID())
 

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -258,7 +258,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 
 	baseURL := msg.Channel().StringConfigForKey(models.ConfigBaseURL, "https://api.infobip.com")
-	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
+	callbackDomain := msg.Channel().CallbackDomain(h.Runtime().Config.Domain)
 	statusURL := fmt.Sprintf("https://%s%s%s/delivered", callbackDomain, "/c/ib/", msg.Channel().UUID())
 
 	var requestBody *bytes.Buffer

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -144,7 +144,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		return courier.ErrChannelConfig
 	}
 
-	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
+	callbackDomain := msg.Channel().CallbackDomain(h.Runtime().Config.Domain)
 	dlrURL := fmt.Sprintf("https://%s/c/js/%s/status", callbackDomain, msg.Channel().UUID())
 
 	// build our request

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -233,7 +233,7 @@ func (h *handler) RedactValues(ch courier.Channel) []string {
 }
 
 // BuildAttachmentRequest download media for message attachment
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	parsedURL, err := url.Parse(attachmentURL)
 	if err != nil {
 		return nil, err

--- a/handlers/jiochat/handler_test.go
+++ b/handlers/jiochat/handler_test.go
@@ -264,7 +264,7 @@ func newServer(backend courier.Backend) *courier.Server {
 	cfg := runtime.NewDefaultConfig()
 	cfg.DB = "postgres://courier_test:temba@postgres:5432/courier_test?sslmode=disable"
 	cfg.Valkey = "valkey://valkey:6379/0"
-	return courier.NewServerWithLogger(cfg, backend, logger)
+	return courier.NewServerWithLogger(runtime.NewTestRuntime(cfg), backend, logger)
 }
 
 func TestDescribeURN(t *testing.T) {

--- a/handlers/jiochat/handler_test.go
+++ b/handlers/jiochat/handler_test.go
@@ -323,7 +323,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, testChannels[0], handler.RedactValues(testChannels[0]))
 
 	// check that request has the fetched access token
-	req, err := handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://channels.jiochat.com/media/download.action?media_id=12", clog)
+	req, err := handler.BuildAttachmentRequest(context.Background(), testChannels[0], "https://channels.jiochat.com/media/download.action?media_id=12", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://channels.jiochat.com/media/download.action?media_id=12", req.URL.String())
 	assert.Equal(t, "Bearer SESAME", req.Header.Get("Authorization"))
@@ -333,7 +333,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	assert.Equal(t, "https://channels.jiochat.com/auth/token.action", clog.HttpLogs[0].URL)
 
 	// check that another request reads token from cache
-	req, err = handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://channels.jiochat.com/media/download.action?media_id=13", clog)
+	req, err = handler.BuildAttachmentRequest(context.Background(), testChannels[0], "https://channels.jiochat.com/media/download.action?media_id=13", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://channels.jiochat.com/media/download.action?media_id=13", req.URL.String())
 	assert.Equal(t, "Bearer SESAME", req.Header.Get("Authorization"))

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -238,7 +238,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 }
 
 func (h *handler) newSendForm(channel courier.Channel, msgType, toContact string) map[string]string {
-	callbackDomain := channel.CallbackDomain(h.Server().Config().Domain)
+	callbackDomain := channel.CallbackDomain(h.Runtime().Config.Domain)
 	statusURL := fmt.Sprintf("https://%s/c/kwa/%s/status", callbackDomain, channel.UUID())
 
 	return map[string]string{

--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -128,7 +128,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 	dlrMask := msg.Channel().StringConfigForKey(configDLRMask, defaultDLRMask)
 
-	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
+	callbackDomain := msg.Channel().CallbackDomain(h.Runtime().Config.Domain)
 	dlrURL := fmt.Sprintf("https://%s/c/kn/%s/status?uuid=%s&status=%%d", callbackDomain, msg.Channel().UUID(), msg.UUID())
 
 	// build our request

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -178,7 +178,7 @@ func buildMediaURL(mediaID string) string {
 }
 
 // BuildAttachmentRequest to download media for message attachment with Bearer token set
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	token := channel.StringConfigForKey(models.ConfigAuthToken, "")
 	if token == "" {
 		return nil, fmt.Errorf("missing token for LN channel")

--- a/handlers/line/handler_test.go
+++ b/handlers/line/handler_test.go
@@ -619,10 +619,8 @@ func TestOutgoing(t *testing.T) {
 }
 
 func TestBuildAttachmentRequest(t *testing.T) {
-	mb := test.NewMockBackend()
-
 	lnHandler := &handler{NewBaseHandler(models.ChannelType("LN"), "Line")}
-	req, _ := lnHandler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://example.org/v1/media/41", nil)
+	req, _ := lnHandler.BuildAttachmentRequest(context.Background(), testChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer the-auth-token", req.Header.Get("Authorization"))
 }

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -306,7 +306,7 @@ func (h *handler) validateSignature(c courier.Channel, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	CalledURL := fmt.Sprintf("https://%s%s", c.CallbackDomain(h.Server().Config().Domain), r.URL.Path)
+	CalledURL := fmt.Sprintf("https://%s%s", c.CallbackDomain(h.Runtime().Config.Domain), r.URL.Path)
 	expectedURLHash := calculateSignature([]byte(CalledURL))
 	URLHash := verifiedToken["url_hash"].(string)
 

--- a/handlers/meta/facebook_test.go
+++ b/handlers/meta/facebook_test.go
@@ -647,7 +647,7 @@ func TestFacebookBuildAttachmentRequest(t *testing.T) {
 
 	handler := &handler{NewBaseHandler(models.ChannelType("FBA"), "Facebook", DisableUUIDRouting())}
 	handler.Initialize(s)
-	req, _ := handler.BuildAttachmentRequest(context.Background(), mb, facebookTestChannels[0], "https://example.org/v1/media/41", nil)
+	req, _ := handler.BuildAttachmentRequest(context.Background(), facebookTestChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, http.Header{}, req.Header)
 }

--- a/handlers/meta/facebook_test.go
+++ b/handlers/meta/facebook_test.go
@@ -293,7 +293,7 @@ func TestFacebookDescribeURN(t *testing.T) {
 
 	channel := facebookTestChannels[0]
 	handler := newHandler("FBA", "Facebook")
-	handler.Initialize(courier.NewServer(runtime.NewDefaultConfig(), test.NewMockBackend()))
+	handler.Initialize(courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), test.NewMockBackend()))
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, channel, handler.RedactValues(channel))
 
 	tcs := []struct {
@@ -643,7 +643,7 @@ func TestSigning(t *testing.T) {
 
 func TestFacebookBuildAttachmentRequest(t *testing.T) {
 	mb := test.NewMockBackend()
-	s := courier.NewServer(runtime.NewDefaultConfig(), mb)
+	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), mb)
 
 	handler := &handler{NewBaseHandler(models.ChannelType("FBA"), "Facebook", DisableUUIDRouting())}
 	handler.Initialize(s)

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -111,7 +111,7 @@ type Notifications struct {
 
 func (h *handler) RedactValues(ch courier.Channel) []string {
 	vals := h.BaseHandler.RedactValues(ch)
-	vals = append(vals, h.Server().Config().FacebookApplicationSecret, h.Server().Config().FacebookWebhookSecret, h.Server().Config().WhatsappAdminSystemUserToken)
+	vals = append(vals, h.Runtime().Config.FacebookApplicationSecret, h.Runtime().Config.FacebookWebhookSecret, h.Runtime().Config.WhatsappAdminSystemUserToken)
 	return vals
 }
 
@@ -175,7 +175,7 @@ func (h *handler) receiveVerify(ctx context.Context, channel courier.Channel, w 
 
 	// verify the token against our server facebook webhook secret, if the same return the challenge FB sent us
 	secret := r.URL.Query().Get("hub.verify_token")
-	if !utils.SecretEqual(secret, h.Server().Config().FacebookWebhookSecret) {
+	if !utils.SecretEqual(secret, h.Runtime().Config.FacebookWebhookSecret) {
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, fmt.Errorf("token does not match secret"))
 	}
 	// and respond with the challenge token
@@ -247,7 +247,7 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 	// the list of data we will return in our response
 	data := make([]any, 0, 2)
 
-	token := h.Server().Config().WhatsappAdminSystemUserToken
+	token := h.Runtime().Config.WhatsappAdminSystemUserToken
 
 	seenMsgIDs := make(map[string]bool, 2)
 	contactNames := make(map[string]string)
@@ -699,7 +699,7 @@ func (h *handler) sendFacebookInstagramMsg(ctx context.Context, msg courier.MsgO
 
 func (h *handler) sendWhatsAppMsg(ctx context.Context, msg courier.MsgOut, res *courier.SendResult, clog *courier.ChannelLog) error {
 	// can't do anything without an access token
-	accessToken := h.Server().Config().WhatsappAdminSystemUserToken
+	accessToken := h.Runtime().Config.WhatsappAdminSystemUserToken
 
 	base, _ := url.Parse(graphURL)
 	path, _ := url.Parse(fmt.Sprintf("/%s/messages", msg.Channel().Address()))
@@ -822,7 +822,7 @@ func (h *handler) validateSignature(r *http.Request) error {
 	if headerSignature == "" {
 		return fmt.Errorf("missing request signature")
 	}
-	appSecret := h.Server().Config().FacebookApplicationSecret
+	appSecret := h.Runtime().Config.FacebookApplicationSecret
 
 	body, err := handlers.ReadBody(r, maxRequestBodyBytes)
 	if err != nil {
@@ -860,7 +860,7 @@ func fbCalculateSignature(appSecret string, body []byte) (string, error) {
 
 // BuildAttachmentRequest to download media for message attachment with Bearer token set
 func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
-	token := h.Server().Config().WhatsappAdminSystemUserToken
+	token := h.Runtime().Config.WhatsappAdminSystemUserToken
 	if token == "" {
 		return nil, fmt.Errorf("missing token for WAC channel")
 	}

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -859,7 +859,7 @@ func fbCalculateSignature(appSecret string, body []byte) (string, error) {
 }
 
 // BuildAttachmentRequest to download media for message attachment with Bearer token set
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	token := h.Runtime().Config.WhatsappAdminSystemUserToken
 	if token == "" {
 		return nil, fmt.Errorf("missing token for WAC channel")

--- a/handlers/meta/instagram_test.go
+++ b/handlers/meta/instagram_test.go
@@ -474,7 +474,7 @@ func TestInstagramBuildAttachmentRequest(t *testing.T) {
 
 	handler := &handler{NewBaseHandler(models.ChannelType("IG"), "Instagram", DisableUUIDRouting())}
 	handler.Initialize(s)
-	req, _ := handler.BuildAttachmentRequest(context.Background(), mb, facebookTestChannels[0], "https://example.org/v1/media/41", nil)
+	req, _ := handler.BuildAttachmentRequest(context.Background(), facebookTestChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, http.Header{}, req.Header)
 }

--- a/handlers/meta/instagram_test.go
+++ b/handlers/meta/instagram_test.go
@@ -449,7 +449,7 @@ func TestInstagramDescribeURN(t *testing.T) {
 
 	channel := instgramTestChannels[0]
 	handler := newHandler("IG", "Instagram")
-	handler.Initialize(courier.NewServer(runtime.NewDefaultConfig(), test.NewMockBackend()))
+	handler.Initialize(courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), test.NewMockBackend()))
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, channel, handler.RedactValues(channel))
 
 	tcs := []struct {
@@ -470,7 +470,7 @@ func TestInstagramDescribeURN(t *testing.T) {
 
 func TestInstagramBuildAttachmentRequest(t *testing.T) {
 	mb := test.NewMockBackend()
-	s := courier.NewServer(runtime.NewDefaultConfig(), mb)
+	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), mb)
 
 	handler := &handler{NewBaseHandler(models.ChannelType("IG"), "Instagram", DisableUUIDRouting())}
 	handler.Initialize(s)

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -914,7 +914,7 @@ func TestWhatsAppBuildAttachmentRequest(t *testing.T) {
 	s := newServerWithWAC(mb)
 	handler := &handler{NewBaseHandler(models.ChannelType("WAC"), "WhatsApp Cloud", DisableUUIDRouting())}
 	handler.Initialize(s)
-	req, _ := handler.BuildAttachmentRequest(context.Background(), mb, whatsappTestChannels[0], "https://example.org/v1/media/41", nil)
+	req, _ := handler.BuildAttachmentRequest(context.Background(), whatsappTestChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer wac_admin_system_user_token", req.Header.Get("Authorization"))
 }

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -922,5 +922,5 @@ func TestWhatsAppBuildAttachmentRequest(t *testing.T) {
 func newServerWithWAC(backend courier.Backend) *courier.Server {
 	cfg := runtime.NewDefaultConfig()
 	cfg.WhatsappAdminSystemUserToken = "wac_admin_system_user_token"
-	return courier.NewServer(cfg, backend)
+	return courier.NewServer(runtime.NewTestRuntime(cfg), backend)
 }

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -179,7 +179,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 
 	// build our callback URL
-	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
+	callbackDomain := msg.Channel().CallbackDomain(h.Runtime().Config.Domain)
 	callbackURL := fmt.Sprintf("https://%s/c/nx/%s/status", callbackDomain, msg.Channel().UUID())
 
 	text := handlers.GetTextAndAttachments(msg)

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -145,7 +145,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		return courier.ErrChannelConfig
 	}
 
-	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
+	callbackDomain := msg.Channel().CallbackDomain(h.Runtime().Config.Domain)
 	statusURL := fmt.Sprintf("https://%s/c/pl/%s/status", callbackDomain, msg.Channel().UUID())
 
 	parts := handlers.SplitMsgByChannel(msg.Channel(), handlers.GetTextAndAttachments(msg), maxMsgLength)

--- a/handlers/responses.go
+++ b/handlers/responses.go
@@ -11,7 +11,7 @@ import (
 func WriteMsgsAndResponse(ctx context.Context, h courier.ChannelHandler, msgs []courier.MsgIn, w http.ResponseWriter, r *http.Request, clog *courier.ChannelLog) ([]courier.Event, error) {
 	events := make([]courier.Event, len(msgs))
 	for i, m := range msgs {
-		err := h.Server().Backend().WriteMsg(ctx, m, clog)
+		err := h.Backend().WriteMsg(ctx, m, clog)
 		if err != nil {
 			return nil, err
 		}
@@ -23,7 +23,7 @@ func WriteMsgsAndResponse(ctx context.Context, h courier.ChannelHandler, msgs []
 
 // WriteMsgStatusAndResponse write the passed in status to our backend
 func WriteMsgStatusAndResponse(ctx context.Context, h courier.ChannelHandler, channel courier.Channel, status courier.StatusUpdate, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
-	err := h.Server().Backend().WriteStatusUpdate(ctx, status)
+	err := h.Backend().WriteStatusUpdate(ctx, status)
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/rocketchat/handler.go
+++ b/handlers/rocketchat/handler.go
@@ -84,7 +84,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 }
 
 // BuildAttachmentRequest download media for message attachment with RC auth_token/user_id set
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	adminAuthToken := channel.StringConfigForKey(configAdminAuthToken, "")
 	adminUserID := channel.StringConfigForKey(configAdminUserID, "")
 	if adminAuthToken == "" || adminUserID == "" {

--- a/handlers/slack/handler_test.go
+++ b/handlers/slack/handler_test.go
@@ -371,7 +371,7 @@ func TestDescribeURN(t *testing.T) {
 	defer server.Close()
 
 	handler := newHandler()
-	handler.Initialize(courier.NewServer(runtime.NewDefaultConfig(), test.NewMockBackend()))
+	handler.Initialize(courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), test.NewMockBackend()))
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, testChannels[0], handler.RedactValues(testChannels[0]))
 	urn, _ := urns.New(urns.Slack, "U012345")
 

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -81,7 +81,7 @@ type IncomingTestCase struct {
 func testHandlerRequest(tb testing.TB, s *courier.Server, path string, headers map[string]string, data string, multipartFormFields map[string]string, expectedStatus int, expectedBodyContains string, requestPrepFunc RequestPrepFunc) string {
 	var req *http.Request
 	var err error
-	url := fmt.Sprintf("https://%s%s", s.Config().Domain, path)
+	url := fmt.Sprintf("https://%s%s", s.Runtime().Config.Domain, path)
 
 	if data != "" {
 		req, err = http.NewRequest(http.MethodPost, url, strings.NewReader(data))

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -148,7 +148,7 @@ func newServer(backend courier.Backend) *courier.Server {
 	cfg.FacebookApplicationSecret = "fb_app_secret"
 	cfg.WhatsappAdminSystemUserToken = "wac_admin_system_user_token"
 
-	return courier.NewServerWithLogger(cfg, backend, logger)
+	return courier.NewServerWithLogger(runtime.NewTestRuntime(cfg), backend, logger)
 
 }
 

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -312,7 +312,7 @@ func resolveMediaURL(channel courier.Channel, mediaID string) (string, error) {
 }
 
 // BuildAttachmentRequest to download media for message attachment with Bearer token set
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	token := channel.StringConfigForKey(models.ConfigAuthToken, "")
 	if token == "" {
 		return nil, fmt.Errorf("missing token for TRN channel")

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -578,10 +578,8 @@ func TestIncoming(t *testing.T) {
 }
 
 func TestBuildAttachmentRequest(t *testing.T) {
-	mb := test.NewMockBackend()
-
 	waHandler := &handler{NewBaseHandler(models.ChannelType("TRN"), "WhatsApp")}
-	req, _ := waHandler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://example.org/v1/media/41", nil)
+	req, _ := waHandler.BuildAttachmentRequest(context.Background(), testChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer a123", req.Header.Get("Authorization"))
 }

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -227,7 +227,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w 
 
 func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.SendResult, clog *courier.ChannelLog) error {
 	// build our callback URL
-	callbackDomain := msg.Channel().CallbackDomain(h.Server().Config().Domain)
+	callbackDomain := msg.Channel().CallbackDomain(h.Runtime().Config.Domain)
 	callbackURL := fmt.Sprintf("https://%s/c/%s/%s/status?uuid=%s&action=callback", callbackDomain, strings.ToLower(string(h.ChannelType())), msg.Channel().UUID(), msg.UUID())
 
 	accountSID := msg.Channel().StringConfigForKey(configAccountSID, "")

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -429,7 +429,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 }
 
 // BuildAttachmentRequest to download media for message attachment with Basic auth set
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	accountSID := channel.StringConfigForKey(configAccountSID, "")
 	if accountSID == "" {
 		return nil, fmt.Errorf("missing account sid for %s channel", h.ChannelName())

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -1422,8 +1422,6 @@ func TestOutgoing(t *testing.T) {
 }
 
 func TestBuildAttachmentRequest(t *testing.T) {
-	mb := test.NewMockBackend()
-
 	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "T", "2020", "US",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
@@ -1431,7 +1429,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 			models.ConfigAuthToken: "authToken"})
 
 	twHandler := &handler{NewBaseHandler(models.ChannelType("T"), "Twilio"), true}
-	req, _ := twHandler.BuildAttachmentRequest(context.Background(), mb, defaultChannel, "https://example.org/v1/media/41", nil)
+	req, _ := twHandler.BuildAttachmentRequest(context.Background(), defaultChannel, "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Basic YWNjb3VudFNJRDphdXRoVG9rZW4=", req.Header.Get("Authorization"))
 
@@ -1443,7 +1441,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 			configSendURL:          "BASE_URL",
 		})
 	swHandler := &handler{NewBaseHandler(models.ChannelType("SW"), "SignalWire"), false}
-	req, _ = swHandler.BuildAttachmentRequest(context.Background(), mb, swChannel, "https://example.org/v1/media/41", nil)
+	req, _ = swHandler.BuildAttachmentRequest(context.Background(), swChannel, "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "", req.Header.Get("Authorization"))
 }

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -522,7 +522,7 @@ func (h *handler) downloadMedia(mediaURL string) (io.Reader, error) {
 		return nil, err
 	}
 
-	if res, err := httpx.Do(h.Backend().HttpClient(), req, nil, nil); err == nil {
+	if res, err := httpx.Do(h.Server().Runtime().HttpClient, req, nil, nil); err == nil {
 		return res.Body, nil
 	} else {
 		return nil, err

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -522,7 +522,7 @@ func (h *handler) downloadMedia(mediaURL string) (io.Reader, error) {
 		return nil, err
 	}
 
-	if res, err := httpx.Do(h.Server().Runtime().HttpClient, req, nil, nil); err == nil {
+	if res, err := httpx.Do(h.Server().Runtime().HTTP, req, nil, nil); err == nil {
 		return res.Body, nil
 	} else {
 		return nil, err

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -522,7 +522,7 @@ func (h *handler) downloadMedia(mediaURL string) (io.Reader, error) {
 		return nil, err
 	}
 
-	if res, err := httpx.Do(h.Server().Runtime().HTTP, req, nil, nil); err == nil {
+	if res, err := httpx.Do(h.Runtime().HTTP, req, nil, nil); err == nil {
 		return res.Body, nil
 	} else {
 		return nil, err

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -522,7 +522,7 @@ func (h *handler) downloadMedia(mediaURL string) (io.Reader, error) {
 		return nil, err
 	}
 
-	if res, err := httpx.Do(h.Runtime().HTTP, req, nil, nil); err == nil {
+	if res, err := httpx.Do(h.Runtime().HTTP, req, nil, h.Runtime().HTTPAccess); err == nil {
 		return res.Body, nil
 	} else {
 		return nil, err

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -374,7 +374,7 @@ func TestDescribeURN(t *testing.T) {
 	defer func() { apiBaseURL = realAPIUrl }()
 
 	handler := newHandler()
-	handler.Initialize(courier.NewServer(runtime.NewDefaultConfig(), test.NewMockBackend()))
+	handler.Initialize(courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), test.NewMockBackend()))
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, testChannels[0], handler.RedactValues(testChannels[0]))
 	urn, _ := urns.New(urns.VK, "123456789")
 	data := map[string]string{"name": "John Doe"}

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -256,7 +256,7 @@ func (h *handler) RedactValues(ch courier.Channel) []string {
 }
 
 // BuildAttachmentRequest download media for message attachment
-func (h *handler) BuildAttachmentRequest(ctx context.Context, b courier.Backend, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
+func (h *handler) BuildAttachmentRequest(ctx context.Context, channel courier.Channel, attachmentURL string, clog *courier.ChannelLog) (*http.Request, error) {
 	accessToken, err := h.getAccessToken(channel, clog)
 	if err != nil {
 		return nil, err

--- a/handlers/wechat/handler_test.go
+++ b/handlers/wechat/handler_test.go
@@ -276,7 +276,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, testChannels[0], handler.RedactValues(testChannels[0]))
 
 	// check that request has the fetched access token
-	req, err := handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://api.weixin.qq.com/cgi-bin/media/download.action?media_id=12", clog)
+	req, err := handler.BuildAttachmentRequest(context.Background(), testChannels[0], "https://api.weixin.qq.com/cgi-bin/media/download.action?media_id=12", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://api.weixin.qq.com/cgi-bin/media/download.action?access_token=SESAME&media_id=12", req.URL.String())
 
@@ -285,7 +285,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	assert.Equal(t, "https://api.weixin.qq.com/cgi-bin/token?appid=app-id&grant_type=client_credential&secret=**********", clog.HttpLogs[0].URL)
 
 	// check that another request reads token from cache
-	req, err = handler.BuildAttachmentRequest(context.Background(), mb, testChannels[0], "https://api.weixin.qq.com/cgi-bin/media/download.action?media_id=13", clog)
+	req, err = handler.BuildAttachmentRequest(context.Background(), testChannels[0], "https://api.weixin.qq.com/cgi-bin/media/download.action?media_id=13", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://api.weixin.qq.com/cgi-bin/media/download.action?access_token=SESAME&media_id=13", req.URL.String())
 	assert.Len(t, clog.HttpLogs, 1)

--- a/handlers/wechat/handler_test.go
+++ b/handlers/wechat/handler_test.go
@@ -217,7 +217,7 @@ func newServer(backend courier.Backend) *courier.Server {
 	cfg := runtime.NewDefaultConfig()
 	cfg.DB = "postgres://courier_test:temba@postgres:5432/courier_test?sslmode=disable"
 	cfg.Valkey = "valkey://valkey:6379/0"
-	return courier.NewServerWithLogger(cfg, backend, logger)
+	return courier.NewServerWithLogger(runtime.NewTestRuntime(cfg), backend, logger)
 }
 
 func TestDescribeURN(t *testing.T) {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -24,7 +24,7 @@ type Runtime struct {
 	S3     *s3x.Service
 	CW     *cwatch.Service
 
-	HTTP *http.Client
+	HTTP       *http.Client
 	HTTPAccess *httpx.AccessConfig
 
 	Writers *Writers
@@ -69,7 +69,10 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 	transport.IdleConnTimeout = 15 * time.Second
 	rt.HTTP = &http.Client{Transport: transport, Timeout: 30 * time.Second}
 
-	disallowedIPs, disallowedNets, _ := cfg.ParseDisallowedNetworks()
+	disallowedIPs, disallowedNets, err := cfg.ParseDisallowedNetworks()
+	if err != nil {
+		return nil, fmt.Errorf("error parsing disallowed networks: %w", err)
+	}
 	rt.HTTPAccess = httpx.NewAccessConfig(10*time.Second, disallowedIPs, disallowedNets)
 
 	rt.Spool = dynamo.NewSpool(rt.Dynamo, rt.Config.SpoolDir+"/dynamo", 30*time.Second)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -24,8 +24,8 @@ type Runtime struct {
 	S3     *s3x.Service
 	CW     *cwatch.Service
 
-	HttpClient *http.Client
-	HttpAccess *httpx.AccessConfig
+	HTTP *http.Client
+	HTTPAccess *httpx.AccessConfig
 
 	Writers *Writers
 	Spool   *dynamo.Spool
@@ -67,10 +67,10 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 	transport.MaxIdleConns = 64
 	transport.MaxIdleConnsPerHost = 8
 	transport.IdleConnTimeout = 15 * time.Second
-	rt.HttpClient = &http.Client{Transport: transport, Timeout: 30 * time.Second}
+	rt.HTTP = &http.Client{Transport: transport, Timeout: 30 * time.Second}
 
 	disallowedIPs, disallowedNets, _ := cfg.ParseDisallowedNetworks()
-	rt.HttpAccess = httpx.NewAccessConfig(10*time.Second, disallowedIPs, disallowedNets)
+	rt.HTTPAccess = httpx.NewAccessConfig(10*time.Second, disallowedIPs, disallowedNets)
 
 	rt.Spool = dynamo.NewSpool(rt.Dynamo, rt.Config.SpoolDir+"/dynamo", 30*time.Second)
 	rt.Writers = newWriters(cfg, rt.Dynamo, rt.Spool)
@@ -79,10 +79,10 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 }
 
 // NewTestRuntime returns a minimal Runtime wrapping the given config, suitable for tests that need a
-// Runtime but don't bring up real backing services. It populates HttpClient with http.DefaultClient so
+// Runtime but don't bring up real backing services. It populates HTTP with http.DefaultClient so
 // code paths that issue outbound HTTP requests work against test servers.
 func NewTestRuntime(cfg *Config) *Runtime {
-	return &Runtime{Config: cfg, HttpClient: http.DefaultClient}
+	return &Runtime{Config: cfg, HTTP: http.DefaultClient}
 }
 
 func (r *Runtime) Start() error {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -10,6 +11,7 @@ import (
 	"github.com/nyaruka/gocommon/aws/cwatch"
 	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/gocommon/aws/s3x"
+	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/vkutil"
 	"github.com/vinovest/sqlx"
 )
@@ -21,6 +23,9 @@ type Runtime struct {
 	VK     *redis.Pool
 	S3     *s3x.Service
 	CW     *cwatch.Service
+
+	HttpClient *http.Client
+	HttpAccess *httpx.AccessConfig
 
 	Writers *Writers
 	Spool   *dynamo.Spool
@@ -58,10 +63,26 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 		return nil, fmt.Errorf("error creating Cloudwatch service: %w", err)
 	}
 
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 64
+	transport.MaxIdleConnsPerHost = 8
+	transport.IdleConnTimeout = 15 * time.Second
+	rt.HttpClient = &http.Client{Transport: transport, Timeout: 30 * time.Second}
+
+	disallowedIPs, disallowedNets, _ := cfg.ParseDisallowedNetworks()
+	rt.HttpAccess = httpx.NewAccessConfig(10*time.Second, disallowedIPs, disallowedNets)
+
 	rt.Spool = dynamo.NewSpool(rt.Dynamo, rt.Config.SpoolDir+"/dynamo", 30*time.Second)
 	rt.Writers = newWriters(cfg, rt.Dynamo, rt.Spool)
 
 	return rt, nil
+}
+
+// NewTestRuntime returns a minimal Runtime wrapping the given config, suitable for tests that need a
+// Runtime but don't bring up real backing services. It populates HttpClient with http.DefaultClient so
+// code paths that issue outbound HTTP requests work against test servers.
+func NewTestRuntime(cfg *Config) *Runtime {
+	return &Runtime{Config: cfg, HttpClient: http.DefaultClient}
 }
 
 func (r *Runtime) Start() error {

--- a/server.go
+++ b/server.go
@@ -34,7 +34,7 @@ const (
 	contextRequestStart
 )
 
-// NewServer creates a new Server for the passed in configuration. The server will have to be started
+// NewServer creates a new Server for the passed in runtime. The server will have to be started
 // afterwards, which is when configuration options are checked.
 func NewServer(rt *runtime.Runtime, backend Backend) *Server {
 	// create our top level router
@@ -42,7 +42,7 @@ func NewServer(rt *runtime.Runtime, backend Backend) *Server {
 	return NewServerWithLogger(rt, backend, logger)
 }
 
-// NewServerWithLogger creates a new Server for the passed in configuration. The server will have to be started
+// NewServerWithLogger creates a new Server for the passed in runtime. The server will have to be started
 // afterwards, which is when configuration options are checked.
 func NewServerWithLogger(rt *runtime.Runtime, backend Backend, logger *slog.Logger) *Server {
 	// channelRouter holds the dynamically-registered channel handler routes - mounted at /c/ on the public listener
@@ -235,7 +235,6 @@ type Server struct {
 	waitGroup *sync.WaitGroup
 	stopChan  chan bool
 	stopped   bool
-
 }
 
 func (s *Server) initializeChannelHandlers() {
@@ -428,4 +427,3 @@ func (s *Server) tokenAuthRequired(h http.HandlerFunc) http.HandlerFunc {
 		h(w, r)
 	}
 }
-

--- a/server.go
+++ b/server.go
@@ -36,15 +36,15 @@ const (
 
 // NewServer creates a new Server for the passed in configuration. The server will have to be started
 // afterwards, which is when configuration options are checked.
-func NewServer(config *runtime.Config, backend Backend) *Server {
+func NewServer(rt *runtime.Runtime, backend Backend) *Server {
 	// create our top level router
 	logger := slog.Default()
-	return NewServerWithLogger(config, backend, logger)
+	return NewServerWithLogger(rt, backend, logger)
 }
 
 // NewServerWithLogger creates a new Server for the passed in configuration. The server will have to be started
 // afterwards, which is when configuration options are checked.
-func NewServerWithLogger(config *runtime.Config, backend Backend, logger *slog.Logger) *Server {
+func NewServerWithLogger(rt *runtime.Runtime, backend Backend, logger *slog.Logger) *Server {
 	// channelRouter holds the dynamically-registered channel handler routes - mounted at /c/ on the public listener
 	channelRouter := chi.NewRouter()
 
@@ -61,7 +61,7 @@ func NewServerWithLogger(config *runtime.Config, backend Backend, logger *slog.L
 	testRouter.Mount("/c/", channelRouter)
 
 	return &Server{
-		config:  config,
+		rt:      rt,
 		backend: backend,
 
 		channelRouter: channelRouter,
@@ -80,12 +80,12 @@ func (s *Server) Start() error {
 	// bind both listener sockets up front so callers know we're accepting connections by the
 	// time Start returns, and so a bind failure fails fast before we've started the backend,
 	// spool flushers, or anything else that would need to be unwound
-	publicAddr := fmt.Sprintf("%s:%d", s.config.PublicAddress, s.config.PublicPort)
+	publicAddr := fmt.Sprintf("%s:%d", s.rt.Config.PublicAddress, s.rt.Config.PublicPort)
 	publicLn, err := net.Listen("tcp", publicAddr)
 	if err != nil {
 		return fmt.Errorf("error binding public listener on %s: %w", publicAddr, err)
 	}
-	internalAddr := fmt.Sprintf("%s:%d", s.config.InternalAddress, s.config.InternalPort)
+	internalAddr := fmt.Sprintf("%s:%d", s.rt.Config.InternalAddress, s.rt.Config.InternalPort)
 	internalLn, err := net.Listen("tcp", internalAddr)
 	if err != nil {
 		publicLn.Close()
@@ -151,7 +151,7 @@ func (s *Server) Start() error {
 		defer s.waitGroup.Done()
 
 		log := slog.With("comp", "server", "listener", "public", "address", s.publicServer.Addr)
-		log.Info("server started", "version", s.config.Version)
+		log.Info("server started", "version", s.rt.Config.Version)
 
 		err := s.publicServer.Serve(publicLn)
 		if err != nil && err != http.ErrServerClosed {
@@ -163,7 +163,7 @@ func (s *Server) Start() error {
 		defer s.waitGroup.Done()
 
 		log := slog.With("comp", "server", "listener", "internal", "address", s.internalServer.Addr)
-		log.Info("server started", "version", s.config.Version)
+		log.Info("server started", "version", s.rt.Config.Version)
 
 		err := s.internalServer.Serve(internalLn)
 		if err != nil && err != http.ErrServerClosed {
@@ -172,7 +172,7 @@ func (s *Server) Start() error {
 	}()
 
 	// start our foreman for outgoing messages
-	s.foreman = NewForeman(s, s.config.MaxWorkers)
+	s.foreman = NewForeman(s, s.rt.Config.MaxWorkers)
 	s.foreman.Start()
 
 	return nil
@@ -214,7 +214,8 @@ func (s *Server) GetHandler(ch Channel) ChannelHandler { return activeHandlers[c
 
 func (s *Server) WaitGroup() *sync.WaitGroup { return s.waitGroup }
 func (s *Server) StopChan() chan bool        { return s.stopChan }
-func (s *Server) Config() *runtime.Config    { return s.config }
+func (s *Server) Runtime() *runtime.Runtime  { return s.rt }
+func (s *Server) Config() *runtime.Config    { return s.rt.Config }
 func (s *Server) Stopped() bool              { return s.stopped }
 
 func (s *Server) Backend() Backend   { return s.backend }
@@ -230,7 +231,7 @@ type Server struct {
 
 	foreman *Foreman
 
-	config *runtime.Config
+	rt *runtime.Runtime
 
 	waitGroup *sync.WaitGroup
 	stopChan  chan bool
@@ -239,8 +240,8 @@ type Server struct {
 }
 
 func (s *Server) initializeChannelHandlers() {
-	includes := s.config.IncludeChannels
-	excludes := s.config.ExcludeChannels
+	includes := s.rt.Config.IncludeChannels
+	excludes := s.rt.Config.ExcludeChannels
 
 	// initialize handlers which are included/not-excluded in the config
 	for _, handler := range registeredHandlers {
@@ -358,7 +359,7 @@ func (s *Server) handleFetchAttachment(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
 	defer cancel()
 
-	resp, err := fetchAttachment(ctx, s.backend, r)
+	resp, err := fetchAttachment(ctx, s.rt, s.backend, r)
 	if err != nil {
 		slog.Error("error fetching attachment", "error", err)
 		WriteError(w, http.StatusBadRequest, err)
@@ -411,7 +412,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(jsonx.MustMarshal(map[string]string{
 		"component": "courier",
-		"version":   s.config.Version,
+		"version":   s.rt.Config.Version,
 	}))
 }
 
@@ -419,7 +420,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 func (s *Server) tokenAuthRequired(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		authHeader := r.Header.Get("Authorization")
-		if !strings.HasPrefix(authHeader, "Bearer ") || !utils.SecretEqual(authHeader[7:], s.config.AuthToken) {
+		if !strings.HasPrefix(authHeader, "Bearer ") || !utils.SecretEqual(authHeader[7:], s.rt.Config.AuthToken) {
 			w.Header().Set("Content-Type", "text/plain")
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte("Unauthorized"))

--- a/server.go
+++ b/server.go
@@ -215,7 +215,6 @@ func (s *Server) GetHandler(ch Channel) ChannelHandler { return activeHandlers[c
 func (s *Server) WaitGroup() *sync.WaitGroup { return s.waitGroup }
 func (s *Server) StopChan() chan bool        { return s.stopChan }
 func (s *Server) Runtime() *runtime.Runtime  { return s.rt }
-func (s *Server) Config() *runtime.Config    { return s.rt.Config }
 func (s *Server) Stopped() bool              { return s.stopped }
 
 func (s *Server) Backend() Backend   { return s.backend }

--- a/server_test.go
+++ b/server_test.go
@@ -34,7 +34,7 @@ func testConfig() *runtime.Config {
 func TestIncoming(t *testing.T) {
 	// create and start our backend and server
 	mb := test.NewMockBackend()
-	s := courier.NewServer(testConfig(), mb)
+	s := courier.NewServer(runtime.NewTestRuntime(testConfig()), mb)
 
 	require.NoError(t, s.Start())
 	defer s.Stop()
@@ -79,7 +79,7 @@ func TestOutgoing(t *testing.T) {
 
 	// create and start our backend and server
 	mb := test.NewMockBackend()
-	s := courier.NewServer(testConfig(), mb)
+	s := courier.NewServer(runtime.NewTestRuntime(testConfig()), mb)
 
 	require.NoError(t, s.Start())
 	defer s.Stop()
@@ -205,7 +205,7 @@ func TestFetchAttachment(t *testing.T) {
 	mockChannel := test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
 	mb.AddChannel(mockChannel)
 
-	server := courier.NewServerWithLogger(cfg, mb, logger)
+	server := courier.NewServerWithLogger(runtime.NewTestRuntime(cfg), mb, logger)
 	require.NoError(t, server.Start())
 	defer server.Stop()
 
@@ -269,7 +269,7 @@ func TestListeners(t *testing.T) {
 	mb := test.NewMockBackend()
 	mb.AddChannel(test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, nil))
 
-	server := courier.NewServerWithLogger(cfg, mb, slog.Default())
+	server := courier.NewServerWithLogger(runtime.NewTestRuntime(cfg), mb, slog.Default())
 	require.NoError(t, server.Start())
 	defer server.Stop()
 

--- a/test/backend.go
+++ b/test/backend.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
 	"sync"
 	"time"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/utils"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
 )
@@ -339,14 +337,6 @@ func (mb *MockBackend) ResolveMedia(ctx context.Context, mediaUrl string) (*mode
 	}
 
 	return media, nil
-}
-
-func (mb *MockBackend) HttpClient() *http.Client {
-	return http.DefaultClient
-}
-
-func (mb *MockBackend) HttpAccess() *httpx.AccessConfig {
-	return nil
 }
 
 // RedisPool returns the redisPool for this backend

--- a/test/handler.go
+++ b/test/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils/clogs"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
@@ -17,7 +18,7 @@ func init() {
 }
 
 type mockHandler struct {
-	server  *courier.Server
+	rt      *runtime.Runtime
 	backend courier.Backend
 }
 
@@ -26,7 +27,8 @@ func NewMockHandler() courier.ChannelHandler {
 	return &mockHandler{}
 }
 
-func (h *mockHandler) Server() *courier.Server               { return h.server }
+func (h *mockHandler) Runtime() *runtime.Runtime             { return h.rt }
+func (h *mockHandler) Backend() courier.Backend              { return h.backend }
 func (h *mockHandler) ChannelName() string                   { return "Mock Handler" }
 func (h *mockHandler) ChannelType() models.ChannelType       { return models.ChannelType("MCK") }
 func (h *mockHandler) UseChannelRouteUUID() bool             { return true }
@@ -39,7 +41,7 @@ func (h *mockHandler) GetChannel(ctx context.Context, r *http.Request) (courier.
 
 // Initialize is called by the engine once everything is loaded
 func (h *mockHandler) Initialize(s *courier.Server) error {
-	h.server = s
+	h.rt = s.Runtime()
 	h.backend = s.Backend()
 	s.AddHandlerRoute(h, http.MethodGet, "receive", courier.ChannelLogTypeMsgReceive, h.receiveMsg)
 	return nil


### PR DESCRIPTION
## Summary

Decouples HTTP infrastructure and handler request-handling from the `Backend` interface and the `Server` type, moving both onto `Runtime` where the other shared infrastructure (DB, Dynamo, S3, Valkey, CloudWatch) already lives.

### HTTP client on Runtime
- Added `HTTP *http.Client` and `HTTPAccess *httpx.AccessConfig` to `Runtime`, constructed in `NewRuntime`. Field names match mailroom and Go acronym conventions.
- Dropped `HttpClient()` and `HttpAccess()` from the `Backend` interface, the rapidpro backend, and `MockBackend`.

### Server takes Runtime
- `NewServer` / `NewServerWithLogger` now take `*runtime.Runtime` instead of `*runtime.Config`. Added `Server.Runtime()` and have `Server.Config()` delegate to it.
- Plumbed `Runtime` into `FetchAndStoreAttachment` / `fetchAttachment` so the attachment fetcher can reach the HTTP client without going through `Backend`.
- Added `runtime.NewTestRuntime` helper for tests that need a `Runtime` with a usable `HTTP` client but no real backing services.

### Handlers no longer depend on Server at request time
- `ChannelHandler` interface now exposes `Runtime()` and `Backend()` instead of `Server()`.
- `BaseHandler` stores `*runtime.Runtime` directly (populated from the server in `SetServer`).
- Rewrote 21 call sites across handlers — every previous `h.Server()` was just a proxy to reach `Config`/`Runtime`/`Backend`.
- `Initialize(*Server)` is unchanged — route registration is genuinely a Server responsibility.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -p=1 ./...`