### PR TITLE
Fail startup if spool directories aren't writable

### DIFF
--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -172,19 +172,14 @@ func (b *backend) Start() error {
 	}, time.Minute)
 	b.channelsByAddr.Start()
 
-	// make sure our spool dirs are writable
-	err = courier.EnsureSpoolDirPresent(b.rt.Config.SpoolDir, "msgs")
-	if err == nil {
-		err = courier.EnsureSpoolDirPresent(b.rt.Config.SpoolDir, "statuses")
+	// make sure our spool dirs are writable - fail hard so a misconfigured spool volume can't
+	// silently drop msgs and statuses spooled during database outages
+	for _, subdir := range []string{"msgs", "statuses", "events"} {
+		if err := courier.EnsureSpoolDirPresent(b.rt.Config.SpoolDir, subdir); err != nil {
+			return err
+		}
 	}
-	if err == nil {
-		err = courier.EnsureSpoolDirPresent(b.rt.Config.SpoolDir, "events")
-	}
-	if err != nil {
-		log.Error("spool directories not writable", "error", err)
-	} else {
-		log.Info("spool directories ok")
-	}
+	log.Info("spool directories ok")
 
 	// create our batched writers and start them
 	b.statusWriter = NewStatusWriter(b, b.rt.Config.SpoolDir)

--- a/spool.go
+++ b/spool.go
@@ -68,12 +68,22 @@ func startSpoolFlushers(s *Server) {
 }
 
 // EnsureSpoolDirPresent checks that the passed in spool directory is present and writable
-func EnsureSpoolDirPresent(spoolDir string, subdir string) (err error) {
-	msgsDir := path.Join(spoolDir, subdir)
-	if _, err = os.Stat(msgsDir); os.IsNotExist(err) {
-		err = os.MkdirAll(msgsDir, 0770)
+func EnsureSpoolDirPresent(spoolDir string, subdir string) error {
+	dir := path.Join(spoolDir, subdir)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, 0770); err != nil {
+			return err
+		}
 	}
-	return err
+
+	// creating the directory isn't enough - it can exist but be unwritable, e.g. a read-only mount,
+	// so probe with an actual write (flushers ignore non-json files so a leftover probe is harmless)
+	probe, err := os.CreateTemp(dir, ".probe-*")
+	if err != nil {
+		return fmt.Errorf("spool directory %s not writable: %w", dir, err)
+	}
+	probe.Close()
+	return os.Remove(probe.Name())
 }
 
 // creates a new spool flusher

--- a/spool_test.go
+++ b/spool_test.go
@@ -1,0 +1,29 @@
+package courier_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nyaruka/courier/v26"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureSpoolDirPresent(t *testing.T) {
+	spoolDir := t.TempDir()
+
+	// creates the subdir if it doesn't exist
+	assert.NoError(t, courier.EnsureSpoolDirPresent(spoolDir, "msgs"))
+	info, err := os.Stat(filepath.Join(spoolDir, "msgs"))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	// ok with a subdir that already exists
+	assert.NoError(t, courier.EnsureSpoolDirPresent(spoolDir, "msgs"))
+
+	// errors if the path exists but can't be written to (a file rather than a directory here, since
+	// permission based cases don't apply when running tests as root)
+	require.NoError(t, os.WriteFile(filepath.Join(spoolDir, "statuses"), []byte("!"), 0640))
+	assert.Error(t, courier.EnsureSpoolDirPresent(spoolDir, "statuses"))
+}


### PR DESCRIPTION
Previously an unwritable spool directory was only logged at startup, and spool writes would then fail silently at the worst possible time (during a database outage, which is when spooling happens). Now:

- `EnsureSpoolDirPresent` probes writability with an actual temp-file write after ensuring the directory exists, catching existing-but-unwritable paths such as read-only mounts. Leftover probe files are harmless as flushers ignore non-`.json` files.
- The backend returns the error from startup instead of logging and continuing, so the process exits non-zero.