### PR TITLE
Change default spool dir to ./_spool

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -66,7 +66,7 @@ func NewDefaultConfig() *Config {
 	return &Config{
 		DB:       "postgres://temba:temba@postgres/temba?sslmode=disable",
 		Valkey:   "valkey://valkey:6379/15",
-		SpoolDir: "/var/spool/courier",
+		SpoolDir: "./_spool",
 
 		Domain:          "localhost",
 		PublicAddress:   "",


### PR DESCRIPTION
Changes the default `SpoolDir` from `/var/spool/courier` to `./_spool` for consistency with mailroom. Deployments that set `COURIER_SPOOL_DIR` explicitly are unaffected, and `/_spool` is already gitignored.