### PR TITLE
Resolve AWS credentials and region from the standard SDK default chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ environment variables and parameters and for more details on each option.
 
 ### AWS services:
 
- * `COURIER_AWS_ACCESS_KEY_ID`: AWS access key id used to authenticate to AWS
- * `COURIER_AWS_SECRET_ACCESS_KEY`: AWS secret access key used to authenticate to AWS
- * `COURIER_AWS_REGION`: AWS region (e.g. `eu-west-1`)
+The AWS region and credentials are resolved via the standard AWS SDK default chain — the `AWS_REGION`
+(or `AWS_DEFAULT_REGION`) environment variable, the instance/task IAM role, the
+`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` environment variables, and the shared config/credentials
+files. There is no built-in default region, so `AWS_REGION` (or `AWS_DEFAULT_REGION`) must be set.
+
  * `COURIER_S3_ATTACHMENTS_BUCKET`: name of your S3 bucket (e.g. `rp-attachments`)
 
 ### Logging and error reporting:

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -617,7 +617,7 @@ func (b *backend) ResolveMedia(ctx context.Context, mediaUrl string) (*models.Me
 	mediaUUID := uuidRegex.FindString(u.Path)
 
 	// if hostname isn't our media domain, or path doesn't contain a UUID, don't try to resolve
-	if strings.Replace(u.Hostname(), fmt.Sprintf("%s.", b.rt.Config.AWSRegion), "", -1) != b.rt.Config.MediaDomain || mediaUUID == "" {
+	if strings.Replace(u.Hostname(), fmt.Sprintf("%s.", b.rt.AWSRegion), "", -1) != b.rt.Config.MediaDomain || mediaUUID == "" {
 		return nil, nil
 	}
 
@@ -646,7 +646,7 @@ func (b *backend) ResolveMedia(ctx context.Context, mediaUrl string) (*models.Me
 	}
 
 	// if we found a media record but it doesn't match the URL, don't use it
-	if media == nil || (media.URL() != mediaUrl && media.URL() != strings.Replace(mediaUrl, fmt.Sprintf("%s.", b.rt.Config.AWSRegion), "", -1)) {
+	if media == nil || (media.URL() != mediaUrl && media.URL() != strings.Replace(mediaUrl, fmt.Sprintf("%s.", b.rt.AWSRegion), "", -1)) {
 		return nil, nil
 	}
 

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -26,10 +26,6 @@ type Config struct {
 	InternalAddress string `help:"the network interface address our internal web server will bind to"`
 	InternalPort    int    `help:"the port our internal web server will listen on"`
 
-	AWSAccessKeyID     string `help:"access key ID to use for AWS services"`
-	AWSSecretAccessKey string `help:"secret access key to use for AWS services"`
-	AWSRegion          string `help:"region to use for AWS services, e.g. us-east-1"`
-
 	MetricsReporting    string `validate:"eq=off|eq=basic|eq=advanced"     help:"the level of metrics reporting"`
 	CloudwatchNamespace string `help:"the namespace to use for cloudwatch metrics"`
 	DeploymentID        string `help:"the deployment identifier to use for metrics"`
@@ -74,10 +70,6 @@ func NewDefaultConfig() *Config {
 		PublicPort:      8080,
 		InternalAddress: "localhost",
 		InternalPort:    8081,
-
-		AWSAccessKeyID:     "",
-		AWSSecretAccessKey: "",
-		AWSRegion:          "us-east-1",
 
 		MetricsReporting:    "off",
 		CloudwatchNamespace: "Courier",

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -59,6 +59,11 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error resolving AWS config: %w", err)
 	}
+	// the SDK doesn't error when no region can be resolved, it just leaves it empty, so fail fast here
+	// rather than let an empty region silently break region-qualified S3 hostname handling
+	if awsCfg.Region == "" {
+		return nil, fmt.Errorf("no AWS region resolved - set AWS_REGION or AWS_DEFAULT_REGION")
+	}
 	rt.AWSRegion = awsCfg.Region
 
 	// pass empty credentials and region to the AWS service constructors so the SDK resolves them from

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/gomodule/redigo/redis"
 	_ "github.com/lib/pq" // postgres driver
+	awsx "github.com/nyaruka/gocommon/aws"
 	"github.com/nyaruka/gocommon/aws/cwatch"
 	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/gocommon/aws/s3x"
@@ -23,6 +24,11 @@ type Runtime struct {
 	VK     *redis.Pool
 	S3     *s3x.Service
 	CW     *cwatch.Service
+
+	// AWSRegion is the region resolved from the standard AWS SDK default chain. It's kept here so code
+	// that needs to reason about region-qualified S3 hostnames (e.g. media URL resolution) can use it
+	// without a courier-specific region config setting.
+	AWSRegion string
 
 	HTTP *http.Client
 
@@ -46,7 +52,18 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 	rt.DB.SetMaxIdleConns(4)
 	rt.DB.SetMaxOpenConns(16)
 
-	rt.Dynamo, err = dynamo.NewClient(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, cfg.AWSRegion, cfg.DynamoEndpoint)
+	// resolve the AWS region from the standard SDK default chain (AWS_REGION / AWS_DEFAULT_REGION env
+	// vars, shared config, etc.) so we can reason about region-qualified S3 hostnames without a
+	// courier-specific region setting.
+	awsCfg, err := awsx.NewConfig("", "", "")
+	if err != nil {
+		return nil, fmt.Errorf("error resolving AWS config: %w", err)
+	}
+	rt.AWSRegion = awsCfg.Region
+
+	// pass empty credentials and region to the AWS service constructors so the SDK resolves them from
+	// its default chain (env vars, instance/task IAM role, shared config/credentials files, etc.)
+	rt.Dynamo, err = dynamo.NewClient("", "", "", cfg.DynamoEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DynamoDB client: %w", err)
 	}
@@ -56,12 +73,12 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 		return nil, fmt.Errorf("error creating Valkey pool: %w", err)
 	}
 
-	rt.S3, err = s3x.NewService(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, cfg.AWSRegion, cfg.S3Endpoint, cfg.S3PathStyle)
+	rt.S3, err = s3x.NewService("", "", "", cfg.S3Endpoint, cfg.S3PathStyle)
 	if err != nil {
 		return nil, fmt.Errorf("error creating S3 service: %w", err)
 	}
 
-	rt.CW, err = cwatch.NewService(cfg.AWSAccessKeyID, cfg.AWSSecretAccessKey, cfg.AWSRegion, cfg.CloudwatchNamespace, cfg.DeploymentID)
+	rt.CW, err = cwatch.NewService("", "", "", cfg.CloudwatchNamespace, cfg.DeploymentID)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Cloudwatch service: %w", err)
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestHTTPProxied(t *testing.T) {
+	// NewRuntime resolves the AWS region from the SDK default chain and fails if none is set
+	t.Setenv("AWS_REGION", "us-east-1")
+
 	// without SendProxyURL configured, HTTPProxied is the same client as HTTP
 	cfg := runtime.NewDefaultConfig()
 	require.NoError(t, cfg.Validate())

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -24,9 +24,13 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.Valkey = "valkey://valkey:6379/0"
 	cfg.MediaDomain = "nyaruka.s3.com"
 
+	// AWS credentials and region are resolved from the standard SDK default chain, so export them as
+	// the standard env vars (localstack values) rather than via courier config
+	t.Setenv("AWS_ACCESS_KEY_ID", "root")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "tembatemba")
+	t.Setenv("AWS_REGION", "us-east-1")
+
 	// configure S3 to use a localstack instance
-	cfg.AWSAccessKeyID = "root"
-	cfg.AWSSecretAccessKey = "tembatemba"
 	cfg.S3Endpoint = "http://localstack:4566"
 	cfg.S3AttachmentsBucket = "test-attachments"
 	cfg.S3PathStyle = true


### PR DESCRIPTION
## What

Remove courier's own `AWSAccessKeyID`, `AWSSecretAccessKey` and `AWSRegion` config options and instead resolve AWS credentials and region from the standard AWS SDK default chain:

- `AWS_REGION` / `AWS_DEFAULT_REGION` environment variables
- the instance/task IAM role
- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables
- shared config/credentials files

The AWS service constructors (`dynamo.NewClient`, `s3x.NewService`, `cwatch.NewService`) are now passed empty strings for the access key, secret and region, which tells the SDK to resolve them from that chain. Test setup exports the standard `AWS_*` env vars instead of setting config fields, and the README documents the new resolution behavior.

## Why

First step in migrating the service off EC2 and onto ECS. On ECS, credentials come from a task IAM role rather than static keys, so relying on the SDK's default chain removes the need to plumb credentials and region through service-specific config.

## Note on the media URL resolver

The media URL resolver normalizes region-qualified S3 hostnames (e.g. `bucket.<region>.s3...`) and so still needs to know the region. Rather than reintroduce a config setting, the runtime now resolves the region once from the SDK default chain and exposes it for that use.

## Breaking change

The AWS access key, secret and region config options no longer exist. Deployments must supply credentials and region via the standard AWS environment.

Since there is no longer a built-in default region, **`AWS_REGION` (or `AWS_DEFAULT_REGION`) must be set** wherever deployments previously relied on the built-in `us-east-1` default.

## Testing

`gofmt`, `go vet` and `go build ./cmd/courier` clean. Full test suite passes against localstack/postgres/valkey, including the S3/DynamoDB-backed backend tests and `TestResolveMedia` (which exercises the region-qualified hostname normalization).
