### PR TITLE
Support WhatsApp BSUIDs as whatsapp URNs alongside phone numbers

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -985,6 +985,25 @@ func (ts *BackendTestSuite) TestContactForMsg() {
 	ts.NoError(err)
 	ts.False(matchedByBSUID.IsNew_)
 	ts.Equal(c1.ID_, matchedByBSUID.ID_)
+
+	// BSUID already owned by one contact while the phone belongs to a different contact: the message resolves to
+	// the BSUID owner (matched BSUID-first) and the phone contact is left untouched
+	bsuidOwner, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, "whatsapp:US.7777", nil, "", true, clog)
+	ts.NoError(err)
+	phoneOwner, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, "whatsapp:12065557777", nil, "", true, clog)
+	ts.NoError(err)
+	ts.NotEqual(bsuidOwner.ID_, phoneOwner.ID_)
+
+	resolved, err := contactForMsg(ctx, ts.b, newBSUIDMsg("whatsapp:US.7777", "whatsapp:12065557777"), clog)
+	ts.NoError(err)
+	ts.Equal(bsuidOwner.ID_, resolved.ID_)                       // resolved to the BSUID owner, not duplicated
+	ts.Equal(phoneOwner.ID_, lookup("whatsapp:12065557777").ID_) // phone stayed on its original contact
+
+	// addContactURN must not steal a URN that already belongs to another contact - it rolls back and reports moved
+	moved, err := addContactURN(ctx, ts.b, waChannel, phoneOwner, "whatsapp:US.7777", nil)
+	ts.NoError(err)
+	ts.True(moved)
+	ts.Equal(bsuidOwner.ID_, lookup("whatsapp:US.7777").ID_) // BSUID still owned by its original contact
 }
 
 func (ts *BackendTestSuite) TestWriteMsg() {

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -979,6 +979,9 @@ func (ts *BackendTestSuite) TestContactForMsg() {
 	ts.False(matched.IsNew_)
 	ts.Equal(existingByPhone.ID_, matched.ID_)
 	ts.Equal(existingByPhone.ID_, lookup("whatsapp:US.5555").ID_) // BSUID now resolves to the same contact
+	// the matched whatsapp phone URN was flipped to a tel URN in place
+	ts.Nil(lookup("whatsapp:12065559999"))                        // whatsapp phone URN no longer exists
+	ts.Equal(existingByPhone.ID_, lookup("tel:+12065559999").ID_) // now stored as a tel URN on the same contact
 
 	// existing contact already known by the BSUID: matched directly
 	matchedByBSUID, err := contactForMsg(ctx, ts.b, newBSUIDMsg("whatsapp:US.9876", "whatsapp:12065551234"), clog)
@@ -1004,6 +1007,20 @@ func (ts *BackendTestSuite) TestContactForMsg() {
 	ts.NoError(err)
 	ts.True(moved)
 	ts.Equal(bsuidOwner.ID_, lookup("whatsapp:US.7777").ID_) // BSUID still owned by its original contact
+
+	// the equivalent tel URN already belongs to a different contact: don't steal it, so the matched whatsapp phone
+	// URN is left as-is rather than flipped
+	telOwner, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, "tel:+12065558888", nil, "", true, clog)
+	ts.NoError(err)
+	waPhoneOwner, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, "whatsapp:12065558888", nil, "", true, clog)
+	ts.NoError(err)
+	ts.NotEqual(telOwner.ID_, waPhoneOwner.ID_)
+
+	notFlipped, err := contactForMsg(ctx, ts.b, newBSUIDMsg("whatsapp:US.8888", "whatsapp:12065558888"), clog)
+	ts.NoError(err)
+	ts.Equal(waPhoneOwner.ID_, notFlipped.ID_)                     // matched by the whatsapp phone URN
+	ts.Equal(waPhoneOwner.ID_, lookup("whatsapp:12065558888").ID_) // whatsapp phone URN was NOT flipped
+	ts.Equal(telOwner.ID_, lookup("tel:+12065558888").ID_)         // tel URN still on its original contact
 }
 
 func (ts *BackendTestSuite) TestWriteMsg() {

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -945,6 +945,48 @@ func (ts *BackendTestSuite) TestSaveAttachment() {
 	ts.Equal("http://localstack:4566/test-attachments/attachments/1/c00e/5d67/c00e5d67-c275-4389-aded-7d8b151cbd5b.jpg", newURL)
 }
 
+func (ts *BackendTestSuite) TestContactForMsg() {
+	ctx := context.Background()
+	waChannel := ts.getChannel("WAC", "dbc126ed-66bc-4e28-b67b-81dc33277a17")
+	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, waChannel, nil)
+
+	// an incoming WhatsApp message with a business-scoped user ID is keyed on the BSUID (primary URN) with the
+	// phone number attached as its new URN
+	newBSUIDMsg := func(bsuid, phone urns.URN) *MsgIn {
+		m := ts.b.NewIncomingMsg(ctx, waChannel, bsuid, "hi", "", clog).(*MsgIn)
+		m.WithNewURN(phone, models.NewURNAppend)
+		return m
+	}
+	lookup := func(urn urns.URN) *models.Contact {
+		c, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, urn, nil, "", false, clog)
+		ts.NoError(err)
+		return c
+	}
+
+	// no existing contact: a message with a BSUID and phone creates one keyed on the BSUID
+	c1, err := contactForMsg(ctx, ts.b, newBSUIDMsg("whatsapp:US.9876", "whatsapp:12065551234"), clog)
+	ts.NoError(err)
+	ts.True(c1.IsNew_)
+	ts.Equal(c1.ID_, lookup("whatsapp:US.9876").ID_)
+
+	// existing contact known only by its all-digit whatsapp URN: a new BSUID is matched to it (not duplicated)
+	// and the BSUID is added to it
+	existingByPhone, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, "whatsapp:12065559999", nil, "", true, clog)
+	ts.NoError(err)
+
+	matched, err := contactForMsg(ctx, ts.b, newBSUIDMsg("whatsapp:US.5555", "whatsapp:12065559999"), clog)
+	ts.NoError(err)
+	ts.False(matched.IsNew_)
+	ts.Equal(existingByPhone.ID_, matched.ID_)
+	ts.Equal(existingByPhone.ID_, lookup("whatsapp:US.5555").ID_) // BSUID now resolves to the same contact
+
+	// existing contact already known by the BSUID: matched directly
+	matchedByBSUID, err := contactForMsg(ctx, ts.b, newBSUIDMsg("whatsapp:US.9876", "whatsapp:12065551234"), clog)
+	ts.NoError(err)
+	ts.False(matchedByBSUID.IsNew_)
+	ts.Equal(c1.ID_, matchedByBSUID.ID_)
+}
+
 func (ts *BackendTestSuite) TestWriteMsg() {
 	ctx := context.Background()
 	knChannel := ts.getChannel("KN", "dbc126ed-66bc-4e28-b67b-81dc3327c95d")

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -214,12 +213,9 @@ func contactForMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.Chan
 // match one. For a WhatsApp business-scoped user ID (a whatsapp URN in the CC.xxx form) with a phone number
 // attached as its new URN, that's the phone number's (all-digit) whatsapp URN.
 func altLookupURNs(m *MsgIn) []urns.URN {
-	if m.NewURN_ == nil || m.URN_.Scheme() != urns.WhatsApp.Prefix {
-		return nil
-	}
-
-	// only business-scoped user IDs (which contain a "."), not all-digit whatsapp phone numbers
-	if !strings.Contains(m.URN_.Path(), ".") {
+	// only when the primary URN is a whatsapp business-scoped user ID (not an all-digit phone number) with a
+	// phone number attached as its new URN
+	if m.NewURN_ == nil || !urns.IsWhatsAppBSUID(m.URN_) {
 		return nil
 	}
 

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -193,8 +193,14 @@ func contactForMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.Chan
 		if contact != nil {
 			// matched an existing contact by the phone number - add the BSUID to it so the message stays
 			// attributed to the BSUID
-			if err := addContactURN(ctx, b, m.channel, contact, m.URN_, m.URNAuthTokens_); err != nil {
+			moved, err := addContactURN(ctx, b, m.channel, contact, m.URN_, m.URNAuthTokens_)
+			if err != nil {
 				return nil, err
+			}
+			// between our BSUID lookup above and now, the BSUID was claimed by another contact - don't steal
+			// it, re-look-up the BSUID and return the contact that already owns it
+			if moved {
+				return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
 			}
 			return contact, nil
 		}
@@ -221,23 +227,31 @@ func altLookupURNs(m *MsgIn) []urns.URN {
 }
 
 // addContactURN adds the given URN to the contact (if not already present) and points the contact's URNID at it,
-// so the incoming message is attributed to this URN.
-func addContactURN(ctx context.Context, b *backend, channel *models.Channel, contact *models.Contact, urn urns.URN, authTokens map[string]string) error {
+// so the incoming message is attributed to this URN. If the URN already belonged to a different contact, it
+// returns moved=true without stealing it (the transaction is rolled back), leaving it on its current owner.
+func addContactURN(ctx context.Context, b *backend, channel *models.Channel, contact *models.Contact, urn urns.URN, authTokens map[string]string) (moved bool, err error) {
 	tx, err := b.rt.DB.BeginTxx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("error beginning transaction: %w", err)
+		return false, fmt.Errorf("error beginning transaction: %w", err)
 	}
 
 	contactURN, err := models.GetOrCreateContactURN(ctx, tx, channel, contact.ID_, urn, authTokens)
 	if err != nil {
 		tx.Rollback()
-		return fmt.Errorf("error adding URN to contact: %w", err)
+		return false, fmt.Errorf("error adding URN to contact: %w", err)
+	}
+
+	// GetOrCreateContactURN will have re-pointed the URN from its previous owner to us - we don't want to steal
+	// it, so roll back and let the caller re-look-up the contact that already owns it
+	if contactURN.PrevContactID != models.NilContactID {
+		tx.Rollback()
+		return true, nil
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("error committing transaction: %w", err)
+		return false, fmt.Errorf("error committing transaction: %w", err)
 	}
 
 	contact.URNID_ = contactURN.ID
-	return nil
+	return false, nil
 }

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -201,6 +201,10 @@ func contactForMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.Chan
 			if moved {
 				return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
 			}
+			// migrate the matched whatsapp phone URN onto the tel scheme so the phone number is stored as a tel URN
+			if err := flipWhatsAppPhoneToTel(ctx, b, m.OrgID_, alt); err != nil {
+				return nil, err
+			}
 			return contact, nil
 		}
 	}
@@ -250,4 +254,53 @@ func addContactURN(ctx context.Context, b *backend, channel *models.Channel, con
 
 	contact.URNID_ = contactURN.ID
 	return false, nil
+}
+
+// flipWhatsAppPhoneToTel migrates a WhatsApp phone URN (an all-digit whatsapp URN) onto the equivalent tel URN, in
+// place, so a phone number that predates BSUIDs and was stored as a whatsapp URN is moved onto the tel scheme once we
+// resolve a contact by it. It's a no-op if the URN isn't a whatsapp phone number or can't be parsed as one, or if the
+// equivalent tel URN already exists (on this or any other contact) - we don't steal or duplicate it, so the guard
+// covers the "no other matching tel URN on a different contact" case (and, conservatively, the same-contact case too).
+func flipWhatsAppPhoneToTel(ctx context.Context, b *backend, orgID models.OrgID, phoneURN urns.URN) error {
+	if phoneURN.Scheme() != urns.WhatsApp.Prefix || urns.IsWhatsAppBSUID(phoneURN) {
+		return nil
+	}
+
+	telURN, err := urns.ParsePhone("+"+phoneURN.Path(), "", false, false)
+	if err != nil {
+		return nil // not a parseable phone number, leave it on the whatsapp scheme
+	}
+
+	tx, err := b.rt.DB.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("error beginning transaction: %w", err)
+	}
+
+	// if the tel URN already exists (on any contact), don't steal or duplicate it - leave the whatsapp URN as-is
+	_, err = models.GetContactURNByIdentity(ctx, tx, orgID, telURN)
+	if err == nil {
+		tx.Rollback()
+		return nil
+	}
+	if err != sql.ErrNoRows {
+		tx.Rollback()
+		return fmt.Errorf("error looking up tel URN: %w", err)
+	}
+
+	// load the whatsapp phone URN we just matched and rewrite it in place onto the tel scheme
+	waURN, err := models.GetContactURNByIdentity(ctx, tx, orgID, phoneURN)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("error getting whatsapp phone URN: %w", err)
+	}
+	waURN.Identity = string(telURN.Identity())
+	waURN.Scheme = telURN.Scheme()
+	waURN.Path = telURN.Path()
+
+	if err := models.UpdateContactURNFully(ctx, tx, waURN); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("error flipping whatsapp phone URN to tel: %w", err)
+	}
+
+	return tx.Commit()
 }

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -158,4 +159,85 @@ func contactForURN(ctx context.Context, b *backend, org models.OrgID, channel *m
 	b.stats.RecordContactCreated()
 
 	return contact, nil
+}
+
+// contactForMsg resolves the contact for an incoming message. It normally looks the contact up by (or creates it
+// from) the message's primary URN. But when a WhatsApp message arrives with a business-scoped user ID as its
+// primary URN and a phone number attached as its new URN, we also look for an existing contact by that phone
+// number's whatsapp URN - so a contact which predates the BSUID (and is only known by its all-digit whatsapp URN)
+// is reused rather than duplicated. In that case the BSUID is added to the matched contact so it stays the
+// message's (highest priority) URN.
+func contactForMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLog) (*models.Contact, error) {
+	altURNs := altLookupURNs(m)
+
+	// simple case: no alternative URNs to consider, look up or create by the primary URN
+	if len(altURNs) == 0 {
+		return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+	}
+
+	// try the primary URN first (the whatsapp BSUID), without creating a contact
+	contact, err := contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, false, clog)
+	if err != nil {
+		return nil, err
+	}
+	if contact != nil {
+		return contact, nil
+	}
+
+	// the BSUID didn't match an existing contact, try the alternatives (the phone number's whatsapp URN)
+	for _, alt := range altURNs {
+		contact, err = contactForURN(ctx, b, m.OrgID_, m.channel, alt, nil, "", false, clog)
+		if err != nil {
+			return nil, err
+		}
+		if contact != nil {
+			// matched an existing contact by the phone number - add the BSUID to it so the message stays
+			// attributed to the BSUID
+			if err := addContactURN(ctx, b, m.channel, contact, m.URN_, m.URNAuthTokens_); err != nil {
+				return nil, err
+			}
+			return contact, nil
+		}
+	}
+
+	// no existing contact matched any URN, create one from the primary URN
+	return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+}
+
+// altLookupURNs returns alternative URNs to look up an existing contact by when the message's primary URN doesn't
+// match one. For a WhatsApp business-scoped user ID (a whatsapp URN in the CC.xxx form) with a phone number
+// attached as its new URN, that's the phone number's (all-digit) whatsapp URN.
+func altLookupURNs(m *MsgIn) []urns.URN {
+	if m.NewURN_ == nil || m.URN_.Scheme() != urns.WhatsApp.Prefix {
+		return nil
+	}
+
+	// only business-scoped user IDs (which contain a "."), not all-digit whatsapp phone numbers
+	if !strings.Contains(m.URN_.Path(), ".") {
+		return nil
+	}
+
+	return []urns.URN{m.NewURN_.Value}
+}
+
+// addContactURN adds the given URN to the contact (if not already present) and points the contact's URNID at it,
+// so the incoming message is attributed to this URN.
+func addContactURN(ctx context.Context, b *backend, channel *models.Channel, contact *models.Contact, urn urns.URN, authTokens map[string]string) error {
+	tx, err := b.rt.DB.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("error beginning transaction: %w", err)
+	}
+
+	contactURN, err := models.GetOrCreateContactURN(ctx, tx, channel, contact.ID_, urn, authTokens)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("error adding URN to contact: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("error committing transaction: %w", err)
+	}
+
+	contact.URNID_ = contactURN.ID
+	return nil
 }

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -118,7 +118,7 @@ func writeMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLo
 }
 
 func writeMsgToDB(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLog) (*models.Contact, error) {
-	contact, err := contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+	contact, err := contactForMsg(ctx, b, m, clog)
 
 	if err != nil {
 		// our db is down, write to the spool, we will write/queue this later

--- a/core/models/urn.go
+++ b/core/models/urn.go
@@ -204,7 +204,7 @@ UPDATE contacts_contacturn
 
 const sqlFullyUpdateURN = `
 UPDATE contacts_contacturn
-   SET channel_id = :channel_id, contact_id = :contact_id, identity = :identity, path = :path, display = :display, auth_tokens = :auth_tokens, priority = :priority
+   SET channel_id = :channel_id, contact_id = :contact_id, identity = :identity, scheme = :scheme, path = :path, display = :display, auth_tokens = :auth_tokens, priority = :priority
  WHERE id = :id`
 
 // UpdateContactURN updates the channel and contact on an existing URN
@@ -223,7 +223,7 @@ func UpdateContactURN(ctx context.Context, tx *sqlx.Tx, urn *ContactURN) error {
 	return err
 }
 
-// UpdateContactURNFully updates the identity, channel and contact on an existing URN
+// UpdateContactURNFully updates the identity, scheme, path, channel and contact on an existing URN
 func UpdateContactURNFully(ctx context.Context, tx *sqlx.Tx, urn *ContactURN) error {
 	// see https://github.com/vinovest/sqlx/issues/447
 	rows, err := tx.NamedQuery(sqlFullyUpdateURN, urn)

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -148,6 +148,20 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					}
 				}
 
+				// ExtractData gives us the phone number as a whatsapp URN; if the message also carries a
+				// business-scoped user ID, make that WhatsApp URN the primary URN and attach the phone number
+				// as a secondary URN
+				appendURN := urns.NilURN
+				if waMsg.FromUserID != "" {
+					userIDURN, urnErr := urns.New(urns.WhatsApp, waMsg.FromUserID)
+					if urnErr == nil {
+						appendURN = urn
+						urn = userIDURN
+					} else {
+						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for WhatsApp URN: %w", urnErr))
+					}
+				}
+
 				// create our message
 				event := h.Backend().NewIncomingMsg(ctx, channel, urn, text, waMsg.ID, clog).WithReceivedOn(date).WithContactName(contactNames[waMsg.From])
 
@@ -155,14 +169,8 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					event.WithAttachment(mediaURL)
 				}
 
-				// if we have a user_id, add it as secondary BSUID URN
-				if waMsg.FromUserID != "" {
-					userIDURN, urnErr := urns.New(urns.BSUID, waMsg.FromUserID)
-					if urnErr == nil {
-						event.WithNewURN(userIDURN, models.NewURNAppend)
-					} else {
-						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for BSUID URN: %w", urnErr))
-					}
+				if appendURN != urns.NilURN {
+					event.WithNewURN(appendURN, models.NewURNAppend)
 				}
 
 				err = h.Backend().WriteMsg(ctx, event, clog)
@@ -293,9 +301,9 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	// if we got a user_id in the response, set it as a new URN on the send result so the backend
 	// can queue a contact_changed task to append it to the contact
 	if userID != "" {
-		userIDURN, err := urns.New(urns.BSUID, userID)
+		userIDURN, err := urns.New(urns.WhatsApp, userID)
 		if err != nil {
-			clog.RawError(fmt.Errorf("unable to make BSUID URN from user_id %s: %w", userID, err))
+			clog.RawError(fmt.Errorf("unable to make WhatsApp URN from user_id %s: %w", userID, err))
 		} else {
 			res.SetNewURN(userIDURN)
 		}

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -59,10 +59,10 @@ var testCasesD3C = []IncomingTestCase{
 		NoQueueErrorCheck:     true,
 		NoInvalidChannelCheck: true,
 		ExpectedMsgText:       Sp("Hello World"),
-		ExpectedURN:           "whatsapp:5678",
+		ExpectedURN:           "whatsapp:US.1234",
 		ExpectedExternalID:    "external_id",
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
-		ExpectedNewURN:        &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend},
+		ExpectedNewURN:        &models.NewURNSpec{Value: "whatsapp:5678", Action: models.NewURNAppend},
 	},
 	{
 		Label:                 "Receive Duplicate Valid Message",
@@ -351,7 +351,7 @@ var SendTestCasesD3C = []OutgoingTestCase{
 	{
 		Label:   "Plain Send with BSUID",
 		MsgText: "Simple Message",
-		MsgURN:  "bsuid:US.1234",
+		MsgURN:  "whatsapp:US.1234",
 		MockResponses: map[string][]*httpx.MockResponse{
 			"https://waba-v2.360dialog.io/messages": {
 				httpx.NewMockResponse(200, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
@@ -377,14 +377,14 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 		ExpectedContactURNs: map[string]bool{
 			"whatsapp:250788123123": true,
-			"bsuid:US.1234":         true,
+			"whatsapp:US.1234":      true,
 		},
 	},
 	{
 		Label:               "Plain Send with user_id already on contact",
 		MsgText:             "Simple Message",
 		MsgURN:              "whatsapp:250788123123",
-		MsgContactOtherURNs: []urns.URN{"bsuid:US.1234"},
+		MsgContactOtherURNs: []urns.URN{"whatsapp:US.1234"},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"https://waba-v2.360dialog.io/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "contacts": [{"input": "250788123123", "user_id": "US.1234"}], "messages": [{"id": "157b5e14568e8"}] }`)),

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -292,6 +292,20 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					}
 				}
 
+				// ExtractData gives us the phone number as a whatsapp URN; if the message also carries a
+				// business-scoped user ID, make that WhatsApp URN the primary URN and attach the phone number
+				// as a secondary URN
+				appendURN := urns.NilURN
+				if waMsg.FromUserID != "" {
+					userIDURN, urnErr := urns.New(urns.WhatsApp, waMsg.FromUserID)
+					if urnErr == nil {
+						appendURN = urn
+						urn = userIDURN
+					} else {
+						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for WhatsApp URN: %w", urnErr))
+					}
+				}
+
 				// create our message
 				event := h.Backend().NewIncomingMsg(ctx, channel, urn, text, waMsg.ID, clog).WithReceivedOn(date).WithContactName(contactNames[waMsg.From])
 
@@ -299,14 +313,8 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					event.WithAttachment(mediaURL)
 				}
 
-				// if we have a user_id, add it as secondary BSUID URN
-				if waMsg.FromUserID != "" {
-					userIDURN, urnErr := urns.New(urns.BSUID, waMsg.FromUserID)
-					if urnErr == nil {
-						event.WithNewURN(userIDURN, models.NewURNAppend)
-					} else {
-						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for BSUID URN: %w", urnErr))
-					}
+				if appendURN != urns.NilURN {
+					event.WithNewURN(appendURN, models.NewURNAppend)
 				}
 
 				err = h.Backend().WriteMsg(ctx, event, clog)
@@ -724,9 +732,9 @@ func (h *handler) sendWhatsAppMsg(ctx context.Context, msg courier.MsgOut, res *
 	// if we got a user_id in the response, set it as a new URN on the send result so the backend
 	// can queue a contact_changed task to append it to the contact
 	if userID != "" {
-		userIDURN, err := urns.New(urns.BSUID, userID)
+		userIDURN, err := urns.New(urns.WhatsApp, userID)
 		if err != nil {
-			clog.RawError(fmt.Errorf("unable to make BSUID URN from user_id %s: %w", userID, err))
+			clog.RawError(fmt.Errorf("unable to make WhatsApp URN from user_id %s: %w", userID, err))
 		} else {
 			res.SetNewURN(userIDURN)
 		}

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -46,10 +46,10 @@ var whatsappIncomingTests = []IncomingTestCase{
 		NoQueueErrorCheck:     true,
 		NoInvalidChannelCheck: true,
 		ExpectedMsgText:       Sp("Hello World"),
-		ExpectedURN:           "whatsapp:5678",
+		ExpectedURN:           "whatsapp:US.1234",
 		ExpectedExternalID:    "external_id",
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
-		ExpectedNewURN:        &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend},
+		ExpectedNewURN:        &models.NewURNSpec{Value: "whatsapp:5678", Action: models.NewURNAppend},
 		PrepRequest:           addValidSignature,
 	},
 	{
@@ -329,7 +329,7 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 	{
 		Label:   "Plain Send with BSUID",
 		MsgText: "Simple Message",
-		MsgURN:  "bsuid:US.1234",
+		MsgURN:  "whatsapp:US.1234",
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/12345_ID/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
@@ -355,14 +355,14 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 		ExpectedContactURNs: map[string]bool{
 			"whatsapp:250788123123": true,
-			"bsuid:US.1234":         true,
+			"whatsapp:US.1234":      true,
 		},
 	},
 	{
 		Label:               "Plain Send with user_id already on contact",
 		MsgText:             "Simple Message",
 		MsgURN:              "whatsapp:250788123123",
-		MsgContactOtherURNs: []urns.URN{"bsuid:US.1234"},
+		MsgContactOtherURNs: []urns.URN{"whatsapp:US.1234"},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/12345_ID/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "contacts": [{"input": "250788123123", "user_id": "US.1234"}], "messages": [{"id": "157b5e14568e8"}] }`)),

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -3,6 +3,7 @@ package whatsapp
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/nyaruka/courier/v26"
@@ -20,10 +21,14 @@ func GetMsgPayloads(ctx context.Context, msg courier.MsgOut, maxMsgLength int, c
 	return buildContentPayloads(msg, maxMsgLength, clog)
 }
 
-// RecipientFields returns the to and recipient field values for the given URN, using the recipient field for
-// business-scoped user ID (BSUID) URNs and the to field otherwise.
+// allDigitsRegex matches a WhatsApp identity that is a phone number rather than a business-scoped user ID.
+var allDigitsRegex = regexp.MustCompile(`^[0-9]+$`)
+
+// RecipientFields returns the to and recipient field values for the given URN. A whatsapp URN may hold either a
+// phone number (all digits) or a business-scoped user ID (the CC.xxx form); the business-scoped user ID goes in
+// the recipient field and the phone number goes in the to field.
 func RecipientFields(urn urns.URN) (to, recipient string) {
-	if urn.Scheme() == urns.BSUID.Prefix {
+	if urn.Scheme() == urns.WhatsApp.Prefix && !allDigitsRegex.MatchString(urn.Path()) {
 		return "", urn.Path()
 	}
 	return urn.Path(), ""

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -3,7 +3,6 @@ package whatsapp
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/nyaruka/courier/v26"
@@ -21,14 +20,11 @@ func GetMsgPayloads(ctx context.Context, msg courier.MsgOut, maxMsgLength int, c
 	return buildContentPayloads(msg, maxMsgLength, clog)
 }
 
-// allDigitsRegex matches a WhatsApp identity that is a phone number rather than a business-scoped user ID.
-var allDigitsRegex = regexp.MustCompile(`^[0-9]+$`)
-
 // RecipientFields returns the to and recipient field values for the given URN. A whatsapp URN may hold either a
 // phone number (all digits) or a business-scoped user ID (the CC.xxx form); the business-scoped user ID goes in
 // the recipient field and the phone number goes in the to field.
 func RecipientFields(urn urns.URN) (to, recipient string) {
-	if urn.Scheme() == urns.WhatsApp.Prefix && !allDigitsRegex.MatchString(urn.Path()) {
+	if urns.IsWhatsAppBSUID(urn) {
 		return "", urn.Path()
 	}
 	return urn.Path(), ""

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -15,6 +15,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRecipientFields(t *testing.T) {
+	tcs := []struct {
+		urn               urns.URN
+		expectedTo        string
+		expectedRecipient string
+	}{
+		{urn: "whatsapp:250788123123", expectedTo: "250788123123", expectedRecipient: ""}, // phone number -> to
+		{urn: "whatsapp:US.1234", expectedTo: "", expectedRecipient: "US.1234"},            // business-scoped user ID -> recipient
+	}
+
+	for _, tc := range tcs {
+		to, recipient := whatsapp.RecipientFields(tc.urn)
+		assert.Equal(t, tc.expectedTo, to, "to mismatch for %s", tc.urn)
+		assert.Equal(t, tc.expectedRecipient, recipient, "recipient mismatch for %s", tc.urn)
+	}
+}
+
 func TestGetMsgPayloads(t *testing.T) {
 	ctx := context.Background()
 	maxMsgLength := 4096
@@ -297,7 +314,7 @@ func TestGetMsgPayloads(t *testing.T) {
 		{
 			label:                 "Send message by BSUID",
 			text:                  "Hello, BSUID",
-			urn:                   "bsuid:US.1234",
+			urn:                   "whatsapp:US.1234",
 			expectedPayloadsCount: 1,
 			expectedType:          "text",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
@@ -312,7 +329,7 @@ func TestGetMsgPayloads(t *testing.T) {
 			text:                  "Pick an option",
 			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "Option 1"}, {Type: "text", Text: "Option 2"}},
-			urn:                   "bsuid:US.1234",
+			urn:                   "whatsapp:US.1234",
 			expectedPayloadsCount: 1,
 			expectedType:          "interactive",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -235,6 +235,19 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 			courier.LogRequestError(r, channel, fmt.Errorf("unsupported message type %s", msg.Type))
 		}
 
+		// the phone number is a whatsapp URN; if the message also carries a business-scoped user ID, make that
+		// WhatsApp URN the primary URN and attach the phone number as a secondary URN
+		appendURN := urns.NilURN
+		if msg.FromBSUID != "" {
+			userIDURN, urnErr := urns.New(urns.WhatsApp, msg.FromBSUID)
+			if urnErr == nil {
+				appendURN = urn
+				urn = userIDURN
+			} else {
+				courier.LogRequestError(r, channel, fmt.Errorf("invalid from_bsuid for WhatsApp URN: %w", urnErr))
+			}
+		}
+
 		// create our message
 		event := h.Backend().NewIncomingMsg(ctx, channel, urn, text, msg.ID, clog).WithReceivedOn(date).WithContactName(contactNames[msg.From])
 
@@ -247,13 +260,8 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 			event.WithAttachment(mediaURL)
 		}
 
-		if msg.FromBSUID != "" {
-			userIDURN, urnErr := urns.New(urns.BSUID, msg.FromBSUID)
-			if urnErr == nil {
-				event.WithNewURN(userIDURN, models.NewURNAppend)
-			} else {
-				courier.LogRequestError(r, channel, fmt.Errorf("invalid from_bsuid for BSUID URN: %w", urnErr))
-			}
+		if appendURN != urns.NilURN {
+			event.WithNewURN(appendURN, models.NewURNAppend)
 		}
 
 		err = h.Backend().WriteMsg(ctx, event, clog)

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -360,10 +360,10 @@ var testCasesTurn = []IncomingTestCase{
 		ExpectedBodyContains:  `"type":"msg"`,
 		ExpectedContactName:   Sp("Jerry Cooney"),
 		ExpectedMsgText:       Sp("hello world"),
-		ExpectedURN:           "whatsapp:250788123123",
+		ExpectedURN:           "whatsapp:US.1234",
 		ExpectedExternalID:    "41",
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
-		ExpectedNewURN:        &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend},
+		ExpectedNewURN:        &models.NewURNSpec{Value: "whatsapp:250788123123", Action: models.NewURNAppend},
 		NoQueueErrorCheck:     true,
 		NoInvalidChannelCheck: true,
 	},
@@ -622,7 +622,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 	{
 		Label:   "Plain Send with BSUID",
 		MsgText: "Simple Message",
-		MsgURN:  "bsuid:US.1234",
+		MsgURN:  "whatsapp:US.1234",
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/v1/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -147,18 +147,26 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		text = form.ButtonText
 	}
 
-	// build our msg
-	msg := h.Backend().NewIncomingMsg(ctx, channel, urn, text, form.MessageSID, clog)
-
+	// if we have a business-scoped user ID (ExternalUserId), make that WhatsApp URN the primary URN and attach
+	// the phone number as a secondary URN
+	appendURN := urns.NilURN
 	if form.ExternalUserId != "" && channel.IsScheme(urns.WhatsApp) {
 		userIDURN, urnErr := h.parseURN(channel, form.ExternalUserId, i18n.Country(form.FromCountry))
 
 		if urnErr == nil {
-			msg.WithNewURN(userIDURN, models.NewURNAppend)
+			appendURN = urn
+			urn = userIDURN
 		} else {
 			slog.Warn("ignoring invalid ExternalUserId for message", "ExternalUserId", form.ExternalUserId, "MessageSID", form.MessageSID, "Error", urnErr.Error())
 
 		}
+	}
+
+	// build our msg
+	msg := h.Backend().NewIncomingMsg(ctx, channel, urn, text, form.MessageSID, clog)
+
+	if appendURN != urns.NilURN {
+		msg.WithNewURN(appendURN, models.NewURNAppend)
 	}
 
 	// process any attached media
@@ -467,8 +475,8 @@ func (h *handler) parseURN(channel courier.Channel, text string, country i18n.Co
 		}
 
 		if dot := strings.Index(fromTel, "."); dot >= 0 && dot < len(fromTel)-1 {
-			// if we have a BSUID, use that as the URN
-			return urns.New(urns.BSUID, fromTel)
+			// a business-scoped user ID becomes a WhatsApp URN
+			return urns.New(urns.WhatsApp, fromTel)
 		}
 
 		// trim off left +, official whatsapp IDs dont have that

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -454,7 +454,7 @@ var twaTestCases = []IncomingTestCase{
 		ExpectedMsgText: Sp("Msg"), ExpectedURN: "whatsapp:14133881111", ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",
 		PrepRequest: addValidSignature},
 	{Label: "Receive BSUID Valid", URL: twaReceiveURL, Data: waReceiveBSUIDValid, ExpectedRespStatus: 200, ExpectedBodyContains: "<Response/>",
-		ExpectedMsgText: Sp("Msg"), ExpectedURN: "whatsapp:14133881111", ExpectedNewURN: &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend}, ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",
+		ExpectedMsgText: Sp("Msg"), ExpectedURN: "whatsapp:US.1234", ExpectedNewURN: &models.NewURNSpec{Value: "whatsapp:14133881111", Action: models.NewURNAppend}, ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",
 		PrepRequest: addValidSignature},
 	{Label: "Receive Valid", URL: twaReceiveURL, Data: waReceiveButtonValid, ExpectedRespStatus: 200, ExpectedBodyContains: "<Response/>",
 		ExpectedMsgText: Sp("Confirm"), ExpectedURN: "whatsapp:14133881111", ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",

--- a/testsuite/testdata/data.sql
+++ b/testsuite/testdata/data.sql
@@ -31,6 +31,9 @@ INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modifi
 INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
                       VALUES('16', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327222a', 'EX', NULL, 1, 'US', '', '{}');
 
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
+                      VALUES('17', '{"whatsapp"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc33277a17', 'WAC', '12345', 1, NULL, 'SR', '{}');
+
 /* Contacts with ids 100, 101 */
 DELETE FROM contacts_contact;
 INSERT INTO contacts_contact("id", "is_active", "status", "created_on", "modified_on", "uuid", "language", "ticket_count", "created_by_id", "modified_by_id", "org_id")


### PR DESCRIPTION
A whatsapp URN may now hold either a phone number (all digits) or a business-scoped user ID (the CC.xxx form), so:

- sending routes the URN to the correct WhatsApp API field by content - a business-scoped user ID goes in the recipient field and a phone number in the to field (previously keyed on the separate bsuid scheme)
- receiving stores an incoming user_id/BSUID as a whatsapp URN (was the bsuid scheme), makes it the message's primary URN, and attaches the phone number as a secondary URN
- contact resolution looks up an existing contact by the whatsapp BSUID first and falls back to the phone number's all-digit whatsapp URN, reusing a contact that predates the BSUID instead of duplicating it

Applied across the meta, dialog360, turn and twiml handlers plus the rapidpro backend. Depends on the gocommon change accepting business-scoped user IDs as WhatsApp URNs; a dev-only replace directive points at it until that is released.