### PR TITLE
Rename Public* server config to Internet*, default internal address to all interfaces

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -21,9 +21,9 @@ type Config struct {
 	SentryDSN string `help:"the DSN used for logging errors to Sentry"`
 
 	Domain          string `help:"the domain courier is exposed on"`
-	PublicAddress   string `help:"the network interface address our public web server will bind to"`
+	PublicAddress   string `help:"the address our public web server will bind to, empty means all interfaces"`
 	PublicPort      int    `help:"the port our public web server will listen on"`
-	InternalAddress string `help:"the network interface address our internal web server will bind to"`
+	InternalAddress string `help:"the address our internal web server will bind to, empty means all interfaces"`
 	InternalPort    int    `help:"the port our internal web server will listen on"`
 
 	MetricsReporting    string `validate:"eq=off|eq=basic|eq=advanced"     help:"the level of metrics reporting"`
@@ -71,7 +71,7 @@ func NewDefaultConfig() *Config {
 		Domain:          "localhost",
 		PublicAddress:   "",
 		PublicPort:      8080,
-		InternalAddress: "localhost",
+		InternalAddress: "",
 		InternalPort:    8081,
 
 		MetricsReporting:    "off",

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -21,8 +21,8 @@ type Config struct {
 	SentryDSN string `help:"the DSN used for logging errors to Sentry"`
 
 	Domain          string `help:"the domain courier is exposed on"`
-	PublicAddress   string `help:"the address our public web server will bind to, empty means all interfaces"`
-	PublicPort      int    `help:"the port our public web server will listen on"`
+	InternetAddress string `help:"the address our internet facing web server will bind to, empty means all interfaces"`
+	InternetPort    int    `help:"the port our internet facing web server will listen on"`
 	InternalAddress string `help:"the address our internal web server will bind to, empty means all interfaces"`
 	InternalPort    int    `help:"the port our internal web server will listen on"`
 
@@ -69,8 +69,8 @@ func NewDefaultConfig() *Config {
 		SpoolDir: "./_spool",
 
 		Domain:          "localhost",
-		PublicAddress:   "",
-		PublicPort:      8080,
+		InternetAddress: "",
+		InternetPort:    8080,
 		InternalAddress: "",
 		InternalPort:    8081,
 

--- a/server.go
+++ b/server.go
@@ -72,7 +72,7 @@ func (s *Server) Start() error {
 	// bind both listener sockets up front so callers know we're accepting connections by the
 	// time Start returns, and so a bind failure fails fast before we've started the backend,
 	// spool flushers, or anything else that would need to be unwound
-	internetAddr := fmt.Sprintf("%s:%d", s.rt.Config.PublicAddress, s.rt.Config.PublicPort)
+	internetAddr := fmt.Sprintf("%s:%d", s.rt.Config.InternetAddress, s.rt.Config.InternetPort)
 	internetLn, err := net.Listen("tcp", internetAddr)
 	if err != nil {
 		return fmt.Errorf("error binding internet listener on %s: %w", internetAddr, err)

--- a/server_test.go
+++ b/server_test.go
@@ -26,7 +26,7 @@ func testConfig() *runtime.Config {
 	cfg := runtime.NewDefaultConfig()
 	cfg.DB = "postgres://courier_test:temba@postgres:5432/courier_test?sslmode=disable"
 	cfg.Valkey = "valkey://valkey:6379/0"
-	cfg.PublicPort = 8180
+	cfg.InternetPort = 8180
 	cfg.InternalPort = 8181
 	return cfg
 }
@@ -179,7 +179,7 @@ func TestFetchAttachment(t *testing.T) {
 
 	cfg := runtime.NewDefaultConfig()
 	cfg.AuthToken = "sesame"
-	cfg.PublicPort = 8180
+	cfg.InternetPort = 8180
 	cfg.InternalPort = 8181
 
 	mb := test.NewMockBackend()


### PR DESCRIPTION
* Renames the `PublicAddress`/`PublicPort` config fields to `InternetAddress`/`InternetPort` (env vars `COURIER_INTERNET_ADDRESS`/`COURIER_INTERNET_PORT`), matching the naming already used inside `Server.Start`.
* Changes the `InternalAddress` default from `localhost` to `""` (all interfaces), matching the internet server. Operators who want either server bound more narrowly can still set the address explicitly.