### PR TITLE
Omit charset param for kannel unicode (body already UTF-16BE)

### DIFF
--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -168,8 +168,9 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 	}
 
-	// if we are unicode, encode the body to UTF-16BE (UCS-2) ourselves and tell kannel the charset matches so it
-	// doesn't attempt (and possibly fail with "Charset or body misformed, rejected") a server-side recode
+	// if we are unicode, encode the body to UTF-16BE (UCS-2) ourselves and don't send a charset param - that way
+	// kannel skips its server-side recode entirely (which fails with "Charset or body misformed, rejected" on
+	// builds compiled without iconv) and passes our already-encoded body straight through as coding=2 / UCS-2
 	if encoding == encodingUnicode {
 		encoder := unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewEncoder()
 		utf16beText, err := encoder.String(handlers.GetTextAndAttachments(msg))
@@ -177,7 +178,6 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 			return err
 		}
 		form["coding"] = []string{"2"}
-		form["charset"] = []string{"UTF-16BE"}
 		form["text"] = []string{utf16beText}
 	}
 

--- a/handlers/kannel/handler_test.go
+++ b/handlers/kannel/handler_test.go
@@ -162,12 +162,11 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Params: url.Values{
-				// ☺ (U+263A) encoded as UTF-16BE bytes 0x26 0x3a
+				// ☺ (U+263A) encoded as UTF-16BE bytes 0x26 0x3a, no charset param so kannel skips its recode
 				"text":     {string([]byte{0x26, 0x3a})},
 				"to":       {"+250788383383"},
 				"from":     {"2020"},
 				"coding":   {"2"},
-				"charset":  {"UTF-16BE"},
 				"dlr-mask": {"27"},
 				"dlr-url":  {"https://localhost/c/kn/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%d"},
 				"username": {"Username"},
@@ -192,7 +191,6 @@ var defaultSendTestCases = []OutgoingTestCase{
 				"to":       {"+250788383383"},
 				"from":     {"2020"},
 				"coding":   {"2"},
-				"charset":  {"UTF-16BE"},
 				"dlr-mask": {"27"},
 				"dlr-url":  {"https://localhost/c/kn/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%d"},
 				"username": {"Username"},


### PR DESCRIPTION
## What

Follow-up to #1029. For unicode messages the Kannel handler already encodes the body to UTF-16BE itself; this drops the `charset` param entirely (previously `charset=UTF-16BE`).

## Why

A report came in that messages were still rejected with `Charset or body misformed, rejected` even with the correct UTF-16BE body + `charset=UTF-16BE`.

Root cause, traced in the Kannel source: `gwlib/charset.c: charset_convert()` only short-circuits the `from == to` no-op conversion **inside** its `#if HAVE_ICONV` block. On Kannel builds compiled **without iconv** the function unconditionally `return -1`, so `charset_processing()` fails for *any* non-empty charset with `coding=2` — including our no-op UTF-16BE→UTF-16BE — producing the rejection.

By sending **no** `charset` param, `charset_processing()`'s `if (octstr_len(charset))` guard is false, so `charset_convert` is never called. It returns success on every build (iconv or not), and our already-UTF-16BE body passes straight through as `coding=2` / UCS-2.

## Notes for reviewers

- The UTF-16BE encoding from #1029 is unchanged; only the `charset` param is removed.
- GSM7 paths are unchanged (no `coding`/`charset`).
- Tests updated: "Unicode Send" and "Unicode Send Mixed" no longer expect a `charset` param.
- This supersedes the alternative `fix-charset-KN` branch, which omits charset but keeps raw UTF-8 in the body — that would deliver garbled text when sent as `coding=2` on no-iconv builds.