### PR TITLE
Retry WhatsApp Cloud media upload errors (131053) instead of failing them

### DIFF
--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -330,6 +330,10 @@ func (h *handler) requestD3C(payload whatsapp.SendRequest, accessToken string, r
 		return "", courier.ErrConnectionThrottled
 	}
 
+	if slices.Contains(whatsapp.WACRetryableErrorCodes, respPayload.Error.Code) {
+		return "", courier.ErrRetryableWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
+	}
+
 	if respPayload.Error.Code != 0 || respPayload.Error.Message != "" {
 		return "", courier.ErrFailedWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
 	}

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -841,6 +841,23 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		ExpectedError: courier.ErrConnectionThrottled,
 	},
 	{
+		Label:   "Error Retryable",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://waba-v2.360dialog.io/messages": {
+				httpx.NewMockResponse(400, nil, []byte(`{ "error": {"message": "Media upload error","code": 131053 }}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Path: "/messages",
+				Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"text","text":{"body":"Error","preview_url":false}}`,
+			},
+		},
+		ExpectedError: courier.ErrRetryableWithReason("131053", "Media upload error"),
+	},
+	{
 		Label:   "Error Message",
 		MsgText: "Error",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -762,6 +762,10 @@ func (h *handler) requestWAC(payload whatsapp.SendRequest, accessToken string, r
 		return "", courier.ErrConnectionThrottled
 	}
 
+	if slices.Contains(whatsapp.WACRetryableErrorCodes, respPayload.Error.Code) {
+		return "", courier.ErrRetryableWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
+	}
+
 	if respPayload.Error.Code != 0 || respPayload.Error.Message != "" {
 		return "", courier.ErrFailedWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
 	}

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -853,6 +853,17 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedError: courier.ErrConnectionThrottled,
 	},
 	{
+		Label:   "Error Retryable",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(400, nil, []byte(`{ "error": {"message": "Media upload error","code": 131053 }}`)),
+			},
+		},
+		ExpectedError: courier.ErrRetryableWithReason("131053", "Media upload error"),
+	},
+	{
 		Label:   "Error",
 		MsgText: "Error",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/meta/whatsapp/api.go
+++ b/handlers/meta/whatsapp/api.go
@@ -26,6 +26,10 @@ var IgnoreStatuses = map[string]bool{
 
 var WACThrottlingErrorCodes = []int{4, 80007, 130429, 131048, 131056, 133016}
 
+// WACRetryableErrorCodes are error codes for transient failures that should be retried rather than failed. 131053
+// is a media upload/download error which is often caused by Meta failing to fetch the media from the given link.
+var WACRetryableErrorCodes = []int{131053}
+
 // see https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media#example-2
 type MOMedia struct {
 	Caption  string `json:"caption"`

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -928,6 +928,10 @@ func (h *handler) makeAPIRequest(payload any, accessToken string, res *courier.S
 		return courier.ErrConnectionThrottled
 	}
 
+	if slices.Contains(whatsapp.WACRetryableErrorCodes, respPayload.Error.Code) {
+		return courier.ErrRetryableWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
+	}
+
 	if respPayload.Error.Code != 0 || respPayload.Error.Message != "" {
 		return courier.ErrFailedWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
 	}
@@ -935,6 +939,9 @@ func (h *handler) makeAPIRequest(payload any, accessToken string, res *courier.S
 	if len(respPayload.Errors) > 0 {
 		if slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Errors[0].Code) {
 			return courier.ErrConnectionThrottled
+		}
+		if slices.Contains(whatsapp.WACRetryableErrorCodes, respPayload.Errors[0].Code) {
+			return courier.ErrRetryableWithReason(strconv.Itoa(respPayload.Errors[0].Code), respPayload.Errors[0].Title)
 		}
 		return courier.ErrFailedWithReason(strconv.Itoa(respPayload.Errors[0].Code), respPayload.Errors[0].Title)
 	}

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -1052,6 +1052,17 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrConnectionThrottled,
 	},
 	{
+		Label:   "Error Retryable",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(400, nil, []byte(`{ "error": {"message": "Media upload error","code": 131053 }}`)),
+			},
+		},
+		ExpectedError: courier.ErrRetryableWithReason("131053", "Media upload error"),
+	},
+	{
 		Label:   "Error",
 		MsgText: "Error",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -650,6 +650,21 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrFailedWithReason("232", "Error Sending"),
 	},
 	{
+		Label:   "Error Field Retryable",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "errors": [{"title":"Media upload error", "code": 131053}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Path: "/v1/messages",
+			Body: `{"to":"250788123123","type":"text","text":{"body":"Error"}}`,
+		}},
+		ExpectedError: courier.ErrRetryableWithReason("131053", "Media upload error"),
+	},
+	{
 		Label:          "Audio attachment but upload fails",
 		MsgText:        "audio has no caption, sent as text",
 		MsgURN:         "whatsapp:250788123123",

--- a/sender.go
+++ b/sender.go
@@ -139,6 +139,18 @@ func ErrFailedWithReason(code, desc string) *SendError {
 	}
 }
 
+// ErrRetryableWithReason is like ErrFailedWithReason but for failures that may be transient and so should be retried
+func ErrRetryableWithReason(code, desc string) *SendError {
+	return &SendError{
+		msg:         "channel rejected send with retryable reason",
+		retryable:   true,
+		loggable:    false,
+		clogCode:    "rejected_with_reason",
+		clogMsg:     desc,
+		clogExtCode: code,
+	}
+}
+
 // Foreman takes care of managing our set of sending workers and assigns msgs for each to send
 type Foreman struct {
 	server           *Server


### PR DESCRIPTION
## What

WhatsApp Cloud error code `131053` ("Media upload error") is now treated as a **retryable** failure across all three WhatsApp Cloud send paths (meta, dialog360, turn), instead of failing the message on the first occurrence.

## Why

Courier sends WhatsApp media by link — the attachment URL is passed to the API and the platform fetches it from its own infrastructure. When that fetch fails, the API returns `131053` with details like:

> Downloading media from weblink failed with http code 502, status message DNS query shed at inflight cap

This is typically a transient failure on the platform's media-fetch side, not a permanent problem with the message or media. Previously `131053` fell into the generic error branch (`ErrFailedWithReason`, non-retryable), so the message was marked failed on the first hit with no retry.

## How

- `ErrRetryableWithReason(code, desc)` — a retryable sibling of `ErrFailedWithReason`. It keeps the external error code and message in the channel log (so the specific `131053` stays visible for debugging) but marks the message errored so it goes through the normal bounded retry cycle. This is preferred over adding `131053` to the throttling list, which would mislabel a media-fetch failure as a rate limit in the logs.
- `WACRetryableErrorCodes` — a shared list of WhatsApp Cloud error codes that should be retried, mirroring the existing `WACThrottlingErrorCodes`. Currently just `131053`.
- Each send path checks the new list and returns `ErrRetryableWithReason` (turn checks it in both its `error` and `errors[]` branches).

## Notes for reviewers

- Retries are bounded by the normal errored-message retry cycle downstream — this won't loop forever on a persistently bad media URL.
- This treats *every* `131053` as transient. It can also indicate a genuinely bad/oversized/unfetchable media URL, which will now consume the retries before failing — an acceptable trade for recovering the transient case.

## Testing

- Added an "Error Retryable" case to the meta, dialog360 and turn handler test suites.
- `go build ./...`, all three handler suites, and the root package tests pass.