### PR TITLE
Drop unused NewServerWithLogger constructor

### DIFF
--- a/handlers/jiochat/handler_test.go
+++ b/handlers/jiochat/handler_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"io"
 	"log"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -259,12 +258,11 @@ func buildMockJCAPI(testCases []IncomingTestCase) *httptest.Server {
 
 func newServer(backend courier.Backend) *courier.Server {
 	// for benchmarks, log to null
-	logger := slog.Default()
 	log.SetOutput(io.Discard)
 	cfg := runtime.NewDefaultConfig()
 	cfg.DB = "postgres://courier_test:temba@postgres:5432/courier_test?sslmode=disable"
 	cfg.Valkey = "valkey://valkey:6379/0"
-	return courier.NewServerWithLogger(runtime.NewTestRuntime(cfg), backend, logger)
+	return courier.NewServer(runtime.NewTestRuntime(cfg), backend)
 }
 
 func TestDescribeURN(t *testing.T) {

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"log/slog"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -140,7 +139,6 @@ func testHandlerRequest(tb testing.TB, s *courier.Server, path string, headers m
 
 func newServer(backend courier.Backend) *courier.Server {
 	// for benchmarks, log to null
-	logger := slog.Default()
 	log.SetOutput(io.Discard)
 
 	cfg := runtime.NewDefaultConfig()
@@ -148,8 +146,7 @@ func newServer(backend courier.Backend) *courier.Server {
 	cfg.FacebookApplicationSecret = "fb_app_secret"
 	cfg.WhatsappAdminSystemUserToken = "wac_admin_system_user_token"
 
-	return courier.NewServerWithLogger(runtime.NewTestRuntime(cfg), backend, logger)
-
+	return courier.NewServer(runtime.NewTestRuntime(cfg), backend)
 }
 
 // RunIncomingTestCases runs all the passed in tests cases for the passed in channel configurations

--- a/handlers/wechat/handler_test.go
+++ b/handlers/wechat/handler_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"io"
 	"log"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -212,12 +211,11 @@ func buildMockWCAPI(testCases []IncomingTestCase) *httptest.Server {
 
 func newServer(backend courier.Backend) *courier.Server {
 	// for benchmarks, log to null
-	logger := slog.Default()
 	log.SetOutput(io.Discard)
 	cfg := runtime.NewDefaultConfig()
 	cfg.DB = "postgres://courier_test:temba@postgres:5432/courier_test?sslmode=disable"
 	cfg.Valkey = "valkey://valkey:6379/0"
-	return courier.NewServerWithLogger(runtime.NewTestRuntime(cfg), backend, logger)
+	return courier.NewServer(runtime.NewTestRuntime(cfg), backend)
 }
 
 func TestDescribeURN(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -37,14 +37,6 @@ const (
 // NewServer creates a new Server for the passed in runtime. The server will have to be started
 // afterwards, which is when configuration options are checked.
 func NewServer(rt *runtime.Runtime, backend Backend) *Server {
-	// create our top level router
-	logger := slog.Default()
-	return NewServerWithLogger(rt, backend, logger)
-}
-
-// NewServerWithLogger creates a new Server for the passed in runtime. The server will have to be started
-// afterwards, which is when configuration options are checked.
-func NewServerWithLogger(rt *runtime.Runtime, backend Backend, logger *slog.Logger) *Server {
 	// channelRouter holds the dynamically-registered channel handler routes - mounted at /c/ on the public listener
 	channelRouter := chi.NewRouter()
 

--- a/server_test.go
+++ b/server_test.go
@@ -3,7 +3,6 @@ package courier_test
 import (
 	"context"
 	"io"
-	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
@@ -195,7 +194,6 @@ func TestFetchAttachment(t *testing.T) {
 	defer uuids.SetGenerator(uuids.DefaultGenerator)
 	uuids.SetGenerator(uuids.NewSeededGenerator(1234, dates.NewSequentialNow(time.Date(2024, 9, 11, 14, 33, 0, 0, time.UTC), time.Second)))
 
-	logger := slog.Default()
 	cfg := runtime.NewDefaultConfig()
 	cfg.AuthToken = "sesame"
 	cfg.PublicPort = 8180
@@ -205,7 +203,7 @@ func TestFetchAttachment(t *testing.T) {
 	mockChannel := test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
 	mb.AddChannel(mockChannel)
 
-	server := courier.NewServerWithLogger(runtime.NewTestRuntime(cfg), mb, logger)
+	server := courier.NewServer(runtime.NewTestRuntime(cfg), mb)
 	require.NoError(t, server.Start())
 	defer server.Stop()
 
@@ -269,7 +267,7 @@ func TestListeners(t *testing.T) {
 	mb := test.NewMockBackend()
 	mb.AddChannel(test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, nil))
 
-	server := courier.NewServerWithLogger(runtime.NewTestRuntime(cfg), mb, slog.Default())
+	server := courier.NewServer(runtime.NewTestRuntime(cfg), mb)
 	require.NoError(t, server.Start())
 	defer server.Stop()
 


### PR DESCRIPTION
## Summary

`NewServerWithLogger` accepted a `*slog.Logger` argument but never stored it on `Server` or passed it anywhere — it was functionally identical to `NewServer`. All five callers passed `slog.Default()`, which is what `NewServer` already uses internally.

Removed the constructor and switched callers (`server_test.go`, `handlers/test.go`, `handlers/jiochat/handler_test.go`, `handlers/wechat/handler_test.go`) to `NewServer`, plus cleaned up now-unused `slog` imports and `logger := slog.Default()` locals.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -p=1 . ./handlers/jiochat/... ./handlers/wechat/...` passes