### PR TITLE
Send kannel unicode messages as UTF-16BE to avoid charset recode errors

### DIFF
--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/gocommon/gsm7"
 	"github.com/nyaruka/gocommon/urns"
+	"golang.org/x/text/encoding/unicode"
 )
 
 const (
@@ -167,10 +168,17 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 	}
 
-	// if we are UTF8, set our coding appropriately
+	// if we are unicode, encode the body to UTF-16BE (UCS-2) ourselves and tell kannel the charset matches so it
+	// doesn't attempt (and possibly fail with "Charset or body misformed, rejected") a server-side recode
 	if encoding == encodingUnicode {
+		encoder := unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewEncoder()
+		utf16beText, err := encoder.String(handlers.GetTextAndAttachments(msg))
+		if err != nil {
+			return err
+		}
 		form["coding"] = []string{"2"}
-		form["charset"] = []string{"utf-8"}
+		form["charset"] = []string{"UTF-16BE"}
+		form["text"] = []string{utf16beText}
 	}
 
 	// our send URL may have form parameters in it already, append our own afterwards

--- a/handlers/kannel/handler_test.go
+++ b/handlers/kannel/handler_test.go
@@ -162,11 +162,37 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Params: url.Values{
-				"text":     {"☺"},
+				// ☺ (U+263A) encoded as UTF-16BE bytes 0x26 0x3a
+				"text":     {string([]byte{0x26, 0x3a})},
 				"to":       {"+250788383383"},
 				"from":     {"2020"},
 				"coding":   {"2"},
-				"charset":  {"utf-8"},
+				"charset":  {"UTF-16BE"},
+				"dlr-mask": {"27"},
+				"dlr-url":  {"https://localhost/c/kn/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%d"},
+				"username": {"Username"},
+				"password": {"Password"},
+			},
+		}},
+	},
+	{
+		Label:           "Unicode Send Mixed",
+		MsgText:         "Hi ☺",
+		MsgURN:          "tel:+250788383383",
+		MsgHighPriority: false,
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://example.com/send*": {
+				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Params: url.Values{
+				// "Hi ☺" encoded as UTF-16BE: H=0x0048 i=0x0069 space=0x0020 ☺=0x263a
+				"text":     {string([]byte{0x00, 0x48, 0x00, 0x69, 0x00, 0x20, 0x26, 0x3a})},
+				"to":       {"+250788383383"},
+				"from":     {"2020"},
+				"coding":   {"2"},
+				"charset":  {"UTF-16BE"},
 				"dlr-mask": {"27"},
 				"dlr-url":  {"https://localhost/c/kn/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%d"},
 				"username": {"Username"},


### PR DESCRIPTION
## What

For unicode (non-GSM7) messages, the Kannel handler now encodes the body to **UTF-16BE itself** and labels it `charset=UTF-16BE` (with `coding=2`), instead of sending raw UTF-8 text and relying on the remote Kannel server to recode it.

## Why

Sending raw UTF-8 with `charset=utf-8` makes Kannel recode the body to UTF-16BE server-side. When that recode fails, Kannel rejects the request with `Charset or body misformed, rejected`.

Tracing the Kannel source (`smsbox.c: charset_processing` -> `charset_convert`/`octstr_recode`) confirmed:
- That server-side recode is exactly the failing step.
- Charset names are compared **case-insensitively**, so the earlier `utf8` -> `utf-8` change was functionally inert and couldn't have fixed a real recode failure.

By pre-encoding to UTF-16BE and setting `charset=UTF-16BE`, Kannel's recode short-circuits (`from == to`) and leaves the body untouched - the misformed-charset rejection becomes structurally impossible, independent of the remote Kannel version or its host `iconv`. The on-the-wire result is identical UCS-2, just produced client-side. This reuses the same encoder pattern already used by the Jasmin handler.

## Notes for reviewers

- The UTF-16BE bytes (including `0x00` high bytes for ASCII chars) are percent-encoded by the existing `form.Encode()`; Kannel's HTTP parser is binary-safe (Octstr).
- GSM7 paths ("Plain Send", "Smart Encoding") are unchanged - still no `coding`/`charset`.
- Tests: updated "Unicode Send" to expect `charset=UTF-16BE` and the UTF-16BE bytes of the smiley; added "Unicode Send Mixed" to verify ASCII chars round-trip correctly.