### PR TITLE
Publish instance level metrics without a Host dimension and remove InstanceID config setting

### DIFF
--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -660,15 +660,16 @@ func (b *backend) reportMetrics(ctx context.Context) (int, error) {
 	b.dbWaitDuration = dbStats.WaitDuration
 	b.redisWaitDuration = redisStats.WaitDuration
 
-	hostDim := cwatch.Dimension("Host", b.rt.Config.InstanceID)
+	// instance level metrics are published without an instance dimension so that instances (which come and go with
+	// deploys) are just samples of the same metric, and can be aggregated with statistics like Max and Sum
 	metrics = append(metrics,
-		cwatch.Datum("DBConnectionsInUse", float64(dbStats.InUse), cwtypes.StandardUnitCount, hostDim),
-		cwatch.Datum("DBConnectionWaitDuration", float64(dbWaitDurationInPeriod)/float64(time.Second), cwtypes.StandardUnitSeconds, hostDim),
-		cwatch.Datum("ValkeyConnectionsInUse", float64(redisStats.ActiveCount), cwtypes.StandardUnitCount, hostDim),
-		cwatch.Datum("ValkeyConnectionsWaitDuration", float64(redisWaitDurationInPeriod)/float64(time.Second), cwtypes.StandardUnitSeconds, hostDim),
+		cwatch.Datum("DBConnectionsInUse", float64(dbStats.InUse), cwtypes.StandardUnitCount),
+		cwatch.Datum("DBConnectionWaitDuration", float64(dbWaitDurationInPeriod)/float64(time.Second), cwtypes.StandardUnitSeconds),
+		cwatch.Datum("ValkeyConnectionsInUse", float64(redisStats.ActiveCount), cwtypes.StandardUnitCount),
+		cwatch.Datum("ValkeyConnectionsWaitDuration", float64(redisWaitDurationInPeriod)/float64(time.Second), cwtypes.StandardUnitSeconds),
 		cwatch.Datum("QueuedMsgs", float64(bulkSize), cwtypes.StandardUnitCount, cwatch.Dimension("QueueName", "bulk")),
 		cwatch.Datum("QueuedMsgs", float64(prioritySize), cwtypes.StandardUnitCount, cwatch.Dimension("QueueName", "priority")),
-		cwatch.Datum("DynamoSpooledItems", float64(b.rt.Spool.Size()), cwtypes.StandardUnitCount, hostDim),
+		cwatch.Datum("DynamoSpooledItems", float64(b.rt.Spool.Size()), cwtypes.StandardUnitCount),
 	)
 
 	if err := b.rt.CW.Send(ctx, metrics...); err != nil {

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -26,7 +26,7 @@ func Service(version, date string) error {
 
 	// if we have a DSN entry, try to initialize it
 	if cfg.SentryDSN != "" {
-		err := sentry.Init(sentry.ClientOptions{Dsn: cfg.SentryDSN, ServerName: cfg.InstanceID, Release: version, AttachStacktrace: true})
+		err := sentry.Init(sentry.ClientOptions{Dsn: cfg.SentryDSN, Release: version, AttachStacktrace: true})
 		if err != nil {
 			return err
 		}

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net"
 	"net/url"
-	"os"
 
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/ezconf"
@@ -29,7 +28,6 @@ type Config struct {
 	MetricsReporting    string `validate:"eq=off|eq=basic|eq=advanced"     help:"the level of metrics reporting"`
 	CloudwatchNamespace string `help:"the namespace to use for cloudwatch metrics"`
 	DeploymentID        string `help:"the deployment identifier to use for metrics"`
-	InstanceID          string `help:"the instance identifier to use for metrics"`
 
 	DynamoEndpoint    string `help:"DynamoDB service endpoint, e.g. https://dynamodb.us-east-1.amazonaws.com"`
 	DynamoTablePrefix string `help:"prefix to use for DynamoDB tables"`
@@ -62,7 +60,6 @@ type Config struct {
 
 // NewDefaultConfig returns a new default configuration object
 func NewDefaultConfig() *Config {
-	hostname, _ := os.Hostname()
 	return &Config{
 		DB:       "postgres://temba:temba@postgres/temba?sslmode=disable",
 		Valkey:   "valkey://valkey:6379/15",
@@ -77,7 +74,6 @@ func NewDefaultConfig() *Config {
 		MetricsReporting:    "off",
 		CloudwatchNamespace: "Courier",
 		DeploymentID:        "dev",
-		InstanceID:          hostname,
 
 		DynamoEndpoint:    "", // let library generate it
 		DynamoTablePrefix: "Temba",


### PR DESCRIPTION
Drops the `Host` dimension from the instance-level metrics (`DBConnectionsInUse`, `DBConnectionWaitDuration`, `ValkeyConnectionsInUse`, `ValkeyConnectionsWaitDuration`, `DynamoSpooledItems`).

In container environments instances are replaced on every deploy, so per-instance metric streams churn constantly — any alarm or dashboard bound to a specific `Host` value breaks, and dead streams accumulate. Without the dimension, each instance's minutely report becomes a sample of one shared metric per deployment, and standard statistics recover the useful views: `Max` for worst-instance pool saturation, `Sum` for fleet-wide wait time or total spooled items, and `SampleCount` as a bonus count of live reporting instances.

Note for operators: the un-dimensioned metrics are new streams, so alarms on the old `Host`-dimensioned metrics (e.g. on `DynamoSpooledItems`) should be recreated against the new ones.

Since this removed `InstanceID`'s last real consumer, the config setting is also removed — its only other use was Sentry's `ServerName`, which the SDK already defaults to the hostname.