### PR TITLE
Publish msg_status_changed events to subscribed history sockets

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -3,6 +3,7 @@ package rapidpro
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -21,6 +22,7 @@ import (
 	"github.com/nyaruka/courier/v26/utils/queue"
 	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/gocommon/aws/dynamo/dyntest"
+	"github.com/nyaruka/gocommon/centrifugo"
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/dbutil/assertdb"
 	"github.com/nyaruka/gocommon/httpx"
@@ -554,6 +556,47 @@ func (ts *BackendTestSuite) TestMsgStatus() {
 	ts.Equal(m.ErrorCount, 3)
 	ts.Equal(null.String("E"), m.FailedReason)
 
+}
+
+func (ts *BackendTestSuite) TestMsgStatusSocketPublish() {
+	ctx := context.Background()
+	channel := ts.getChannel("KN", "dbc126ed-66bc-4e28-b67b-81dc3327c95d")
+	clog := courier.NewChannelLog(courier.ChannelLogTypeMsgStatus, channel, nil)
+
+	ts.b.rt.Centrifugo.(*centrifugo.MockClient).Clear()
+
+	vc := ts.b.rt.VK.Get()
+	defer vc.Close()
+
+	socket := "history:a984069d-0008-4d8c-a772-b14a8a6acccc"
+
+	// put test message back into queued state
+	ts.b.rt.DB.MustExec(`UPDATE msgs_msg SET status = 'Q', sent_on = NULL WHERE id = $1`, 10001)
+
+	// write a status update before the contact's socket is subscribed... nothing is published
+	status := ts.b.NewStatusUpdate(channel, "0199df10-10dc-7e6e-834b-3d959ece93b2", models.MsgStatusSent, clog)
+	ts.NoError(ts.b.WriteStatusUpdate(ctx, status))
+	ts.b.statusWriter.Flush()
+
+	ts.Empty(testsuite.CentrifugoHistory(ts.T(), ts.b.rt, socket))
+
+	// mark the socket subscribed (as the authorizing service would) and write another status update
+	_, err := vc.Do("SET", "socket-subs:"+socket, "1")
+	ts.NoError(err)
+	defer vc.Do("DEL", "socket-subs:"+socket)
+
+	status = ts.b.NewStatusUpdate(channel, "0199df10-10dc-7e6e-834b-3d959ece93b2", models.MsgStatusDelivered, clog)
+	ts.NoError(ts.b.WriteStatusUpdate(ctx, status))
+	ts.b.statusWriter.Flush()
+
+	sent := testsuite.CentrifugoHistory(ts.T(), ts.b.rt, socket)
+	if ts.Len(sent, 1) {
+		var decoded map[string]any
+		ts.NoError(json.Unmarshal(sent[0], &decoded))
+		ts.Equal("msg_status_changed", decoded["type"])
+		ts.Equal("0199df10-10dc-7e6e-834b-3d959ece93b2", decoded["msg_uuid"])
+		ts.Equal("delivered", decoded["status"])
+	}
 }
 
 func (ts *BackendTestSuite) TestSentExternalIDCaching() {

--- a/backends/rapidpro/status.go
+++ b/backends/rapidpro/status.go
@@ -135,8 +135,12 @@ func (b *backend) writeStatusUpdatesToDB(ctx context.Context, statuses []*models
 			}
 		}
 
-		// publish changes to any subscribed history sockets - best-effort, never fails the status write
-		if err := models.PublishStatusChanges(ctx, b.rt, changes); err != nil {
+		// publish changes to any subscribed history sockets - best-effort with its own short timeout so a Centrifugo
+		// or Valkey stall can't eat into the batch's DB write budget
+		pubCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		if err := models.PublishStatusChanges(pubCtx, b.rt, changes); err != nil {
 			slog.Error("error publishing status changes", "error", err)
 		}
 	}

--- a/backends/rapidpro/status.go
+++ b/backends/rapidpro/status.go
@@ -134,6 +134,11 @@ func (b *backend) writeStatusUpdatesToDB(ctx context.Context, statuses []*models
 				slog.Error("error queuing status change to writer", "error", err, "msg_uuid", c.MsgUUID, "msg_status", c.MsgStatus)
 			}
 		}
+
+		// publish changes to any subscribed history sockets - best-effort, never fails the status write
+		if err := models.PublishStatusChanges(ctx, b.rt, changes); err != nil {
+			slog.Error("error publishing status changes", "error", err)
+		}
 	}
 
 	return unresolved, nil

--- a/core/models/socket.go
+++ b/core/models/socket.go
@@ -1,0 +1,105 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/gocommon/centrifugo"
+)
+
+// SocketHistoryNamespace is the realtime pub/sub namespace for a contact's message history. A history socket is
+// addressed as "history:<contact-uuid>". Courier publishes msg status changes to these sockets for any live
+// subscribers. ("Socket" is our name for a realtime pub/sub address - so as not to overload Channel, which already
+// means a messaging channel.)
+const SocketHistoryNamespace = "history"
+
+// HistorySocket returns the realtime pub/sub socket for a contact's message history ("history:<contact-uuid>").
+func HistorySocket(contactUUID ContactUUID) string {
+	return fmt.Sprintf("%s:%s", SocketHistoryNamespace, contactUUID)
+}
+
+// subscriptionKey is the valkey key marking that a realtime socket has at least one active subscriber, e.g.
+// "socket-subs:history:<contact-uuid>". The key is a per-socket presence marker written by the service that
+// authorizes subscriptions (it sets/re-arms the key with a TTL on every subscribe and refresh); courier only
+// reads it.
+func subscriptionKey(socket string) string {
+	return fmt.Sprintf("socket-subs:%s", socket)
+}
+
+// SubscribedSockets returns the subset of the given sockets that currently have at least one active subscriber. It
+// resolves them all in a single round-trip by MGETting their presence keys, so checking many sockets at once costs
+// one lookup rather than one per socket. A socket is subscribed when its key is present; missing keys come back nil.
+// The returned map only contains the subscribed sockets.
+func SubscribedSockets(ctx context.Context, rt *runtime.Runtime, sockets ...string) (map[string]bool, error) {
+	if len(sockets) == 0 {
+		return nil, nil
+	}
+
+	keys := make([]any, len(sockets))
+	for i, s := range sockets {
+		keys[i] = subscriptionKey(s)
+	}
+
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	values, err := redis.Values(redis.DoContext(vc, ctx, "MGET", keys...))
+	if err != nil {
+		return nil, fmt.Errorf("error checking socket subscriptions: %w", err)
+	}
+
+	subscribed := make(map[string]bool, len(sockets))
+	for i, v := range values {
+		if v != nil {
+			subscribed[sockets[i]] = true
+		}
+	}
+	return subscribed, nil
+}
+
+// PublishStatusChanges publishes the given status changes to their contacts' history sockets, each as a
+// msg_status_changed event - the same shape mailroom publishes for engine events. It's best-effort and a no-op for
+// any socket that currently has no subscribers; the sockets a batch touches are resolved in a single presence
+// lookup, then every subscribed socket's events are batched into one pipelined request so the whole batch costs one
+// centrifugo round-trip and lands or fails together.
+func PublishStatusChanges(ctx context.Context, rt *runtime.Runtime, changes []*StatusChange) error {
+	if len(changes) == 0 {
+		return nil
+	}
+
+	sockets := make([]string, 0, len(changes))
+	seen := make(map[string]bool, len(changes))
+	for _, c := range changes {
+		if socket := HistorySocket(c.ContactUUID); !seen[socket] {
+			seen[socket] = true
+			sockets = append(sockets, socket)
+		}
+	}
+
+	subscribed, err := SubscribedSockets(ctx, rt, sockets...)
+	if err != nil {
+		return err
+	}
+
+	var pubs []*centrifugo.Publish
+	for _, c := range changes {
+		socket := HistorySocket(c.ContactUUID)
+		if !subscribed[socket] {
+			continue
+		}
+		data, err := json.Marshal(c.historyEvent())
+		if err != nil {
+			return fmt.Errorf("error marshaling status change event for %s: %w", socket, err)
+		}
+		pubs = append(pubs, &centrifugo.Publish{Channel: socket, Data: data})
+	}
+
+	if err := rt.Centrifugo.Publish(ctx, pubs...); err != nil {
+		return fmt.Errorf("error publishing status change events: %w", err)
+	}
+
+	return nil
+}

--- a/core/models/socket_test.go
+++ b/core/models/socket_test.go
@@ -1,0 +1,94 @@
+package models_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/testsuite"
+	"github.com/nyaruka/gocommon/uuids"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHistorySocket(t *testing.T) {
+	contact := models.ContactUUID("a393abc0-283d-4c9b-a1b3-641a035c34bf")
+
+	assert.Equal(t, "history:a393abc0-283d-4c9b-a1b3-641a035c34bf", models.HistorySocket(contact))
+}
+
+func TestPublishStatusChanges(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	defer testsuite.ResetValkey(t, rt)
+
+	vc := rt.VK.Get()
+	defer vc.Close()
+
+	contact1Socket := "history:a984069d-0008-4d8c-a772-b14a8a6acccc"
+	contact2Socket := "history:60d5c8bf-16c8-4dcb-9cda-11a19e3d1c95"
+
+	changes := []*models.StatusChange{
+		{
+			ContactUUID: "a984069d-0008-4d8c-a772-b14a8a6acccc",
+			MsgUUID:     "0199df0f-9f82-7689-b02d-f34105991321",
+			MsgStatus:   models.MsgStatusDelivered,
+			OrgID:       1,
+			CreatedOn:   time.Date(2025, 11, 10, 16, 14, 30, 123456789, time.UTC),
+		},
+		{
+			ContactUUID:  "60d5c8bf-16c8-4dcb-9cda-11a19e3d1c95",
+			MsgUUID:      "0199df10-10dc-7e6e-834b-3d959ece93b2",
+			MsgStatus:    models.MsgStatusFailed,
+			FailedReason: "E",
+			OrgID:        1,
+			CreatedOn:    time.Date(2025, 11, 10, 16, 15, 0, 0, time.UTC),
+		},
+	}
+
+	// no changes is a no-op
+	require.NoError(t, models.PublishStatusChanges(ctx, rt, nil))
+
+	// no sockets subscribed yet, so nothing is published
+	require.NoError(t, models.PublishStatusChanges(ctx, rt, changes))
+	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, contact1Socket))
+	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, contact2Socket))
+
+	// mark contact 1's socket subscribed (as the authorizing service would)
+	_, err := vc.Do("SET", "socket-subs:"+contact1Socket, "1")
+	require.NoError(t, err)
+
+	// now only contact 1's change is published
+	require.NoError(t, models.PublishStatusChanges(ctx, rt, changes))
+
+	sent := testsuite.CentrifugoHistory(t, rt, contact1Socket)
+	require.Len(t, sent, 1)
+	assert.Empty(t, testsuite.CentrifugoHistory(t, rt, contact2Socket))
+
+	// event matches the JSON of goflow's msg_status_changed event
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(sent[0], &decoded))
+	assert.True(t, uuids.Is(decoded["uuid"].(string)))
+	assert.Equal(t, "msg_status_changed", decoded["type"])
+	assert.Equal(t, "2025-11-10T16:14:30.123456789Z", decoded["created_on"])
+	assert.Equal(t, "0199df0f-9f82-7689-b02d-f34105991321", decoded["msg_uuid"])
+	assert.Equal(t, "delivered", decoded["status"])
+	assert.NotContains(t, decoded, "reason") // omitted when there isn't one
+
+	// mark contact 2's socket subscribed as well and both changes are published
+	_, err = vc.Do("SET", "socket-subs:"+contact2Socket, "1")
+	require.NoError(t, err)
+
+	require.NoError(t, models.PublishStatusChanges(ctx, rt, changes))
+
+	assert.Len(t, testsuite.CentrifugoHistory(t, rt, contact1Socket), 2)
+
+	sent = testsuite.CentrifugoHistory(t, rt, contact2Socket)
+	require.Len(t, sent, 1)
+	require.NoError(t, json.Unmarshal(sent[0], &decoded))
+	assert.Equal(t, "msg_status_changed", decoded["type"])
+	assert.Equal(t, "0199df10-10dc-7e6e-834b-3d959ece93b2", decoded["msg_uuid"])
+	assert.Equal(t, "failed", decoded["status"])
+	assert.Equal(t, "error_limit", decoded["reason"])
+}

--- a/core/models/status.go
+++ b/core/models/status.go
@@ -98,20 +98,52 @@ func (s *StatusChange) DynamoKey() dynamo.Key {
 func (s *StatusChange) MarshalDynamo() (*dynamo.Item, error) {
 	data := map[string]any{
 		"created_on": s.CreatedOn,
-		"status":     dynamoStatuses[s.MsgStatus],
+		"status":     statusNames[s.MsgStatus],
 	}
-	if s.MsgStatus == MsgStatusFailed && s.FailedReason == "E" {
-		data["reason"] = "error_limit"
+	if reason := s.reason(); reason != "" {
+		data["reason"] = reason
 	}
 
 	return &dynamo.Item{Key: s.DynamoKey(), OrgID: int(s.OrgID), Data: data}, nil
 }
 
-var dynamoStatuses = map[MsgStatus]string{
+// the client facing names of the statuses, as used in both history items and published events
+var statusNames = map[MsgStatus]string{
 	MsgStatusWired:     "wired",
 	MsgStatusSent:      "sent",
 	MsgStatusDelivered: "delivered",
 	MsgStatusRead:      "read",
 	MsgStatusErrored:   "errored",
 	MsgStatusFailed:    "failed",
+}
+
+// the client facing reason for this change, or "" if there isn't one
+func (s *StatusChange) reason() string {
+	if s.MsgStatus == MsgStatusFailed && s.FailedReason == "E" {
+		return "error_limit"
+	}
+	return ""
+}
+
+// msgStatusChangedEvent matches the JSON of goflow's msg_status_changed event - we don't import goflow so this has
+// to be kept in sync manually, but the shape is pinned by tests
+type msgStatusChangedEvent struct {
+	UUID      uuids.UUID `json:"uuid"`
+	Type      string     `json:"type"`
+	CreatedOn time.Time  `json:"created_on"`
+	MsgUUID   MsgUUID    `json:"msg_uuid"`
+	Status    string     `json:"status"`
+	Reason    string     `json:"reason,omitempty"`
+}
+
+// historyEvent renders this change as the msg_status_changed event published to the contact's history socket
+func (s *StatusChange) historyEvent() *msgStatusChangedEvent {
+	return &msgStatusChangedEvent{
+		UUID:      uuids.NewV7(),
+		Type:      "msg_status_changed",
+		CreatedOn: s.CreatedOn,
+		MsgUUID:   s.MsgUUID,
+		Status:    statusNames[s.MsgStatus],
+		Reason:    s.reason(),
+	}
 }


### PR DESCRIPTION
When an outgoing message's status changes, courier now publishes a `msg_status_changed` event to the contact's history socket (`history:<contact-uuid>`) via Centrifugo, so live chat views see delivery/read status updates in realtime — the same realtime path mailroom uses for engine events.

## What changed

- New `core/models/socket.go` with the socket addressing and subscriber-presence helpers (`HistorySocket`, `SubscribedSockets`) mirroring mailroom's, plus `PublishStatusChanges` which publishes each change as a `msg_status_changed` event using the shared gocommon `centrifugo` client.
- `StatusChange` in `core/models/status.go` now renders itself as that event. The event struct is a small local copy of [goflow's `msg_status_changed`](https://github.com/nyaruka/goflow/blob/main/flows/events/msg_status_changed.go) JSON shape — deliberately not importing goflow for one 6-field struct; the wire format is pinned by tests, following the same precedent as the DynamoDB status overlay items. The status name / failure reason derivation is now shared between the Dynamo item and the event.
- `writeStatusUpdatesToDB` publishes after the DB write, best-effort: a publish failure is logged and never fails or spools the status write.

## Notes for review

- Publishing is a no-op for contacts nobody is watching: the batch's sockets are resolved with a single `MGET` on the `socket-subs:*` presence keys (written by the subscribe-authorizing service), and all events for subscribed sockets go out as one batched publish request. Since statuses are already written in batches (up to 1000 / 500ms), the steady-state cost is one Valkey round-trip per batch.
- All statuses that get a history overlay are published (wired/sent/delivered/read/errored/failed), with `reason: error_limit` on failures from the retry limit — identical mapping to the Dynamo items, so live view matches what a reload would show.
- Tests assert against the Centrifugo mock; no real server needed.