### PR TITLE
Add support for sending and receiving typing indicators

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -49,6 +49,10 @@ type Backend interface {
 	// WriteChannelEvent writes the passed in channel event returning any error
 	WriteChannelEvent(context.Context, ChannelEvent, *ChannelLog) error
 
+	// WriteTypingIndicator records that the contact with the given URN is typing so that chat UIs can surface
+	// that. Unlike channel events, typing indicators are transient and never persisted.
+	WriteTypingIndicator(context.Context, Channel, urns.URN) error
+
 	// WriteChannelLog writes the passed in channel log to our backend
 	WriteChannelLog(context.Context, *ChannelLog) error
 

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -590,6 +590,11 @@ SELECT c.uuid
   JOIN contacts_contacturn u ON u.contact_id = c.id
  WHERE u.org_id = $1 AND u.identity = $2 AND c.is_active = TRUE`
 
+// the valkey key used to mark that the given contact is currently typing
+func typingKey(contactUUID models.ContactUUID) string {
+	return fmt.Sprintf("typing:%s", contactUUID)
+}
+
 // WriteTypingIndicator records that the contact with the given URN is typing as a short lived valkey key which
 // the chat UI reads when polling - stale typing indicators are of no interest to anyone so nothing is persisted.
 func (b *backend) WriteTypingIndicator(ctx context.Context, channel courier.Channel, urn urns.URN) error {
@@ -609,7 +614,7 @@ func (b *backend) WriteTypingIndicator(ctx context.Context, channel courier.Chan
 	vc := b.rt.VK.Get()
 	defer vc.Close()
 
-	_, err = vc.Do("SET", fmt.Sprintf("typing:%s", contactUUID), "1", "EX", typingIndicatorTTL)
+	_, err = vc.Do("SET", typingKey(contactUUID), "1", "EX", typingIndicatorTTL)
 	return err
 }
 

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -43,6 +43,9 @@ const (
 
 	// our timeout for backend operations
 	backendTimeout = time.Second * 20
+
+	// how long a typing indicator stays visible (in seconds)
+	typingIndicatorTTL = 10
 )
 
 var uuidRegex = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
@@ -579,6 +582,35 @@ func (b *backend) WriteChannelEvent(ctx context.Context, event courier.ChannelEv
 	defer cancel()
 
 	return writeChannelEvent(timeout, b, event, clog)
+}
+
+const sqlSelectContactUUIDByURN = `
+SELECT c.uuid
+  FROM contacts_contact c
+  JOIN contacts_contacturn u ON u.contact_id = c.id
+ WHERE u.org_id = $1 AND u.identity = $2 AND c.is_active = TRUE`
+
+// WriteTypingIndicator records that the contact with the given URN is typing as a short lived valkey key which
+// the chat UI reads when polling - stale typing indicators are of no interest to anyone so nothing is persisted.
+func (b *backend) WriteTypingIndicator(ctx context.Context, channel courier.Channel, urn urns.URN) error {
+	timeout, cancel := context.WithTimeout(ctx, backendTimeout)
+	defer cancel()
+
+	ch := channel.(*models.Channel)
+
+	var contactUUID models.ContactUUID
+	err := b.rt.DB.GetContext(timeout, &contactUUID, sqlSelectContactUUIDByURN, ch.OrgID(), urn.Identity())
+	if err == sql.ErrNoRows {
+		return nil // not a contact we know, nothing to record
+	} else if err != nil {
+		return fmt.Errorf("error looking up contact for typing indicator: %w", err)
+	}
+
+	vc := b.rt.VK.Get()
+	defer vc.Close()
+
+	_, err = vc.Do("SET", fmt.Sprintf("typing:%s", contactUUID), "1", "EX", typingIndicatorTTL)
+	return err
 }
 
 // WriteChannelLog persists the passed in log to our database, for rapidpro we swallow all errors, logging isn't critical

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -185,6 +185,16 @@ func (ts *BackendTestSuite) TestWriteTypingIndicator() {
 	ttl, err := redis.Int(rc.Do("TTL", "typing:a984069d-0008-4d8c-a772-b14a8a6acccc"))
 	ts.NoError(err)
 	ts.Equal(10, ttl)
+
+	// an incoming message from the contact clears the marker
+	clog := courier.NewChannelLog(courier.ChannelLogTypeMsgReceive, knChannel, nil)
+	msg := ts.b.NewIncomingMsg(ctx, knChannel, urns.URN("tel:+12067799192"), "stopped typing", "", clog)
+	err = ts.b.WriteMsg(ctx, msg, clog)
+	ts.NoError(err)
+
+	exists, err = redis.Bool(rc.Do("EXISTS", "typing:a984069d-0008-4d8c-a772-b14a8a6acccc"))
+	ts.NoError(err)
+	ts.False(exists)
 }
 
 func (ts *BackendTestSuite) TestContactRace() {

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -161,6 +161,32 @@ func (ts *BackendTestSuite) TestContact() {
 
 }
 
+func (ts *BackendTestSuite) TestWriteTypingIndicator() {
+	testsuite.ResetValkey(ts.T(), ts.b.rt)
+
+	ctx := context.Background()
+	knChannel := ts.getChannel("KN", "dbc126ed-66bc-4e28-b67b-81dc3327c95d")
+
+	rc := ts.b.rt.VK.Get()
+	defer rc.Close()
+
+	// a URN with no matching contact is a noop
+	err := ts.b.WriteTypingIndicator(ctx, knChannel, urns.URN("tel:+16055741111"))
+	ts.NoError(err)
+
+	exists, err := redis.Bool(rc.Do("EXISTS", "typing:a984069d-0008-4d8c-a772-b14a8a6acccc"))
+	ts.NoError(err)
+	ts.False(exists)
+
+	// a URN belonging to a contact in our testdata writes a marker with a TTL
+	err = ts.b.WriteTypingIndicator(ctx, knChannel, urns.URN("tel:+12067799192"))
+	ts.NoError(err)
+
+	ttl, err := redis.Int(rc.Do("TTL", "typing:a984069d-0008-4d8c-a772-b14a8a6acccc"))
+	ts.NoError(err)
+	ts.Equal(10, ttl)
+}
+
 func (ts *BackendTestSuite) TestContactRace() {
 	knChannel := ts.getChannel("KN", "dbc126ed-66bc-4e28-b67b-81dc3327c95d")
 	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, knChannel, nil)

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -112,6 +112,11 @@ func writeMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLo
 	rc := b.rt.VK.Get()
 	defer rc.Close()
 
+	// an incoming message means the contact is no longer typing
+	if _, err := rc.Do("DEL", typingKey(contact.UUID_)); err != nil {
+		slog.Error("error clearing typing indicator", "error", err, "msg", m.UUID_, "contact", contact.ID_)
+	}
+
 	// queue to mailroom for handling
 	if err := queueMsgHandling(ctx, rc, contact, m); err != nil {
 		slog.Error("error queueing msg handling", "error", err, "msg", m.UUID_, "contact", contact.ID_)

--- a/channel_log.go
+++ b/channel_log.go
@@ -10,6 +10,7 @@ import (
 const (
 	ChannelLogTypeUnknown         clogs.Type = "unknown"
 	ChannelLogTypeMsgSend         clogs.Type = "msg_send"
+	ChannelLogTypeEventSend       clogs.Type = "event_send"
 	ChannelLogTypeMsgStatus       clogs.Type = "msg_status"
 	ChannelLogTypeMsgReceive      clogs.Type = "msg_receive"
 	ChannelLogTypeEventReceive    clogs.Type = "event_receive"
@@ -77,6 +78,11 @@ func NewChannelLogForSend(msg MsgOut, redactVals []string) *ChannelLog {
 // NewChannelLogForSend creates a new channel log for an attachment fetch
 func NewChannelLogForAttachmentFetch(ch Channel, redactVals []string) *ChannelLog {
 	return newChannelLog(ChannelLogTypeAttachmentFetch, ch, nil, redactVals)
+}
+
+// NewChannelLogForEventSend creates a new channel log for an event send
+func NewChannelLogForEventSend(ch Channel, redactVals []string) *ChannelLog {
+	return newChannelLog(ChannelLogTypeEventSend, ch, nil, redactVals)
 }
 
 // NewChannelLog creates a new channel log with the given type and channel

--- a/events.go
+++ b/events.go
@@ -1,0 +1,81 @@
+package courier
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/utils"
+	"github.com/nyaruka/courier/v26/utils/clogs"
+	"github.com/nyaruka/gocommon/urns"
+)
+
+// EventOutType is the type of a transient event that can be sent to a contact on a channel
+type EventOutType string
+
+// EventOutTypeTyping is a typing indicator shown to the contact
+const EventOutTypeTyping EventOutType = "typing"
+
+// EventSender is the interface handlers should satisfy if they can send transient events such as typing
+// indicators to contacts. Unlike message sends these are fire and forget - they aren't queued and there
+// are no statuses or retries.
+type EventSender interface {
+	SendEvent(context.Context, Channel, EventOutType, urns.URN, *ChannelLog) error
+}
+
+type sendEventRequest struct {
+	Type        EventOutType       `json:"type"         validate:"required,eq=typing"`
+	ChannelType models.ChannelType `json:"channel_type" validate:"required"`
+	ChannelUUID models.ChannelUUID `json:"channel_uuid" validate:"required,uuid"`
+	URN         urns.URN           `json:"urn"          validate:"required"`
+}
+
+type sendEventResponse struct {
+	LogUUID clogs.UUID `json:"log_uuid"`
+}
+
+func sendEvent(ctx context.Context, b Backend, r *http.Request) (*sendEventResponse, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading request body: %w", err)
+	}
+
+	se := &sendEventRequest{}
+	if err := json.Unmarshal(body, se); err != nil {
+		return nil, fmt.Errorf("error unmarshalling request: %w", err)
+	}
+	if err := utils.Validate(se); err != nil {
+		return nil, err
+	}
+
+	ch, err := b.GetChannel(ctx, se.ChannelType, se.ChannelUUID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting channel: %w", err)
+	}
+
+	handler := GetHandler(ch.ChannelType())
+	sender, canSend := handler.(EventSender)
+	if !canSend {
+		return nil, fmt.Errorf("channel type %s can't send %s events", ch.ChannelType(), se.Type)
+	}
+
+	clog := NewChannelLogForEventSend(ch, handler.RedactValues(ch))
+
+	err = sender.SendEvent(ctx, ch, se.Type, se.URN, clog)
+
+	// try to write channel log even if we have an error
+	clog.End()
+	if logErr := b.WriteChannelLog(ctx, clog); logErr != nil {
+		slog.Error("error writing log", "error", logErr)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("error sending %s event on channel %s: %w", se.Type, ch.UUID(), err)
+	}
+
+	return &sendEventResponse{LogUUID: clog.UUID}, nil
+}

--- a/events_test.go
+++ b/events_test.go
@@ -1,0 +1,99 @@
+package courier_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nyaruka/courier/v26"
+	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/courier/v26/utils"
+	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/gocommon/httpx"
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/gocommon/uuids"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendEvent(t *testing.T) {
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
+	uuids.SetGenerator(uuids.NewSeededGenerator(1234, dates.NewSequentialNow(time.Date(2024, 9, 11, 14, 33, 0, 0, time.UTC), time.Second)))
+
+	cfg := runtime.NewDefaultConfig()
+	cfg.AuthToken = "sesame"
+	cfg.PublicPort = 8180
+	cfg.InternalPort = 8181
+
+	mb := test.NewMockBackend()
+	mockChannel := test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
+	mb.AddChannel(mockChannel)
+
+	// add a channel whose type has no handler registered and thus can't send events
+	brokenChannel := test.NewMockChannel("53e5aafa-8155-449d-9009-fcb30d54bd26", "XX", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
+	mb.AddChannel(brokenChannel)
+
+	server := courier.NewServer(runtime.NewTestRuntime(cfg), mb)
+	server.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"http://mock.com/event": {
+			httpx.NewMockResponse(200, nil, []byte(`OK`)),
+			httpx.NewMockResponse(502, nil, []byte(`bad gateway`)),
+		},
+	})
+	require.NoError(t, server.Start())
+	defer server.Stop()
+
+	submit := func(body, authToken string) (int, []byte) {
+		req, _ := http.NewRequest("POST", "http://localhost:8181/ci/event/send", strings.NewReader(body))
+		if authToken != "" {
+			req.Header.Set("Authorization", "Bearer "+authToken)
+		}
+		trace, _, err := utils.TraceHTTP(http.DefaultClient, req, 0)
+		require.NoError(t, err)
+		return trace.Response.StatusCode, trace.ResponseBody
+	}
+
+	// try to submit with no auth header
+	statusCode, respBody := submit(`{}`, "")
+	assert.Equal(t, 401, statusCode)
+	assert.Equal(t, "Unauthorized", string(respBody))
+
+	// try to submit with empty body
+	statusCode, respBody = submit(`{}`, "sesame")
+	assert.Equal(t, 400, statusCode)
+	assert.Contains(t, string(respBody), `Field validation for 'Type' failed on the 'required' tag`)
+
+	// try to submit with an unsupported event type
+	statusCode, respBody = submit(`{"type": "dancing", "channel_uuid": "e4bb1578-29da-4fa5-a214-9da19dd24230", "channel_type": "MCK", "urn": "tel:+250788123123"}`, "sesame")
+	assert.Equal(t, 400, statusCode)
+	assert.Contains(t, string(respBody), `Field validation for 'Type' failed on the 'eq' tag`)
+
+	// try to submit with non-existent channel
+	statusCode, respBody = submit(`{"type": "typing", "channel_uuid": "c25aab53-f23a-46c9-8ae3-1af850ad9fd9", "channel_type": "VV", "urn": "tel:+250788123123"}`, "sesame")
+	assert.Equal(t, 400, statusCode)
+	assert.Contains(t, string(respBody), `channel not found`)
+
+	// try to submit for a channel type that can't send events
+	statusCode, respBody = submit(`{"type": "typing", "channel_uuid": "53e5aafa-8155-449d-9009-fcb30d54bd26", "channel_type": "XX", "urn": "tel:+250788123123"}`, "sesame")
+	assert.Equal(t, 400, statusCode)
+	assert.Contains(t, string(respBody), `channel type XX can't send typing events`)
+
+	// submit for a channel that can
+	statusCode, respBody = submit(`{"type": "typing", "channel_uuid": "e4bb1578-29da-4fa5-a214-9da19dd24230", "channel_type": "MCK", "urn": "tel:+250788123123"}`, "sesame")
+	assert.Equal(t, 200, statusCode)
+	assert.JSONEq(t, `{"log_uuid": "0191e180-7d60-7000-aded-7d8b151cbd5b"}`, string(respBody))
+
+	assert.Len(t, mb.WrittenChannelLogs(), 1)
+	clog := mb.WrittenChannelLogs()[0]
+	assert.Equal(t, courier.ChannelLogTypeEventSend, clog.Type)
+	assert.Len(t, clog.HttpLogs, 1)
+	assert.Equal(t, "http://mock.com/event", clog.HttpLogs[0].URL)
+
+	// a send error still writes a channel log but returns an error response
+	statusCode, respBody = submit(`{"type": "typing", "channel_uuid": "e4bb1578-29da-4fa5-a214-9da19dd24230", "channel_type": "MCK", "urn": "tel:+250788123123"}`, "sesame")
+	assert.Equal(t, 400, statusCode)
+	assert.Contains(t, string(respBody), `channel connection failed`)
+	assert.Len(t, mb.WrittenChannelLogs(), 2)
+}

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -41,6 +41,8 @@ const (
 	configEncoding        = "encoding"
 	encodingDefault       = "D"
 	encodingSmart         = "S"
+
+	configSendTypingURL = "send_typing_url"
 )
 
 var defaultFromFields = []string{"from", "sender"}
@@ -86,7 +88,38 @@ func (h *handler) Initialize(s *courier.Server) error {
 	s.AddHandlerRoute(h, http.MethodPost, "stopped", courier.ChannelLogTypeEventReceive, h.receiveStopContact)
 	s.AddHandlerRoute(h, http.MethodGet, "stopped", courier.ChannelLogTypeEventReceive, h.receiveStopContact)
 
+	s.AddHandlerRoute(h, http.MethodPost, "typing", courier.ChannelLogTypeEventReceive, h.receiveTyping)
+
 	return nil
+}
+
+type typingForm struct {
+	From string `name:"from" validate:"required"`
+}
+
+// receiveTyping is our HTTP handler function for typing indicators from the contact
+func (h *handler) receiveTyping(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request, clog *courier.ChannelLog) ([]courier.Event, error) {
+	form := &typingForm{}
+	err := handlers.DecodeAndValidateForm(form, r)
+	if err != nil {
+		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
+	}
+
+	// create our URN
+	urn := urns.NilURN
+	if channel.Schemes()[0] == urns.Phone.Prefix {
+		urn, err = urns.ParsePhone(form.From, channel.Country(), true, false)
+	} else {
+		urn, err = urns.NewFromParts(channel.Schemes()[0], form.From, nil, "")
+	}
+	if err != nil {
+		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
+	}
+
+	if err := h.Backend().WriteTypingIndicator(ctx, channel, urn); err != nil {
+		return nil, err
+	}
+	return nil, courier.WriteTypingIndicatorSuccess(w)
 }
 
 type stopContactForm struct {
@@ -393,6 +426,33 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	return nil
 }
+
+// SendEvent sends a typing indicator by POSTing to the channel's configured typing URL, if any
+func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, eventType courier.EventOutType, urn urns.URN, clog *courier.ChannelLog) error {
+	typingURL := ch.StringConfigForKey(configSendTypingURL, "")
+	if typingURL == "" {
+		return courier.ErrChannelConfig
+	}
+
+	payload := jsonx.MustMarshal(map[string]string{"type": string(eventType), "to": urn.Path()})
+
+	req, err := http.NewRequest(http.MethodPost, typingURL, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _, err := h.RequestHTTPProxied(req, clog)
+	if err != nil || resp.StatusCode/100 == 5 {
+		return courier.ErrConnectionFailed
+	} else if resp.StatusCode/100 != 2 {
+		return courier.ErrResponseStatus
+	}
+
+	return nil
+}
+
+var _ courier.EventSender = (*handler)(nil)
 
 type quickReplyXMLItem struct {
 	XMLName xml.Name `xml:"item"`

--- a/handlers/external/handler_test.go
+++ b/handlers/external/handler_test.go
@@ -1,6 +1,7 @@
 package external
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"testing"
@@ -9,9 +10,11 @@ import (
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -192,6 +195,21 @@ var handleTestCases = []IncomingTestCase{
 	{
 		Label:                "Stopped event No Params",
 		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/stopped/",
+		ExpectedRespStatus:   400,
+		ExpectedBodyContains: "field 'from' required",
+	},
+	{
+		Label:                "Typing Indicator",
+		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/typing/",
+		Data:                 "from=%2B2349067554729",
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: "Typing Indicator Accepted",
+		ExpectedTyping:       []urns.URN{"tel:+2349067554729"},
+	},
+	{
+		Label:                "Typing Indicator No Params",
+		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/typing/",
+		Data:                 "nothing=here",
 		ExpectedRespStatus:   400,
 		ExpectedBodyContains: "field 'from' required",
 	},
@@ -1022,4 +1040,45 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigSendAuthorization: "Token ABCDEF",
 		})
 	RunOutgoingTestCases(t, jsonChannelWithSendAuthorization, newHandler(), jsonSendTestCases, []string{"Token ABCDEF"}, nil)
+}
+
+func TestSendEvent(t *testing.T) {
+	mb := test.NewMockBackend()
+	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), mb)
+
+	h := newHandler().(*handler)
+	h.Initialize(s)
+
+	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"http://example.com/typing": {
+			httpx.NewMockResponse(200, nil, []byte(`OK`)),
+			httpx.NewMockResponse(403, nil, []byte(`nope`)),
+			httpx.MockConnectionError,
+		},
+	})
+
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
+		[]string{urns.Phone.Prefix},
+		map[string]any{configSendTypingURL: "http://example.com/typing"},
+	)
+
+	clog := courier.NewChannelLogForEventSend(ch, nil)
+	err := h.SendEvent(context.Background(), ch, courier.EventOutTypeTyping, "tel:+250788123123", clog)
+	assert.NoError(t, err)
+	assert.Len(t, clog.HttpLogs, 1)
+	assert.Equal(t, "http://example.com/typing", clog.HttpLogs[0].URL)
+	assert.Contains(t, clog.HttpLogs[0].Request, `{"to":"+250788123123","type":"typing"}`)
+
+	// non-2XX response is a response error
+	err = h.SendEvent(context.Background(), ch, courier.EventOutTypeTyping, "tel:+250788123123", clog)
+	assert.Equal(t, courier.ErrResponseStatus, err)
+
+	// as is a connection error
+	err = h.SendEvent(context.Background(), ch, courier.EventOutTypeTyping, "tel:+250788123123", clog)
+	assert.Equal(t, courier.ErrConnectionFailed, err)
+
+	// channel without a typing URL configured can't send
+	noURL := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
+	err = h.SendEvent(context.Background(), noURL, courier.EventOutTypeTyping, "tel:+250788123123", clog)
+	assert.Equal(t, courier.ErrChannelConfig, err)
 }

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -288,6 +288,39 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	return nil
 }
 
+// SendEvent sends a typing indicator to the contact as a chat action, see https://core.telegram.org/bots/api#sendchataction
+func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, eventType courier.EventOutType, urn urns.URN, clog *courier.ChannelLog) error {
+	authToken := ch.StringConfigForKey(models.ConfigAuthToken, "")
+	if authToken == "" {
+		return courier.ErrChannelConfig
+	}
+
+	form := url.Values{"chat_id": []string{urn.Path()}, "action": []string{"typing"}}
+
+	sendURL := fmt.Sprintf("%s/bot%s/sendChatAction", apiURL, authToken)
+	req, err := http.NewRequest(http.MethodPost, sendURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, respBody, err := h.RequestHTTP(req, clog)
+	if err != nil || resp.StatusCode/100 == 5 {
+		return courier.ErrConnectionFailed
+	}
+
+	response := &struct {
+		Ok bool `json:"ok"`
+	}{}
+	if err := json.Unmarshal(respBody, response); err != nil || resp.StatusCode/100 != 2 || !response.Ok {
+		return courier.ErrResponseStatus
+	}
+
+	return nil
+}
+
+var _ courier.EventSender = (*handler)(nil)
+
 type fileResponse struct {
 	Ok          bool   `json:"ok"`
 	ErrorCode   int    `json:"error_code"`

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -1,6 +1,7 @@
 package telegram
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,10 +13,12 @@ import (
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/utils/clogs"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/stretchr/testify/assert"
 )
 
 var helloMsg = `{
@@ -965,4 +968,50 @@ func TestOutgoing(t *testing.T) {
 	)
 
 	RunOutgoingTestCases(t, ch, newHandler(), outgoingCases, []string{"auth_token"}, nil)
+}
+
+func TestSendEvent(t *testing.T) {
+	// other tests repoint apiURL at mock servers, so pin it for this test
+	defer func(u string) { apiURL = u }(apiURL)
+	apiURL = "https://api.telegram.org"
+
+	mb := test.NewMockBackend()
+	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), mb)
+
+	h := newHandler().(*handler)
+	h.Initialize(s)
+
+	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"https://api.telegram.org/botauth_token/sendChatAction": {
+			httpx.NewMockResponse(200, nil, []byte(`{"ok": true, "result": true}`)),
+			httpx.NewMockResponse(400, nil, []byte(`{"ok": false, "error_code": 400, "description": "Bad Request"}`)),
+			httpx.MockConnectionError,
+		},
+	})
+
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "TG", "2020", "US",
+		[]string{urns.Telegram.Prefix},
+		map[string]any{models.ConfigAuthToken: "auth_token"},
+	)
+
+	clog := courier.NewChannelLogForEventSend(ch, nil)
+	err := h.SendEvent(context.Background(), ch, courier.EventOutTypeTyping, "telegram:12345", clog)
+	assert.NoError(t, err)
+	assert.Len(t, clog.HttpLogs, 1)
+	assert.Equal(t, "https://api.telegram.org/botauth_token/sendChatAction", clog.HttpLogs[0].URL)
+	assert.Contains(t, clog.HttpLogs[0].Request, "chat_id=12345")
+	assert.Contains(t, clog.HttpLogs[0].Request, "action=typing")
+
+	// non-ok response is a response error
+	err = h.SendEvent(context.Background(), ch, courier.EventOutTypeTyping, "telegram:12345", clog)
+	assert.Equal(t, courier.ErrResponseStatus, err)
+
+	// as is a connection error
+	err = h.SendEvent(context.Background(), ch, courier.EventOutTypeTyping, "telegram:12345", clog)
+	assert.Equal(t, courier.ErrConnectionFailed, err)
+
+	// channel without an auth token can't send
+	noAuth := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "TG", "2020", "US", []string{urns.Telegram.Prefix}, map[string]any{})
+	err = h.SendEvent(context.Background(), noAuth, courier.EventOutTypeTyping, "telegram:12345", clog)
+	assert.Equal(t, courier.ErrChannelConfig, err)
 }

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -71,6 +71,7 @@ type IncomingTestCase struct {
 	ExpectedMsgID         int64
 	ExpectedStatuses      []ExpectedStatus
 	ExpectedEvents        []ExpectedEvent
+	ExpectedTyping        []urns.URN
 	ExpectedErrors        []*clogs.Error
 	ExpectedNewURN        *models.NewURNSpec
 	NoLogsExpected        bool
@@ -225,6 +226,8 @@ func RunIncomingTestCases(t *testing.T, channels []courier.Channel, handler cour
 					assert.Equal(t, expectedEvent.Time, actualEvent.OccurredOn())
 				}
 			}
+
+			assert.Equal(t, tc.ExpectedTyping, mb.WrittenTypingIndicators(), "unexpected typing indicators written")
 
 			if tc.ExpectedContactName != nil {
 				require.Equal(*tc.ExpectedContactName, mb.LastContactName())

--- a/responses.go
+++ b/responses.go
@@ -48,6 +48,11 @@ func WriteChannelEventSuccess(w http.ResponseWriter, event ChannelEvent) error {
 	return WriteDataResponse(w, http.StatusOK, "Event Accepted", []any{NewEventReceiveData(event)})
 }
 
+// WriteTypingIndicatorSuccess writes a JSON response indicating we handled a typing indicator
+func WriteTypingIndicatorSuccess(w http.ResponseWriter) error {
+	return WriteDataResponse(w, http.StatusOK, "Typing Indicator Accepted", []any{})
+}
+
 // WriteMsgSuccess writes a JSON response for the passed in msg indicating we handled it
 func WriteMsgSuccess(w http.ResponseWriter, msgs []MsgIn) error {
 	data := []any{}

--- a/server.go
+++ b/server.go
@@ -121,6 +121,7 @@ func (s *Server) Start() error {
 	internalRouter.MethodNotAllowed(s.handle405("internal"))
 	internalRouter.Get("/", s.handleHealth)
 	internalRouter.Post("/ci/attachment/fetch", s.tokenAuthRequired(s.handleFetchAttachment))
+	internalRouter.Post("/ci/event/send", s.tokenAuthRequired(s.handleSendEvent))
 
 	s.publicServer = &http.Server{
 		Addr:         publicAddr,
@@ -352,6 +353,22 @@ func (s *Server) handleFetchAttachment(w http.ResponseWriter, r *http.Request) {
 	resp, err := fetchAttachment(ctx, s.rt, s.backend, r)
 	if err != nil {
 		slog.Error("error fetching attachment", "error", err)
+		WriteError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonx.MustMarshal(resp))
+}
+
+func (s *Server) handleSendEvent(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+	defer cancel()
+
+	resp, err := sendEvent(ctx, s.backend, r)
+	if err != nil {
+		slog.Error("error sending event", "error", err)
 		WriteError(w, http.StatusBadRequest, err)
 		return
 	}

--- a/test/backend.go
+++ b/test/backend.go
@@ -35,12 +35,13 @@ type MockBackend struct {
 	mutex     sync.RWMutex
 	redisPool *redis.Pool
 
-	writtenMsgs          []courier.MsgIn
-	writtenMsgStatuses   []courier.StatusUpdate
-	writtenChannelEvents []courier.ChannelEvent
-	writtenChannelLogs   []*courier.ChannelLog
-	savedAttachments     []*SavedAttachment
-	storageError         error
+	writtenMsgs             []courier.MsgIn
+	writtenMsgStatuses      []courier.StatusUpdate
+	writtenChannelEvents    []courier.ChannelEvent
+	writtenChannelLogs      []*courier.ChannelLog
+	writtenTypingIndicators []urns.URN
+	savedAttachments        []*SavedAttachment
+	storageError            error
 
 	lastContactName string
 	urnAuthTokens   map[urns.URN]map[string]string
@@ -276,6 +277,15 @@ func (mb *MockBackend) WriteChannelEvent(ctx context.Context, event courier.Chan
 	return nil
 }
 
+// WriteTypingIndicator records that the contact with the given URN is typing
+func (mb *MockBackend) WriteTypingIndicator(ctx context.Context, channel courier.Channel, urn urns.URN) error {
+	mb.mutex.Lock()
+	defer mb.mutex.Unlock()
+
+	mb.writtenTypingIndicators = append(mb.writtenTypingIndicators, urn)
+	return nil
+}
+
 // GetChannel returns the channel with the passed in type and channel uuid
 func (mb *MockBackend) GetChannel(ctx context.Context, cType models.ChannelType, uuid models.ChannelUUID) (courier.Channel, error) {
 	channel, found := mb.channels[uuid]
@@ -352,6 +362,7 @@ func (mb *MockBackend) WrittenMsgs() []courier.MsgIn                  { return m
 func (mb *MockBackend) WrittenMsgStatuses() []courier.StatusUpdate    { return mb.writtenMsgStatuses }
 func (mb *MockBackend) WrittenChannelEvents() []courier.ChannelEvent  { return mb.writtenChannelEvents }
 func (mb *MockBackend) WrittenChannelLogs() []*courier.ChannelLog     { return mb.writtenChannelLogs }
+func (mb *MockBackend) WrittenTypingIndicators() []urns.URN           { return mb.writtenTypingIndicators }
 func (mb *MockBackend) SavedAttachments() []*SavedAttachment          { return mb.savedAttachments }
 func (mb *MockBackend) URNAuthTokens() map[urns.URN]map[string]string { return mb.urnAuthTokens }
 
@@ -385,6 +396,7 @@ func (mb *MockBackend) Reset() {
 	mb.writtenMsgStatuses = nil
 	mb.writtenChannelEvents = nil
 	mb.writtenChannelLogs = nil
+	mb.writtenTypingIndicators = nil
 	mb.urnAuthTokens = nil
 }
 

--- a/test/handler.go
+++ b/test/handler.go
@@ -76,6 +76,22 @@ func (h *mockHandler) Send(ctx context.Context, msg courier.MsgOut, res *courier
 	return nil
 }
 
+// SendEvent sends the given transient event, logging any HTTP calls or errors
+func (h *mockHandler) SendEvent(ctx context.Context, ch courier.Channel, eventType courier.EventOutType, urn urns.URN, clog *courier.ChannelLog) error {
+	req, _ := httpx.NewRequest(ctx, "POST", "http://mock.com/event", nil, nil)
+	trace, resp, err := utils.TraceHTTP(h.rt.HTTP, req, 1024)
+	if trace != nil {
+		clog.HTTP(trace)
+	}
+
+	if err != nil || resp.StatusCode/100 != 2 {
+		return courier.ErrConnectionFailed
+	}
+	return nil
+}
+
+var _ courier.EventSender = (*mockHandler)(nil)
+
 func (h *mockHandler) WriteStatusSuccessResponse(ctx context.Context, w http.ResponseWriter, statuses []courier.StatusUpdate) error {
 	return courier.WriteStatusSuccess(w, statuses)
 }


### PR DESCRIPTION
Adds typing indicators as transient events:

* New internal `POST /ci/event/send` endpoint (mirrors `/ci/attachment/fetch`) that mailroom calls to have a channel send a transient event to a contact. There's no queueing, statuses or retries - stale typing indicators are of no interest to anyone.
* Handlers opt in by implementing the new `EventSender` interface:
  * Telegram sends a `sendChatAction`
  * External channels POST to a configurable `send_typing_url` (used by the msg console)
* External channels also get a `/typing` receive endpoint which records that the contact is typing as a short lived valkey marker (`typing:<contact-uuid>`, 10s TTL) which the chat UI reads when polling. An incoming message from the contact clears the marker.
* New `event_send` channel log type.
