### PR TITLE
Support sending WhatsApp messages by BSUID URN

### DIFF
--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -349,6 +349,23 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
+		Label:   "Plain Send with BSUID",
+		MsgText: "Simple Message",
+		MsgURN:  "bsuid:US.1234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://waba-v2.360dialog.io/messages": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Path: "/messages",
+				Body: `{"messaging_product":"whatsapp","recipient_type":"individual","recipient":"US.1234","type":"text","text":{"body":"Simple Message","preview_url":false}}`,
+			},
+		},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:   "Plain Send with user_id in response",
 		MsgText: "Simple Message",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -327,6 +327,23 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
+		Label:   "Plain Send with BSUID",
+		MsgText: "Simple Message",
+		MsgURN:  "bsuid:US.1234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Path: "/12345_ID/messages",
+				Body: `{"messaging_product":"whatsapp","recipient_type":"individual","recipient":"US.1234","type":"text","text":{"body":"Simple Message","preview_url":false}}`,
+			},
+		},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:   "Plain Send with user_id in response",
 		MsgText: "Simple Message",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/meta/whatsapp/api.go
+++ b/handlers/meta/whatsapp/api.go
@@ -317,7 +317,8 @@ type Interactive struct {
 type SendRequest struct {
 	MessagingProduct string `json:"messaging_product"`
 	RecipientType    string `json:"recipient_type"`
-	To               string `json:"to"`
+	To               string `json:"to,omitempty"`
+	Recipient        string `json:"recipient,omitempty"`
 	Type             string `json:"type"`
 
 	Text *Text `json:"text,omitempty"`

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -20,14 +20,19 @@ func GetMsgPayloads(ctx context.Context, msg courier.MsgOut, maxMsgLength int, c
 	return buildContentPayloads(msg, maxMsgLength, clog)
 }
 
+// RecipientFields returns the to and recipient field values for the given URN, using the recipient field for
+// business-scoped user ID (BSUID) URNs and the to field otherwise.
+func RecipientFields(urn urns.URN) (to, recipient string) {
+	if urn.Scheme() == urns.BSUID.Prefix {
+		return "", urn.Path()
+	}
+	return urn.Path(), ""
+}
+
 // newBasePayload creates a SendRequest with common fields populated.
 func newBasePayload(msg courier.MsgOut) SendRequest {
 	request := SendRequest{MessagingProduct: "whatsapp", RecipientType: "individual"}
-	if urn := msg.URN(); urn.Scheme() == urns.BSUID.Prefix {
-		request.Recipient = urn.Path()
-	} else {
-		request.To = urn.Path()
-	}
+	request.To, request.Recipient = RecipientFields(msg.URN())
 	return request
 }
 

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/courier/v26/utils/clogs"
+	"github.com/nyaruka/gocommon/urns"
 )
 
 func GetMsgPayloads(ctx context.Context, msg courier.MsgOut, maxMsgLength int, clog *courier.ChannelLog) ([]SendRequest, error) {
@@ -21,7 +22,13 @@ func GetMsgPayloads(ctx context.Context, msg courier.MsgOut, maxMsgLength int, c
 
 // newBasePayload creates a SendRequest with common fields populated.
 func newBasePayload(msg courier.MsgOut) SendRequest {
-	return SendRequest{MessagingProduct: "whatsapp", RecipientType: "individual", To: msg.URN().Path()}
+	request := SendRequest{MessagingProduct: "whatsapp", RecipientType: "individual"}
+	if urn := msg.URN(); urn.Scheme() == urns.BSUID.Prefix {
+		request.Recipient = urn.Path()
+	} else {
+		request.To = urn.Path()
+	}
+	return request
 }
 
 func (p SendRequest) withTemplate(templating *models.Templating) SendRequest {

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -28,6 +28,7 @@ func TestGetMsgPayloads(t *testing.T) {
 		attachments           []string
 		quickReplies          []models.QuickReply
 		locale                i18n.Locale
+		urn                   urns.URN
 		expectedPayloadsCount int
 		expectedType          string // type of first payload
 		checkFunc             func(*testing.T, []whatsapp.SendRequest, *courier.ChannelLog)
@@ -38,12 +39,14 @@ func TestGetMsgPayloads(t *testing.T) {
 			text:                  "Pick an option",
 			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "Option 1", Extra: "Description 1"}, {Type: "text", Text: "Option 2", Extra: "Description 2"}},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 2,
 			expectedType:          "image",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
 				assert.Equal(t, 2, len(payloads))
 				// First should be image attachment
 				assert.Equal(t, "image", payloads[0].Type)
+				assert.Equal(t, "250788123123", payloads[0].To)
 				assert.NotNil(t, payloads[0].Image)
 				assert.Equal(t, "https://example.com/image.jpg", payloads[0].Image.Link)
 				// Second should be interactive list
@@ -61,12 +64,14 @@ func TestGetMsgPayloads(t *testing.T) {
 			text:                  "Choose wisely",
 			attachments:           []string{"video/mp4:https://example.com/video.mp4"},
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "Yes", Extra: "Agree"}, {Type: "text", Text: "No", Extra: "Disagree"}},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 2,
 			expectedType:          "video",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
 				assert.Equal(t, 2, len(payloads))
 				// First should be video attachment
 				assert.Equal(t, "video", payloads[0].Type)
+				assert.Equal(t, "250788123123", payloads[0].To)
 				assert.NotNil(t, payloads[0].Video)
 				// Second should be interactive list
 				assert.Equal(t, "interactive", payloads[1].Type)
@@ -79,12 +84,14 @@ func TestGetMsgPayloads(t *testing.T) {
 			text:                  "Select an option",
 			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "Option 1"}, {Type: "text", Text: "Option 2"}},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 1,
 			expectedType:          "interactive",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
 				assert.Equal(t, 1, len(payloads))
 				// Should be interactive button with image header
 				assert.Equal(t, "interactive", payloads[0].Type)
+				assert.Equal(t, "250788123123", payloads[0].To)
 				assert.NotNil(t, payloads[0].Interactive)
 				assert.Equal(t, "button", payloads[0].Interactive.Type)
 				// Check header
@@ -101,12 +108,14 @@ func TestGetMsgPayloads(t *testing.T) {
 			text:                  "Watch and choose",
 			attachments:           []string{"video/mp4:https://example.com/video.mp4"},
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "Like"}, {Type: "text", Text: "Dislike"}, {Type: "text", Text: "Share"}},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 1,
 			expectedType:          "interactive",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
 				assert.Equal(t, 1, len(payloads))
 				// Should be interactive button with video header
 				assert.Equal(t, "interactive", payloads[0].Type)
+				assert.Equal(t, "250788123123", payloads[0].To)
 				assert.Equal(t, "button", payloads[0].Interactive.Type)
 				// Check header
 				assert.NotNil(t, payloads[0].Interactive.Header)
@@ -122,12 +131,14 @@ func TestGetMsgPayloads(t *testing.T) {
 			text:                  "Review this",
 			attachments:           []string{"document/pdf:https://example.com/document.pdf"},
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "Approve"}},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 1,
 			expectedType:          "interactive",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
 				assert.Equal(t, 1, len(payloads))
 				// Should be interactive button with document header
 				assert.Equal(t, "interactive", payloads[0].Type)
+				assert.Equal(t, "250788123123", payloads[0].To)
 				assert.Equal(t, "button", payloads[0].Interactive.Type)
 				// Check header
 				assert.NotNil(t, payloads[0].Interactive.Header)
@@ -142,12 +153,14 @@ func TestGetMsgPayloads(t *testing.T) {
 			text:                  "Listen and respond",
 			attachments:           []string{"audio/mp3:https://example.com/audio.mp3"},
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "Good"}, {Type: "text", Text: "Bad"}},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 2,
 			expectedType:          "audio",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
 				assert.Equal(t, 2, len(payloads))
 				// First should be audio (not used as header)
 				assert.Equal(t, "audio", payloads[0].Type)
+				assert.Equal(t, "250788123123", payloads[0].To)
 				assert.NotNil(t, payloads[0].Audio)
 				// Second should be interactive button WITHOUT header
 				assert.Equal(t, "interactive", payloads[1].Type)
@@ -165,12 +178,14 @@ func TestGetMsgPayloads(t *testing.T) {
 				{Type: "text", Text: "Option 7"}, {Type: "text", Text: "Option 8"}, {Type: "text", Text: "Option 9"},
 				{Type: "text", Text: "Option 10"}, {Type: "text", Text: "Option 11"}, {Type: "text", Text: "Option 12"},
 			},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 1,
 			expectedType:          "interactive",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
 				assert.Equal(t, 1, len(payloads))
 				// Should be interactive list with exactly 10 rows
 				assert.Equal(t, "interactive", payloads[0].Type)
+				assert.Equal(t, "250788123123", payloads[0].To)
 				assert.Equal(t, "list", payloads[0].Interactive.Type)
 				assert.Equal(t, 10, len(payloads[0].Interactive.Action.Sections[0].Rows))
 				// Verify it's the first 10 options
@@ -194,11 +209,13 @@ func TestGetMsgPayloads(t *testing.T) {
 				{Type: "text", Text: "Option 13", Extra: "Desc 13"}, {Type: "text", Text: "Option 14", Extra: "Desc 14"},
 				{Type: "text", Text: "Option 15", Extra: "Desc 15"},
 			},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 1,
 			expectedType:          "interactive",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
 				assert.Equal(t, 1, len(payloads))
 				assert.Equal(t, "interactive", payloads[0].Type)
+				assert.Equal(t, "250788123123", payloads[0].To)
 				assert.Equal(t, "list", payloads[0].Interactive.Type)
 				assert.Equal(t, 10, len(payloads[0].Interactive.Action.Sections[0].Rows))
 				// Verify descriptions are preserved for first 10
@@ -213,11 +230,13 @@ func TestGetMsgPayloads(t *testing.T) {
 			label:                 "4 QRs without Extra - should use list (>3 buttons)",
 			text:                  "Pick one",
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "A"}, {Type: "text", Text: "B"}, {Type: "text", Text: "C"}, {Type: "text", Text: "D"}},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 1,
 			expectedType:          "interactive",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
 				assert.Equal(t, 1, len(payloads))
 				assert.Equal(t, "interactive", payloads[0].Type)
+				assert.Equal(t, "250788123123", payloads[0].To)
 				assert.Equal(t, "list", payloads[0].Interactive.Type)
 				assert.Equal(t, 4, len(payloads[0].Interactive.Action.Sections[0].Rows))
 			},
@@ -226,11 +245,13 @@ func TestGetMsgPayloads(t *testing.T) {
 			label:                 "3 QRs without Extra and no attachment - should use buttons",
 			text:                  "Quick choice",
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "text", Text: "No"}, {Type: "text", Text: "Maybe"}},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 1,
 			expectedType:          "interactive",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
 				assert.Equal(t, 1, len(payloads))
 				assert.Equal(t, "interactive", payloads[0].Type)
+				assert.Equal(t, "250788123123", payloads[0].To)
 				assert.Equal(t, "button", payloads[0].Interactive.Type)
 				assert.Equal(t, 3, len(payloads[0].Interactive.Action.Buttons))
 				assert.Nil(t, payloads[0].Interactive.Header)
@@ -240,11 +261,13 @@ func TestGetMsgPayloads(t *testing.T) {
 			label:                 "No quick replies with attachment and text - should have caption",
 			text:                  "Check this out",
 			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 1,
 			expectedType:          "image",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
 				assert.Equal(t, 1, len(payloads))
 				assert.Equal(t, "image", payloads[0].Type)
+				assert.Equal(t, "250788123123", payloads[0].To)
 				assert.NotNil(t, payloads[0].Image)
 				assert.Equal(t, "Check this out", payloads[0].Image.Caption)
 			},
@@ -254,6 +277,7 @@ func TestGetMsgPayloads(t *testing.T) {
 			text:                  "Multiple files",
 			attachments:           []string{"image/jpeg:https://example.com/image1.jpg", "image/jpeg:https://example.com/image2.jpg"},
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "Download"}},
+			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 2,
 			expectedType:          "image",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
@@ -263,10 +287,24 @@ func TestGetMsgPayloads(t *testing.T) {
 				assert.Equal(t, "https://example.com/image2.jpg", payloads[0].Image.Link)
 				// Then interactive with first attachment as header
 				assert.Equal(t, "interactive", payloads[1].Type)
+				assert.Equal(t, "250788123123", payloads[1].To)
 				assert.Equal(t, "button", payloads[1].Interactive.Type)
 				assert.NotNil(t, payloads[1].Interactive.Header)
 				assert.Equal(t, "image", payloads[1].Interactive.Header.Type)
 				assert.Equal(t, "https://example.com/image1.jpg", payloads[1].Interactive.Header.Image.Link)
+			},
+		},
+		{
+			label:                 "Send message by BSUID",
+			text:                  "Hello, BSUID",
+			urn:                   "bsuid:US.1234",
+			expectedPayloadsCount: 1,
+			expectedType:          "text",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "text", payloads[0].Type)
+				assert.Equal(t, "US.1234", payloads[0].Recipient)
+				assert.Equal(t, "Hello, BSUID", payloads[0].Text.Body)
 			},
 		},
 	}
@@ -274,7 +312,7 @@ func TestGetMsgPayloads(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.label, func(t *testing.T) {
 			// Create mock message
-			mockMsg := test.NewMockMsg("87995844-2017-4ba0-bc73-f3da75b32f9b", channel, "whatsapp:250788123123", tc.text, tc.attachments)
+			mockMsg := test.NewMockMsg("87995844-2017-4ba0-bc73-f3da75b32f9b", channel, tc.urn, tc.text, tc.attachments)
 			mockMsg.SetQuickReplies(tc.quickReplies)
 			var msg courier.MsgOut = mockMsg
 			if tc.locale != "" {

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -307,6 +307,23 @@ func TestGetMsgPayloads(t *testing.T) {
 				assert.Equal(t, "Hello, BSUID", payloads[0].Text.Body)
 			},
 		},
+		{
+			label:                 "Send media and quick replies by BSUID",
+			text:                  "Pick an option",
+			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},
+			quickReplies:          []models.QuickReply{{Type: "text", Text: "Option 1"}, {Type: "text", Text: "Option 2"}},
+			urn:                   "bsuid:US.1234",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
+				// every payload builder routes through newBasePayload, so the recipient field must be
+				// populated (and to left empty) for media/interactive flows too, not just plain text
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "interactive", payloads[0].Type)
+				assert.Equal(t, "US.1234", payloads[0].Recipient)
+				assert.Empty(t, payloads[0].To)
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -362,8 +362,22 @@ var turnWaIgnoreStatuses = map[string]bool{
 //   }
 // }
 
+// recipient identifies the message recipient - either a phone number (to) or a business-scoped user ID (recipient)
+type recipient struct {
+	To        string `json:"to,omitempty"`
+	Recipient string `json:"recipient,omitempty"`
+}
+
+// newRecipient builds the recipient fields from the message URN, using recipient for BSUID URNs and to otherwise.
+func newRecipient(msg courier.MsgOut) recipient {
+	if urn := msg.URN(); urn.Scheme() == urns.BSUID.Prefix {
+		return recipient{Recipient: urn.Path()}
+	}
+	return recipient{To: msg.URN().Path()}
+}
+
 type mtTextPayload struct {
-	To         string `json:"to"    validate:"required"`
+	recipient
 	Type       string `json:"type"  validate:"required"`
 	PreviewURL bool   `json:"preview_url,omitempty"`
 	Text       struct {
@@ -372,7 +386,7 @@ type mtTextPayload struct {
 }
 
 type mtInteractivePayload struct {
-	To          string `json:"to" validate:"required"`
+	recipient
 	Type        string `json:"type" validate:"required"`
 	Interactive struct {
 		Type   string `json:"type" validate:"required"` //"text" | "image" | "video" | "document"
@@ -439,7 +453,7 @@ type Component struct {
 }
 
 type templatePayload struct {
-	To       string `json:"to"`
+	recipient
 	Type     string `json:"type"`
 	Template struct {
 		Namespace string `json:"namespace"`
@@ -453,25 +467,25 @@ type templatePayload struct {
 }
 
 type mtAudioPayload struct {
-	To    string       `json:"to"    validate:"required"`
+	recipient
 	Type  string       `json:"type"  validate:"required"`
 	Audio *mediaObject `json:"audio"`
 }
 
 type mtDocumentPayload struct {
-	To       string       `json:"to"    validate:"required"`
+	recipient
 	Type     string       `json:"type"  validate:"required"`
 	Document *mediaObject `json:"document"`
 }
 
 type mtImagePayload struct {
-	To    string       `json:"to"    validate:"required"`
+	recipient
 	Type  string       `json:"type"  validate:"required"`
 	Image *mediaObject `json:"image"`
 }
 
 type mtVideoPayload struct {
-	To    string       `json:"to" validate:"required"`
+	recipient
 	Type  string       `json:"type" validate:"required"`
 	Video *mediaObject `json:"video"`
 }
@@ -511,15 +525,15 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 			mediaPayload := &mediaObject{ID: mediaID, Link: mediaURL}
 			if strings.HasPrefix(mimeType, "audio") {
 				payload := mtAudioPayload{
-					To:   msg.URN().Path(),
-					Type: "audio",
+					recipient: newRecipient(msg),
+					Type:      "audio",
 				}
 				payload.Audio = mediaPayload
 				payloads = append(payloads, payload)
 			} else if strings.HasPrefix(mimeType, "application") || strings.HasPrefix(mimeType, "document") {
 				payload := mtDocumentPayload{
-					To:   msg.URN().Path(),
-					Type: "document",
+					recipient: newRecipient(msg),
+					Type:      "document",
 				}
 				if attachmentCount == 0 && !isInteractiveMsg {
 					mediaPayload.Caption = msg.Text()
@@ -535,8 +549,8 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 				payloads = append(payloads, payload)
 			} else if strings.HasPrefix(mimeType, "image") {
 				payload := mtImagePayload{
-					To:   msg.URN().Path(),
-					Type: "image",
+					recipient: newRecipient(msg),
+					Type:      "image",
 				}
 				if attachmentCount == 0 && !isInteractiveMsg {
 					mediaPayload.Caption = msg.Text()
@@ -546,8 +560,8 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 				payloads = append(payloads, payload)
 			} else if strings.HasPrefix(mimeType, "video") {
 				payload := mtVideoPayload{
-					To:   msg.URN().Path(),
-					Type: "video",
+					recipient: newRecipient(msg),
+					Type:      "video",
 				}
 				if attachmentCount == 0 && !isInteractiveMsg {
 					mediaPayload.Caption = msg.Text()
@@ -568,14 +582,14 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 				var payload mtTextPayload
 				if strings.Contains(part, "https://") || strings.Contains(part, "http://") {
 					payload = mtTextPayload{
-						To:         msg.URN().Path(),
+						recipient:  newRecipient(msg),
 						Type:       "text",
 						PreviewURL: true,
 					}
 				} else {
 					payload = mtTextPayload{
-						To:   msg.URN().Path(),
-						Type: "text",
+						recipient: newRecipient(msg),
+						Type:      "text",
 					}
 				}
 				payload.Text.Body = part
@@ -587,16 +601,16 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 			for i, part := range parts {
 				if i < (len(parts) - 1) { //if split into more than one message, the first parts will be text and the last interactive
 					payload := mtTextPayload{
-						To:   msg.URN().Path(),
-						Type: "text",
+						recipient: newRecipient(msg),
+						Type:      "text",
 					}
 					payload.Text.Body = part
 					payloads = append(payloads, payload)
 
 				} else {
 					payload := mtInteractivePayload{
-						To:   msg.URN().Path(),
-						Type: "interactive",
+						recipient: newRecipient(msg),
+						Type:      "interactive",
 					}
 
 					if len(locationQRs) > 0 {
@@ -654,8 +668,8 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 			}
 
 			payload := templatePayload{
-				To:   msg.URN().Path(),
-				Type: "template",
+				recipient: newRecipient(msg),
+				Type:      "template",
 			}
 			payload.Template.Namespace = namespace
 			payload.Template.Name = msg.Templating().Template.Name
@@ -693,16 +707,16 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 				for i, part := range parts {
 					if i < (len(parts) - 1) { //if split into more than one message, the first parts will be text and the last interactive
 						payload := mtTextPayload{
-							To:   msg.URN().Path(),
-							Type: "text",
+							recipient: newRecipient(msg),
+							Type:      "text",
 						}
 						payload.Text.Body = part
 						payloads = append(payloads, payload)
 
 					} else {
 						payload := mtInteractivePayload{
-							To:   msg.URN().Path(),
-							Type: "interactive",
+							recipient: newRecipient(msg),
+							Type:      "interactive",
 						}
 
 						if len(locationQRs) > 0 {
@@ -752,14 +766,14 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 					var payload mtTextPayload
 					if strings.Contains(part, "https://") || strings.Contains(part, "http://") {
 						payload = mtTextPayload{
-							To:         msg.URN().Path(),
+							recipient:  newRecipient(msg),
 							Type:       "text",
 							PreviewURL: true,
 						}
 					} else {
 						payload = mtTextPayload{
-							To:   msg.URN().Path(),
-							Type: "text",
+							recipient: newRecipient(msg),
+							Type:      "text",
 						}
 					}
 					payload.Text.Body = part

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -368,12 +368,10 @@ type recipient struct {
 	Recipient string `json:"recipient,omitempty"`
 }
 
-// newRecipient builds the recipient fields from the message URN, using recipient for BSUID URNs and to otherwise.
+// newRecipient builds the recipient fields from the message URN.
 func newRecipient(msg courier.MsgOut) recipient {
-	if urn := msg.URN(); urn.Scheme() == urns.BSUID.Prefix {
-		return recipient{Recipient: urn.Path()}
-	}
-	return recipient{To: msg.URN().Path()}
+	to, rcpt := whatsapp.RecipientFields(msg.URN())
+	return recipient{To: to, Recipient: rcpt}
 }
 
 type mtTextPayload struct {
@@ -494,6 +492,8 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 	var payloads []any
 	var err error
 
+	rcpt := newRecipient(msg)
+
 	parts := handlers.SplitMsgByChannel(msg.Channel(), msg.Text(), maxMsgLength)
 
 	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), "text")
@@ -525,14 +525,14 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 			mediaPayload := &mediaObject{ID: mediaID, Link: mediaURL}
 			if strings.HasPrefix(mimeType, "audio") {
 				payload := mtAudioPayload{
-					recipient: newRecipient(msg),
+					recipient: rcpt,
 					Type:      "audio",
 				}
 				payload.Audio = mediaPayload
 				payloads = append(payloads, payload)
 			} else if strings.HasPrefix(mimeType, "application") || strings.HasPrefix(mimeType, "document") {
 				payload := mtDocumentPayload{
-					recipient: newRecipient(msg),
+					recipient: rcpt,
 					Type:      "document",
 				}
 				if attachmentCount == 0 && !isInteractiveMsg {
@@ -549,7 +549,7 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 				payloads = append(payloads, payload)
 			} else if strings.HasPrefix(mimeType, "image") {
 				payload := mtImagePayload{
-					recipient: newRecipient(msg),
+					recipient: rcpt,
 					Type:      "image",
 				}
 				if attachmentCount == 0 && !isInteractiveMsg {
@@ -560,7 +560,7 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 				payloads = append(payloads, payload)
 			} else if strings.HasPrefix(mimeType, "video") {
 				payload := mtVideoPayload{
-					recipient: newRecipient(msg),
+					recipient: rcpt,
 					Type:      "video",
 				}
 				if attachmentCount == 0 && !isInteractiveMsg {
@@ -582,13 +582,13 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 				var payload mtTextPayload
 				if strings.Contains(part, "https://") || strings.Contains(part, "http://") {
 					payload = mtTextPayload{
-						recipient:  newRecipient(msg),
+						recipient:  rcpt,
 						Type:       "text",
 						PreviewURL: true,
 					}
 				} else {
 					payload = mtTextPayload{
-						recipient: newRecipient(msg),
+						recipient: rcpt,
 						Type:      "text",
 					}
 				}
@@ -601,7 +601,7 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 			for i, part := range parts {
 				if i < (len(parts) - 1) { //if split into more than one message, the first parts will be text and the last interactive
 					payload := mtTextPayload{
-						recipient: newRecipient(msg),
+						recipient: rcpt,
 						Type:      "text",
 					}
 					payload.Text.Body = part
@@ -609,7 +609,7 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 
 				} else {
 					payload := mtInteractivePayload{
-						recipient: newRecipient(msg),
+						recipient: rcpt,
 						Type:      "interactive",
 					}
 
@@ -668,7 +668,7 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 			}
 
 			payload := templatePayload{
-				recipient: newRecipient(msg),
+				recipient: rcpt,
 				Type:      "template",
 			}
 			payload.Template.Namespace = namespace
@@ -707,7 +707,7 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 				for i, part := range parts {
 					if i < (len(parts) - 1) { //if split into more than one message, the first parts will be text and the last interactive
 						payload := mtTextPayload{
-							recipient: newRecipient(msg),
+							recipient: rcpt,
 							Type:      "text",
 						}
 						payload.Text.Body = part
@@ -715,7 +715,7 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 
 					} else {
 						payload := mtInteractivePayload{
-							recipient: newRecipient(msg),
+							recipient: rcpt,
 							Type:      "interactive",
 						}
 
@@ -766,13 +766,13 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 					var payload mtTextPayload
 					if strings.Contains(part, "https://") || strings.Contains(part, "http://") {
 						payload = mtTextPayload{
-							recipient:  newRecipient(msg),
+							recipient:  rcpt,
 							Type:       "text",
 							PreviewURL: true,
 						}
 					} else {
 						payload = mtTextPayload{
-							recipient: newRecipient(msg),
+							recipient: rcpt,
 							Type:      "text",
 						}
 					}

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -620,6 +620,23 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
+		Label:   "Plain Send with BSUID",
+		MsgText: "Simple Message",
+		MsgURN:  "bsuid:US.1234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Path: "/v1/messages",
+				Body: `{"recipient":"US.1234","type":"text","text":{"body":"Simple Message"}}`,
+			},
+		},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:   "Unicode Send",
 		MsgText: "☺",
 		MsgURN:  "whatsapp:250788123123",


### PR DESCRIPTION
Branch on the URN scheme to emit a recipient field instead of to for business-scoped user IDs (bsuid:) across the meta whatsapp, dialog360, and turn handlers.