### PR TITLE
Replace unmaintained patrickmn/go-cache with gocommon's cache.Local

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/nyaruka/goflow v0.280.0
 	github.com/nyaruka/null/v3 v3.0.0
 	github.com/nyaruka/vkutil v0.21.0
-	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/samber/slog-multi v1.8.0
 	github.com/samber/slog-sentry/v2 v2.11.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,6 @@ github.com/nyaruka/phonenumbers/v2 v2.0.2 h1:8+XJFJcApk+rKNi/pbK1WeyH1p6XmLx2UNT
 github.com/nyaruka/phonenumbers/v2 v2.0.2/go.mod h1:pKu+U8m/6xzgPlYxQ9D89irpcWeB4/J7lKd3FbhQaqw=
 github.com/nyaruka/vkutil v0.21.0 h1:Vy1auqZ2slCQ1H6t/texGLv8v5DObwtwTFW7OLid9Ok=
 github.com/nyaruka/vkutil v0.21.0/go.mod h1:5dIAvwkeidExJWAJ5AAYlYN8PJ4MQrzJeFuO8wRdlAo=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -23,12 +23,12 @@ import (
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/handlers/meta/whatsapp"
 	"github.com/nyaruka/courier/v26/utils"
+	"github.com/nyaruka/gocommon/cache"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/vkutil"
-	"github.com/patrickmn/go-cache"
 )
 
 var (
@@ -37,13 +37,14 @@ var (
 	configNamespace = "fb_namespace"
 
 	mediaCacheKeyPattern = "turn_whatsapp_media_%s"
-	failedMediaCache     *cache.Cache
+	failedMediaCache     *cache.Local[string, bool]
 )
 
 func init() {
 	courier.RegisterHandler(newHandler())
 
-	failedMediaCache = cache.New(15*time.Minute, 15*time.Minute)
+	failedMediaCache = cache.NewLocal[string, bool](nil, 15*time.Minute)
+	failedMediaCache.Start()
 }
 
 type handler struct {
@@ -805,10 +806,9 @@ func (h *handler) fetchMediaID(ctx context.Context, msg courier.MsgOut, mediaURL
 
 	// check in failure cache
 	failKey := fmt.Sprintf("%s-%s", msg.Channel().UUID(), mediaURL)
-	found, _ := failedMediaCache.Get(failKey)
 
-	// any non nil value means we cached a failure, don't try again until our cache expires
-	if found != nil {
+	// if we cached a failure, don't try again until our cache expires
+	if failedMediaCache.Get(failKey) {
 		return "", nil
 	}
 
@@ -820,7 +820,7 @@ func (h *handler) fetchMediaID(ctx context.Context, msg courier.MsgOut, mediaURL
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
 	if err != nil || resp.StatusCode/100 != 2 {
-		failedMediaCache.Set(failKey, true, cache.DefaultExpiration)
+		failedMediaCache.Set(failKey, true)
 		return "", nil
 	}
 
@@ -842,7 +842,7 @@ func (h *handler) fetchMediaID(ctx context.Context, msg courier.MsgOut, mediaURL
 
 	resp, respBody, err = h.RequestHTTP(req, clog)
 	if err != nil || resp.StatusCode/100 != 2 {
-		failedMediaCache.Set(failKey, true, cache.DefaultExpiration)
+		failedMediaCache.Set(failKey, true)
 		if err != nil {
 			return "", fmt.Errorf("error uploading media to whatsapp: %w", err)
 		} else {

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -1254,9 +1254,9 @@ func TestWhatsAppOutgoing(t *testing.T) {
 		map[string]any{models.ConfigAuthToken: "a123", "base_url": "https://example.org", "fb_namespace": "waba_namespace"})
 
 	RunOutgoingTestCases(t, channel, newHandler(), defaultSendTestCases, []string{"a123"}, nil)
-	failedMediaCache.Flush()
+	failedMediaCache.Clear()
 	RunOutgoingTestCases(t, channel, newHandler(), mediaCacheSendTestCases, []string{"a123"}, nil)
-	failedMediaCache.Flush()
+	failedMediaCache.Clear()
 }
 
 func TestGetSupportedLanguage(t *testing.T) {


### PR DESCRIPTION
The only usage was `failedMediaCache` in the Turn.io WhatsApp handler — a negative cache of media URLs that recently failed to upload. `patrickmn/go-cache` is effectively unmaintained (last release 2017) and pre-generics, while gocommon's `cache.Local` is already used elsewhere in courier.

Semantics are unchanged: 15-minute TTL per entry, expired entries are never returned, and a failed upload suppresses retries for 15 minutes. The background sweeper (`Start()`) replaces go-cache's janitor.