### PR TITLE
Exit hard if graceful shutdown exceeds 90 seconds

### DIFF
--- a/backends/rapidpro/status.go
+++ b/backends/rapidpro/status.go
@@ -53,7 +53,9 @@ type StatusWriter struct {
 func NewStatusWriter(b *backend, spoolDir string) *StatusWriter {
 	return &StatusWriter{
 		Batcher: syncx.NewBatcher(func(batch []*models.StatusUpdate) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			// keep this comfortably under the shutdown watchdog since final flushes happen during shutdown -
+			// statuses that can't be written in time will be spooled instead
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
 			b.writeStatuseUpdates(ctx, spoolDir, batch)

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -15,11 +15,12 @@ import (
 	slogsentry "github.com/samber/slog-sentry/v2"
 )
 
-// shutdownTimeout is how long we allow for a graceful shutdown before exiting hard. Nothing courier does on
-// shutdown should take long (sends are capped at 35s, everything else is faster) so if we hit this something is
+// shutdownTimeout is how long we allow for a graceful shutdown before exiting hard. The shutdown phases are
+// individually bounded (in-flight requests and the final status flush at 30s, in-flight sends at 35s) but run
+// partly in sequence, so a legitimate slow shutdown can approach ~60s. Past this budget something is genuinely
 // wedged, and it's better to exit with a record of why than be killed by the orchestrator. Orchestrator stop
 // timeouts should be set a bit above this so the watchdog fires first.
-const shutdownTimeout = 45 * time.Second
+const shutdownTimeout = 90 * time.Second
 
 // Service starts the courier service, blocks until a termination signal is received, then stops it.
 func Service(version, date string) error {

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -15,6 +15,12 @@ import (
 	slogsentry "github.com/samber/slog-sentry/v2"
 )
 
+// shutdownTimeout is how long we allow for a graceful shutdown before exiting hard. Nothing courier does on
+// shutdown should take long (sends are capped at 35s, everything else is faster) so if we hit this something is
+// wedged, and it's better to exit with a record of why than be killed by the orchestrator. Orchestrator stop
+// timeouts should be set a bit above this so the watchdog fires first.
+const shutdownTimeout = 45 * time.Second
+
 // Service starts the courier service, blocks until a termination signal is received, then stops it.
 func Service(version, date string) error {
 	cfg := runtime.LoadConfig()
@@ -59,6 +65,13 @@ func Service(version, date string) error {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	log.Info("stopping", "signal", <-ch)
+
+	watchdog := time.AfterFunc(shutdownTimeout, func() {
+		log.Error("shutdown timed out, exiting", "timeout", shutdownTimeout)
+		sentry.Flush(2 * time.Second)
+		os.Exit(1)
+	})
+	defer watchdog.Stop()
 
 	return server.Stop()
 }


### PR DESCRIPTION
Adds a shutdown watchdog: on SIGTERM/SIGINT, if `server.Stop()` hasn't completed within 90 seconds, courier logs the timeout (routed to Sentry when configured), flushes Sentry, and exits non-zero — rather than being SIGKILLed by an orchestrator with no record of why.

The shutdown phases are individually bounded — in-flight requests and the final status flush at 30s (the latter tightened here from 1 minute, with statuses that can't be written in time going to the spool as before), in-flight sends at 35s — but they run partly in sequence, so a legitimate slow shutdown can approach ~60s. The 90s budget sits above that worst case, so the watchdog only fires when something is genuinely wedged.

Orchestrator stop timeouts should be set a bit above 90s (e.g. 120s) so the watchdog fires before the external kill.