### PR TITLE
Handle throttling and bare-message errors consistently across WhatsAp…

### DIFF
--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -325,7 +326,11 @@ func (h *handler) requestD3C(payload whatsapp.SendRequest, accessToken string, r
 		return "", courier.ErrResponseUnparseable
 	}
 
-	if respPayload.Error.Code != 0 {
+	if slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Error.Code) {
+		return "", courier.ErrConnectionThrottled
+	}
+
+	if respPayload.Error.Code != 0 || respPayload.Error.Message != "" {
 		return "", courier.ErrFailedWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
 	}
 

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -801,6 +801,34 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		MsgURN:  "whatsapp:250788123123",
 		MockResponses: map[string][]*httpx.MockResponse{
 			"https://waba-v2.360dialog.io/messages": {
+				httpx.NewMockResponse(403, nil, []byte(`{ "error": {"message": "(#250012) some error","code": 250012 }}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Path: "/messages",
+				Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"text","text":{"body":"Error","preview_url":false}}`,
+			},
+		},
+		ExpectedError: courier.ErrFailedWithReason("250012", "(#250012) some error"),
+	},
+	{
+		Label:   "Error Channel Contact Pair limit hit",
+		MsgText: "Pair limit",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://waba-v2.360dialog.io/messages": {
+				httpx.NewMockResponse(403, nil, []byte(`{ "error": {"message": "(#131056) (Business Account, Consumer Account) pair rate limit hit","code": 131056 }}`)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
+		Label:   "Error Throttled",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://waba-v2.360dialog.io/messages": {
 				httpx.NewMockResponse(403, nil, []byte(`{ "error": {"message": "(#130429) Rate limit hit","code": 130429 }}`)),
 			},
 		},
@@ -810,7 +838,24 @@ var SendTestCasesD3C = []OutgoingTestCase{
 				Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"text","text":{"body":"Error","preview_url":false}}`,
 			},
 		},
-		ExpectedError: courier.ErrFailedWithReason("130429", "(#130429) Rate limit hit"),
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
+		Label:   "Error Message",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://waba-v2.360dialog.io/messages": {
+				httpx.NewMockResponse(403, nil, []byte(`{ "error": {"message": "Other error with message","code": 0 }}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Path: "/messages",
+				Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"text","text":{"body":"Error","preview_url":false}}`,
+			},
+		},
+		ExpectedError: courier.ErrFailedWithReason("0", "Other error with message"),
 	},
 	{
 		Label:   "Error Connection",

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -762,7 +762,7 @@ func (h *handler) requestWAC(payload whatsapp.SendRequest, accessToken string, r
 		return "", courier.ErrConnectionThrottled
 	}
 
-	if respPayload.Error.Code != 0 {
+	if respPayload.Error.Code != 0 || respPayload.Error.Message != "" {
 		return "", courier.ErrFailedWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
 	}
 

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -864,6 +864,17 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedError: courier.ErrFailedWithReason("368", "(#368) Temporarily blocked for policies violations"),
 	},
 	{
+		Label:   "Error Message",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(403, nil, []byte(`{ "error": {"message": "Other error with message","code": 0 }}`)),
+			},
+		},
+		ExpectedError: courier.ErrFailedWithReason("0", "Other error with message"),
+	},
+	{
 		Label:   "Error Connection",
 		MsgText: "Error",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -924,17 +924,12 @@ func (h *handler) makeAPIRequest(payload any, accessToken string, res *courier.S
 		return courier.ErrResponseUnparseable
 	}
 
+	if slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Error.Code) {
+		return courier.ErrConnectionThrottled
+	}
+
 	if respPayload.Error.Code != 0 || respPayload.Error.Message != "" {
-
-		if slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Error.Code) {
-			return courier.ErrConnectionThrottled
-		}
-
-		if respPayload.Error.Code != 0 {
-			return courier.ErrFailedWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
-		} else if respPayload.Error.Message != "" {
-			return courier.ErrFailedWithReason("0", respPayload.Error.Message)
-		}
+		return courier.ErrFailedWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
 	}
 
 	if len(respPayload.Errors) > 0 {

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -1063,6 +1063,17 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrFailedWithReason("368", "(#368) Temporarily blocked for policies violations"),
 	},
 	{
+		Label:   "Error Message",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(403, nil, []byte(`{ "error": {"message": "Other error with message","code": 0 }}`)),
+			},
+		},
+		ExpectedError: courier.ErrFailedWithReason("0", "Other error with message"),
+	},
+	{
 		Label:   "Error Connection",
 		MsgText: "Error",
 		MsgURN:  "whatsapp:250788123123",


### PR DESCRIPTION
…p Cloud send paths

Treat error responses with code 0 but a non-empty message as failures, and route throttling error codes to ErrConnectionThrottled, in the dialog360, meta and turn handlers. Also flatten the duplicated nested error-handling block.