### PR TITLE
Support WhatsApp BSUIDs as whatsapp URNs alongside phone numbers

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -994,10 +994,12 @@ func (ts *BackendTestSuite) TestContactForMsg() {
 	ts.NoError(err)
 	ts.NotEqual(bsuidOwner.ID_, phoneOwner.ID_)
 
-	resolved, err := contactForMsg(ctx, ts.b, newBSUIDMsg("whatsapp:US.7777", "whatsapp:12065557777"), clog)
+	msg := newBSUIDMsg("whatsapp:US.7777", "whatsapp:12065557777")
+	resolved, err := contactForMsg(ctx, ts.b, msg, clog)
 	ts.NoError(err)
 	ts.Equal(bsuidOwner.ID_, resolved.ID_)                       // resolved to the BSUID owner, not duplicated
 	ts.Equal(phoneOwner.ID_, lookup("whatsapp:12065557777").ID_) // phone stayed on its original contact
+	ts.Nil(msg.NewURN_)                                          // phone not queued to mailroom, so an append can't steal it later
 
 	// addContactURN must not steal a URN that already belongs to another contact - it rolls back and reports moved
 	moved, err := addContactURN(ctx, ts.b, waChannel, phoneOwner, "whatsapp:US.7777", nil)

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -945,6 +945,67 @@ func (ts *BackendTestSuite) TestSaveAttachment() {
 	ts.Equal("http://localstack:4566/test-attachments/attachments/1/c00e/5d67/c00e5d67-c275-4389-aded-7d8b151cbd5b.jpg", newURL)
 }
 
+func (ts *BackendTestSuite) TestContactForMsg() {
+	ctx := context.Background()
+	waChannel := ts.getChannel("WAC", "dbc126ed-66bc-4e28-b67b-81dc33277a17")
+	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, waChannel, nil)
+
+	// an incoming WhatsApp message with a business-scoped user ID is keyed on the BSUID (primary URN) with the
+	// phone number attached as its new URN
+	newBSUIDMsg := func(bsuid, phone urns.URN) *MsgIn {
+		m := ts.b.NewIncomingMsg(ctx, waChannel, bsuid, "hi", "", clog).(*MsgIn)
+		m.WithNewURN(phone, models.NewURNAppend)
+		return m
+	}
+	lookup := func(urn urns.URN) *models.Contact {
+		c, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, urn, nil, "", false, clog)
+		ts.NoError(err)
+		return c
+	}
+
+	// no existing contact: a message with a BSUID and phone creates one keyed on the BSUID
+	c1, err := contactForMsg(ctx, ts.b, newBSUIDMsg("whatsapp:US.9876", "whatsapp:12065551234"), clog)
+	ts.NoError(err)
+	ts.True(c1.IsNew_)
+	ts.Equal(c1.ID_, lookup("whatsapp:US.9876").ID_)
+
+	// existing contact known only by its all-digit whatsapp URN: a new BSUID is matched to it (not duplicated)
+	// and the BSUID is added to it
+	existingByPhone, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, "whatsapp:12065559999", nil, "", true, clog)
+	ts.NoError(err)
+
+	matched, err := contactForMsg(ctx, ts.b, newBSUIDMsg("whatsapp:US.5555", "whatsapp:12065559999"), clog)
+	ts.NoError(err)
+	ts.False(matched.IsNew_)
+	ts.Equal(existingByPhone.ID_, matched.ID_)
+	ts.Equal(existingByPhone.ID_, lookup("whatsapp:US.5555").ID_) // BSUID now resolves to the same contact
+
+	// existing contact already known by the BSUID: matched directly
+	matchedByBSUID, err := contactForMsg(ctx, ts.b, newBSUIDMsg("whatsapp:US.9876", "whatsapp:12065551234"), clog)
+	ts.NoError(err)
+	ts.False(matchedByBSUID.IsNew_)
+	ts.Equal(c1.ID_, matchedByBSUID.ID_)
+
+	// BSUID already owned by one contact while the phone belongs to a different contact: the message resolves to
+	// the BSUID owner (matched BSUID-first) and the phone contact is left untouched
+	bsuidOwner, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, "whatsapp:US.7777", nil, "", true, clog)
+	ts.NoError(err)
+	phoneOwner, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, "whatsapp:12065557777", nil, "", true, clog)
+	ts.NoError(err)
+	ts.NotEqual(bsuidOwner.ID_, phoneOwner.ID_)
+
+	resolved, err := contactForMsg(ctx, ts.b, newBSUIDMsg("whatsapp:US.7777", "whatsapp:12065557777"), clog)
+	ts.NoError(err)
+	ts.Equal(bsuidOwner.ID_, resolved.ID_)                       // resolved to the BSUID owner, not duplicated
+	ts.Equal(phoneOwner.ID_, lookup("whatsapp:12065557777").ID_) // phone stayed on its original contact
+
+	// addContactURN must not steal a URN that already belongs to another contact - it rolls back and reports moved
+	moved, err := addContactURN(ctx, ts.b, waChannel, phoneOwner, "whatsapp:US.7777", nil)
+	ts.NoError(err)
+	ts.True(moved)
+	ts.Equal(bsuidOwner.ID_, lookup("whatsapp:US.7777").ID_) // BSUID still owned by its original contact
+}
+
 func (ts *BackendTestSuite) TestWriteMsg() {
 	ctx := context.Background()
 	knChannel := ts.getChannel("KN", "dbc126ed-66bc-4e28-b67b-81dc3327c95d")

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -167,10 +167,10 @@ func contactForURN(ctx context.Context, b *backend, org models.OrgID, channel *m
 // is reused rather than duplicated. In that case the BSUID is added to the matched contact so it stays the
 // message's (highest priority) URN.
 func contactForMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLog) (*models.Contact, error) {
-	altURNs := altLookupURNs(m)
+	alt := altLookupURN(m)
 
-	// simple case: no alternative URNs to consider, look up or create by the primary URN
-	if len(altURNs) == 0 {
+	// simple case: no alternative URN to consider, look up or create by the primary URN
+	if alt == urns.NilURN {
 		return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
 	}
 
@@ -183,43 +183,41 @@ func contactForMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.Chan
 		return contact, nil
 	}
 
-	// the BSUID didn't match an existing contact, try the alternatives (the phone number's whatsapp URN)
-	for _, alt := range altURNs {
-		contact, err = contactForURN(ctx, b, m.OrgID_, m.channel, alt, nil, "", false, clog)
+	// the BSUID didn't match an existing contact, try the alternative (the phone number's whatsapp URN)
+	contact, err = contactForURN(ctx, b, m.OrgID_, m.channel, alt, nil, "", false, clog)
+	if err != nil {
+		return nil, err
+	}
+	if contact != nil {
+		// matched an existing contact by the phone number - add the BSUID to it so the message stays
+		// attributed to the BSUID
+		moved, err := addContactURN(ctx, b, m.channel, contact, m.URN_, m.URNAuthTokens_)
 		if err != nil {
 			return nil, err
 		}
-		if contact != nil {
-			// matched an existing contact by the phone number - add the BSUID to it so the message stays
-			// attributed to the BSUID
-			moved, err := addContactURN(ctx, b, m.channel, contact, m.URN_, m.URNAuthTokens_)
-			if err != nil {
-				return nil, err
-			}
-			// between our BSUID lookup above and now, the BSUID was claimed by another contact - don't steal
-			// it, re-look-up the BSUID and return the contact that already owns it
-			if moved {
-				return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
-			}
-			return contact, nil
+		// between our BSUID lookup above and now, the BSUID was claimed by another contact - don't steal
+		// it, re-look-up the BSUID and return the contact that already owns it
+		if moved {
+			return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
 		}
+		return contact, nil
 	}
 
 	// no existing contact matched any URN, create one from the primary URN
 	return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
 }
 
-// altLookupURNs returns alternative URNs to look up an existing contact by when the message's primary URN doesn't
-// match one. For a WhatsApp business-scoped user ID (a whatsapp URN in the CC.xxx form) with a phone number
-// attached as its new URN, that's the phone number's (all-digit) whatsapp URN.
-func altLookupURNs(m *MsgIn) []urns.URN {
+// altLookupURN returns the URN to look up an existing contact by when the message's primary URN doesn't match one.
+// For a WhatsApp business-scoped user ID (a whatsapp URN in the CC.xxx form) with a phone number attached as its
+// new URN, that's the phone number's (all-digit) whatsapp URN; otherwise NilURN.
+func altLookupURN(m *MsgIn) urns.URN {
 	// only when the primary URN is a whatsapp business-scoped user ID (not an all-digit phone number) with a
 	// phone number attached as its new URN
 	if m.NewURN_ == nil || !urns.IsWhatsAppBSUID(m.URN_) {
-		return nil
+		return urns.NilURN
 	}
 
-	return []urns.URN{m.NewURN_.Value}
+	return m.NewURN_.Value
 }
 
 // addContactURN adds the given URN to the contact (if not already present) and points the contact's URNID at it,

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -180,6 +180,9 @@ func contactForMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.Chan
 		return nil, err
 	}
 	if contact != nil {
+		// the BSUID already resolves a contact - don't queue the phone as a new URN, as an append could steal
+		// it from a different contact that currently owns it
+		m.NewURN_ = nil
 		return contact, nil
 	}
 
@@ -221,8 +224,9 @@ func altLookupURN(m *MsgIn) urns.URN {
 }
 
 // addContactURN adds the given URN to the contact (if not already present) and points the contact's URNID at it,
-// so the incoming message is attributed to this URN. If the URN already belonged to a different contact, it
-// returns moved=true without stealing it (the transaction is rolled back), leaving it on its current owner.
+// so the incoming message is attributed to this URN. If the URN already belonged to a different contact (or was
+// claimed concurrently), it returns moved=true without stealing it (the transaction is rolled back), leaving it
+// on its current owner for the caller to re-look-up.
 func addContactURN(ctx context.Context, b *backend, channel *models.Channel, contact *models.Contact, urn urns.URN, authTokens map[string]string) (moved bool, err error) {
 	tx, err := b.rt.DB.BeginTxx(ctx, nil)
 	if err != nil {
@@ -232,6 +236,12 @@ func addContactURN(ctx context.Context, b *backend, channel *models.Channel, con
 	contactURN, err := models.GetOrCreateContactURN(ctx, tx, channel, contact.ID_, urn, authTokens)
 	if err != nil {
 		tx.Rollback()
+
+		// a concurrent receive inserted the URN after our lookup missed it - treat it like a steal and let the
+		// caller re-look-up the contact that now owns it, rather than spooling the message
+		if dbutil.IsUniqueViolation(err) {
+			return true, nil
+		}
 		return false, fmt.Errorf("error adding URN to contact: %w", err)
 	}
 

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -159,3 +159,95 @@ func contactForURN(ctx context.Context, b *backend, org models.OrgID, channel *m
 
 	return contact, nil
 }
+
+// contactForMsg resolves the contact for an incoming message. It normally looks the contact up by (or creates it
+// from) the message's primary URN. But when a WhatsApp message arrives with a business-scoped user ID as its
+// primary URN and a phone number attached as its new URN, we also look for an existing contact by that phone
+// number's whatsapp URN - so a contact which predates the BSUID (and is only known by its all-digit whatsapp URN)
+// is reused rather than duplicated. In that case the BSUID is added to the matched contact so it stays the
+// message's (highest priority) URN.
+func contactForMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLog) (*models.Contact, error) {
+	altURNs := altLookupURNs(m)
+
+	// simple case: no alternative URNs to consider, look up or create by the primary URN
+	if len(altURNs) == 0 {
+		return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+	}
+
+	// try the primary URN first (the whatsapp BSUID), without creating a contact
+	contact, err := contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, false, clog)
+	if err != nil {
+		return nil, err
+	}
+	if contact != nil {
+		return contact, nil
+	}
+
+	// the BSUID didn't match an existing contact, try the alternatives (the phone number's whatsapp URN)
+	for _, alt := range altURNs {
+		contact, err = contactForURN(ctx, b, m.OrgID_, m.channel, alt, nil, "", false, clog)
+		if err != nil {
+			return nil, err
+		}
+		if contact != nil {
+			// matched an existing contact by the phone number - add the BSUID to it so the message stays
+			// attributed to the BSUID
+			moved, err := addContactURN(ctx, b, m.channel, contact, m.URN_, m.URNAuthTokens_)
+			if err != nil {
+				return nil, err
+			}
+			// between our BSUID lookup above and now, the BSUID was claimed by another contact - don't steal
+			// it, re-look-up the BSUID and return the contact that already owns it
+			if moved {
+				return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+			}
+			return contact, nil
+		}
+	}
+
+	// no existing contact matched any URN, create one from the primary URN
+	return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+}
+
+// altLookupURNs returns alternative URNs to look up an existing contact by when the message's primary URN doesn't
+// match one. For a WhatsApp business-scoped user ID (a whatsapp URN in the CC.xxx form) with a phone number
+// attached as its new URN, that's the phone number's (all-digit) whatsapp URN.
+func altLookupURNs(m *MsgIn) []urns.URN {
+	// only when the primary URN is a whatsapp business-scoped user ID (not an all-digit phone number) with a
+	// phone number attached as its new URN
+	if m.NewURN_ == nil || !urns.IsWhatsAppBSUID(m.URN_) {
+		return nil
+	}
+
+	return []urns.URN{m.NewURN_.Value}
+}
+
+// addContactURN adds the given URN to the contact (if not already present) and points the contact's URNID at it,
+// so the incoming message is attributed to this URN. If the URN already belonged to a different contact, it
+// returns moved=true without stealing it (the transaction is rolled back), leaving it on its current owner.
+func addContactURN(ctx context.Context, b *backend, channel *models.Channel, contact *models.Contact, urn urns.URN, authTokens map[string]string) (moved bool, err error) {
+	tx, err := b.rt.DB.BeginTxx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("error beginning transaction: %w", err)
+	}
+
+	contactURN, err := models.GetOrCreateContactURN(ctx, tx, channel, contact.ID_, urn, authTokens)
+	if err != nil {
+		tx.Rollback()
+		return false, fmt.Errorf("error adding URN to contact: %w", err)
+	}
+
+	// GetOrCreateContactURN will have re-pointed the URN from its previous owner to us - we don't want to steal
+	// it, so roll back and let the caller re-look-up the contact that already owns it
+	if contactURN.PrevContactID != models.NilContactID {
+		tx.Rollback()
+		return true, nil
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("error committing transaction: %w", err)
+	}
+
+	contact.URNID_ = contactURN.ID
+	return false, nil
+}

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -118,7 +118,7 @@ func writeMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLo
 }
 
 func writeMsgToDB(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLog) (*models.Contact, error) {
-	contact, err := contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+	contact, err := contactForMsg(ctx, b, m, clog)
 
 	if err != nil {
 		// our db is down, write to the spool, we will write/queue this later

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -148,6 +148,20 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					}
 				}
 
+				// ExtractData gives us the phone number as a whatsapp URN; if the message also carries a
+				// business-scoped user ID, make that WhatsApp URN the primary URN and attach the phone number
+				// as a secondary URN
+				appendURN := urns.NilURN
+				if waMsg.FromUserID != "" {
+					userIDURN, urnErr := urns.New(urns.WhatsApp, waMsg.FromUserID)
+					if urnErr == nil {
+						appendURN = urn
+						urn = userIDURN
+					} else {
+						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for WhatsApp URN: %w", urnErr))
+					}
+				}
+
 				// create our message
 				event := h.Backend().NewIncomingMsg(ctx, channel, urn, text, waMsg.ID, clog).WithReceivedOn(date).WithContactName(contactNames[waMsg.From])
 
@@ -155,14 +169,8 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					event.WithAttachment(mediaURL)
 				}
 
-				// if we have a user_id, add it as secondary BSUID URN
-				if waMsg.FromUserID != "" {
-					userIDURN, urnErr := urns.New(urns.BSUID, waMsg.FromUserID)
-					if urnErr == nil {
-						event.WithNewURN(userIDURN, models.NewURNAppend)
-					} else {
-						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for BSUID URN: %w", urnErr))
-					}
+				if appendURN != urns.NilURN {
+					event.WithNewURN(appendURN, models.NewURNAppend)
 				}
 
 				err = h.Backend().WriteMsg(ctx, event, clog)
@@ -293,9 +301,9 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	// if we got a user_id in the response, set it as a new URN on the send result so the backend
 	// can queue a contact_changed task to append it to the contact
 	if userID != "" {
-		userIDURN, err := urns.New(urns.BSUID, userID)
+		userIDURN, err := urns.New(urns.WhatsApp, userID)
 		if err != nil {
-			clog.RawError(fmt.Errorf("unable to make BSUID URN from user_id %s: %w", userID, err))
+			clog.RawError(fmt.Errorf("unable to make WhatsApp URN from user_id %s: %w", userID, err))
 		} else {
 			res.SetNewURN(userIDURN)
 		}

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -59,10 +59,10 @@ var testCasesD3C = []IncomingTestCase{
 		NoQueueErrorCheck:     true,
 		NoInvalidChannelCheck: true,
 		ExpectedMsgText:       Sp("Hello World"),
-		ExpectedURN:           "whatsapp:5678",
+		ExpectedURN:           "whatsapp:US.1234",
 		ExpectedExternalID:    "external_id",
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
-		ExpectedNewURN:        &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend},
+		ExpectedNewURN:        &models.NewURNSpec{Value: "whatsapp:5678", Action: models.NewURNAppend},
 	},
 	{
 		Label:                 "Receive Duplicate Valid Message",
@@ -351,7 +351,7 @@ var SendTestCasesD3C = []OutgoingTestCase{
 	{
 		Label:   "Plain Send with BSUID",
 		MsgText: "Simple Message",
-		MsgURN:  "bsuid:US.1234",
+		MsgURN:  "whatsapp:US.1234",
 		MockResponses: map[string][]*httpx.MockResponse{
 			"https://waba-v2.360dialog.io/messages": {
 				httpx.NewMockResponse(200, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
@@ -377,14 +377,14 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 		ExpectedContactURNs: map[string]bool{
 			"whatsapp:250788123123": true,
-			"bsuid:US.1234":         true,
+			"whatsapp:US.1234":      true,
 		},
 	},
 	{
 		Label:               "Plain Send with user_id already on contact",
 		MsgText:             "Simple Message",
 		MsgURN:              "whatsapp:250788123123",
-		MsgContactOtherURNs: []urns.URN{"bsuid:US.1234"},
+		MsgContactOtherURNs: []urns.URN{"whatsapp:US.1234"},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"https://waba-v2.360dialog.io/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "contacts": [{"input": "250788123123", "user_id": "US.1234"}], "messages": [{"id": "157b5e14568e8"}] }`)),

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -292,6 +292,20 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					}
 				}
 
+				// ExtractData gives us the phone number as a whatsapp URN; if the message also carries a
+				// business-scoped user ID, make that WhatsApp URN the primary URN and attach the phone number
+				// as a secondary URN
+				appendURN := urns.NilURN
+				if waMsg.FromUserID != "" {
+					userIDURN, urnErr := urns.New(urns.WhatsApp, waMsg.FromUserID)
+					if urnErr == nil {
+						appendURN = urn
+						urn = userIDURN
+					} else {
+						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for WhatsApp URN: %w", urnErr))
+					}
+				}
+
 				// create our message
 				event := h.Backend().NewIncomingMsg(ctx, channel, urn, text, waMsg.ID, clog).WithReceivedOn(date).WithContactName(contactNames[waMsg.From])
 
@@ -299,14 +313,8 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					event.WithAttachment(mediaURL)
 				}
 
-				// if we have a user_id, add it as secondary BSUID URN
-				if waMsg.FromUserID != "" {
-					userIDURN, urnErr := urns.New(urns.BSUID, waMsg.FromUserID)
-					if urnErr == nil {
-						event.WithNewURN(userIDURN, models.NewURNAppend)
-					} else {
-						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for BSUID URN: %w", urnErr))
-					}
+				if appendURN != urns.NilURN {
+					event.WithNewURN(appendURN, models.NewURNAppend)
 				}
 
 				err = h.Backend().WriteMsg(ctx, event, clog)
@@ -724,9 +732,9 @@ func (h *handler) sendWhatsAppMsg(ctx context.Context, msg courier.MsgOut, res *
 	// if we got a user_id in the response, set it as a new URN on the send result so the backend
 	// can queue a contact_changed task to append it to the contact
 	if userID != "" {
-		userIDURN, err := urns.New(urns.BSUID, userID)
+		userIDURN, err := urns.New(urns.WhatsApp, userID)
 		if err != nil {
-			clog.RawError(fmt.Errorf("unable to make BSUID URN from user_id %s: %w", userID, err))
+			clog.RawError(fmt.Errorf("unable to make WhatsApp URN from user_id %s: %w", userID, err))
 		} else {
 			res.SetNewURN(userIDURN)
 		}

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -46,10 +46,10 @@ var whatsappIncomingTests = []IncomingTestCase{
 		NoQueueErrorCheck:     true,
 		NoInvalidChannelCheck: true,
 		ExpectedMsgText:       Sp("Hello World"),
-		ExpectedURN:           "whatsapp:5678",
+		ExpectedURN:           "whatsapp:US.1234",
 		ExpectedExternalID:    "external_id",
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
-		ExpectedNewURN:        &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend},
+		ExpectedNewURN:        &models.NewURNSpec{Value: "whatsapp:5678", Action: models.NewURNAppend},
 		PrepRequest:           addValidSignature,
 	},
 	{
@@ -329,7 +329,7 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 	{
 		Label:   "Plain Send with BSUID",
 		MsgText: "Simple Message",
-		MsgURN:  "bsuid:US.1234",
+		MsgURN:  "whatsapp:US.1234",
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/12345_ID/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
@@ -355,14 +355,14 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 		ExpectedContactURNs: map[string]bool{
 			"whatsapp:250788123123": true,
-			"bsuid:US.1234":         true,
+			"whatsapp:US.1234":      true,
 		},
 	},
 	{
 		Label:               "Plain Send with user_id already on contact",
 		MsgText:             "Simple Message",
 		MsgURN:              "whatsapp:250788123123",
-		MsgContactOtherURNs: []urns.URN{"bsuid:US.1234"},
+		MsgContactOtherURNs: []urns.URN{"whatsapp:US.1234"},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/12345_ID/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "contacts": [{"input": "250788123123", "user_id": "US.1234"}], "messages": [{"id": "157b5e14568e8"}] }`)),

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -20,10 +20,11 @@ func GetMsgPayloads(ctx context.Context, msg courier.MsgOut, maxMsgLength int, c
 	return buildContentPayloads(msg, maxMsgLength, clog)
 }
 
-// RecipientFields returns the to and recipient field values for the given URN, using the recipient field for
-// business-scoped user ID (BSUID) URNs and the to field otherwise.
+// RecipientFields returns the to and recipient field values for the given URN. A whatsapp URN may hold either a
+// phone number (all digits) or a business-scoped user ID (the CC.xxx form); the business-scoped user ID goes in
+// the recipient field and the phone number goes in the to field.
 func RecipientFields(urn urns.URN) (to, recipient string) {
-	if urn.Scheme() == urns.BSUID.Prefix {
+	if urns.IsWhatsAppBSUID(urn) {
 		return "", urn.Path()
 	}
 	return urn.Path(), ""

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -15,6 +15,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRecipientFields(t *testing.T) {
+	tcs := []struct {
+		urn               urns.URN
+		expectedTo        string
+		expectedRecipient string
+	}{
+		{urn: "whatsapp:250788123123", expectedTo: "250788123123", expectedRecipient: ""}, // phone number -> to
+		{urn: "whatsapp:US.1234", expectedTo: "", expectedRecipient: "US.1234"},            // business-scoped user ID -> recipient
+	}
+
+	for _, tc := range tcs {
+		to, recipient := whatsapp.RecipientFields(tc.urn)
+		assert.Equal(t, tc.expectedTo, to, "to mismatch for %s", tc.urn)
+		assert.Equal(t, tc.expectedRecipient, recipient, "recipient mismatch for %s", tc.urn)
+	}
+}
+
 func TestGetMsgPayloads(t *testing.T) {
 	ctx := context.Background()
 	maxMsgLength := 4096
@@ -297,7 +314,7 @@ func TestGetMsgPayloads(t *testing.T) {
 		{
 			label:                 "Send message by BSUID",
 			text:                  "Hello, BSUID",
-			urn:                   "bsuid:US.1234",
+			urn:                   "whatsapp:US.1234",
 			expectedPayloadsCount: 1,
 			expectedType:          "text",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
@@ -312,7 +329,7 @@ func TestGetMsgPayloads(t *testing.T) {
 			text:                  "Pick an option",
 			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "Option 1"}, {Type: "text", Text: "Option 2"}},
-			urn:                   "bsuid:US.1234",
+			urn:                   "whatsapp:US.1234",
 			expectedPayloadsCount: 1,
 			expectedType:          "interactive",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -236,6 +236,19 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 			courier.LogRequestError(r, channel, fmt.Errorf("unsupported message type %s", msg.Type))
 		}
 
+		// the phone number is a whatsapp URN; if the message also carries a business-scoped user ID, make that
+		// WhatsApp URN the primary URN and attach the phone number as a secondary URN
+		appendURN := urns.NilURN
+		if msg.FromBSUID != "" {
+			userIDURN, urnErr := urns.New(urns.WhatsApp, msg.FromBSUID)
+			if urnErr == nil {
+				appendURN = urn
+				urn = userIDURN
+			} else {
+				courier.LogRequestError(r, channel, fmt.Errorf("invalid from_bsuid for WhatsApp URN: %w", urnErr))
+			}
+		}
+
 		// create our message
 		event := h.Backend().NewIncomingMsg(ctx, channel, urn, text, msg.ID, clog).WithReceivedOn(date).WithContactName(contactNames[msg.From])
 
@@ -248,13 +261,8 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 			event.WithAttachment(mediaURL)
 		}
 
-		if msg.FromBSUID != "" {
-			userIDURN, urnErr := urns.New(urns.BSUID, msg.FromBSUID)
-			if urnErr == nil {
-				event.WithNewURN(userIDURN, models.NewURNAppend)
-			} else {
-				courier.LogRequestError(r, channel, fmt.Errorf("invalid from_bsuid for BSUID URN: %w", urnErr))
-			}
+		if appendURN != urns.NilURN {
+			event.WithNewURN(appendURN, models.NewURNAppend)
 		}
 
 		err = h.Backend().WriteMsg(ctx, event, clog)

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -360,10 +360,10 @@ var testCasesTurn = []IncomingTestCase{
 		ExpectedBodyContains:  `"type":"msg"`,
 		ExpectedContactName:   Sp("Jerry Cooney"),
 		ExpectedMsgText:       Sp("hello world"),
-		ExpectedURN:           "whatsapp:250788123123",
+		ExpectedURN:           "whatsapp:US.1234",
 		ExpectedExternalID:    "41",
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
-		ExpectedNewURN:        &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend},
+		ExpectedNewURN:        &models.NewURNSpec{Value: "whatsapp:250788123123", Action: models.NewURNAppend},
 		NoQueueErrorCheck:     true,
 		NoInvalidChannelCheck: true,
 	},
@@ -622,7 +622,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 	{
 		Label:   "Plain Send with BSUID",
 		MsgText: "Simple Message",
-		MsgURN:  "bsuid:US.1234",
+		MsgURN:  "whatsapp:US.1234",
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/v1/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -147,18 +147,26 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		text = form.ButtonText
 	}
 
-	// build our msg
-	msg := h.Backend().NewIncomingMsg(ctx, channel, urn, text, form.MessageSID, clog)
-
+	// if we have a business-scoped user ID (ExternalUserId), make that WhatsApp URN the primary URN and attach
+	// the phone number as a secondary URN
+	appendURN := urns.NilURN
 	if form.ExternalUserId != "" && channel.IsScheme(urns.WhatsApp) {
 		userIDURN, urnErr := h.parseURN(channel, form.ExternalUserId, i18n.Country(form.FromCountry))
 
 		if urnErr == nil {
-			msg.WithNewURN(userIDURN, models.NewURNAppend)
+			appendURN = urn
+			urn = userIDURN
 		} else {
 			slog.Warn("ignoring invalid ExternalUserId for message", "ExternalUserId", form.ExternalUserId, "MessageSID", form.MessageSID, "Error", urnErr.Error())
 
 		}
+	}
+
+	// build our msg
+	msg := h.Backend().NewIncomingMsg(ctx, channel, urn, text, form.MessageSID, clog)
+
+	if appendURN != urns.NilURN {
+		msg.WithNewURN(appendURN, models.NewURNAppend)
 	}
 
 	// process any attached media
@@ -467,8 +475,8 @@ func (h *handler) parseURN(channel courier.Channel, text string, country i18n.Co
 		}
 
 		if dot := strings.Index(fromTel, "."); dot >= 0 && dot < len(fromTel)-1 {
-			// if we have a BSUID, use that as the URN
-			return urns.New(urns.BSUID, fromTel)
+			// a business-scoped user ID becomes a WhatsApp URN
+			return urns.New(urns.WhatsApp, fromTel)
 		}
 
 		// trim off left +, official whatsapp IDs dont have that

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -454,7 +454,7 @@ var twaTestCases = []IncomingTestCase{
 		ExpectedMsgText: Sp("Msg"), ExpectedURN: "whatsapp:14133881111", ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",
 		PrepRequest: addValidSignature},
 	{Label: "Receive BSUID Valid", URL: twaReceiveURL, Data: waReceiveBSUIDValid, ExpectedRespStatus: 200, ExpectedBodyContains: "<Response/>",
-		ExpectedMsgText: Sp("Msg"), ExpectedURN: "whatsapp:14133881111", ExpectedNewURN: &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend}, ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",
+		ExpectedMsgText: Sp("Msg"), ExpectedURN: "whatsapp:US.1234", ExpectedNewURN: &models.NewURNSpec{Value: "whatsapp:14133881111", Action: models.NewURNAppend}, ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",
 		PrepRequest: addValidSignature},
 	{Label: "Receive Valid", URL: twaReceiveURL, Data: waReceiveButtonValid, ExpectedRespStatus: 200, ExpectedBodyContains: "<Response/>",
 		ExpectedMsgText: Sp("Confirm"), ExpectedURN: "whatsapp:14133881111", ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",

--- a/testsuite/testdata/data.sql
+++ b/testsuite/testdata/data.sql
@@ -31,6 +31,9 @@ INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modifi
 INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
                       VALUES('16', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327222a', 'EX', NULL, 1, 'US', '', '{}');
 
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
+                      VALUES('17', '{"whatsapp"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc33277a17', 'WAC', '12345', 1, NULL, 'SR', '{}');
+
 /* Contacts with ids 100, 101 */
 DELETE FROM contacts_contact;
 INSERT INTO contacts_contact("id", "is_active", "status", "created_on", "modified_on", "uuid", "language", "ticket_count", "created_by_id", "modified_by_id", "org_id")


### PR DESCRIPTION
A WhatsApp identity can be either a phone number or a business-scoped user ID (BSUID). Store both under the single whatsapp URN scheme rather than a separate scheme.

- Sending: route a BSUID to the recipient field and a phone number to the to field.
- Receiving: when a message also carries a BSUID, make that whatsapp URN the primary URN and attach the phone number as a secondary URN.
- Contact resolution: look an existing contact up by the BSUID first, falling back to the phone number's whatsapp URN; a contact matched by phone has the BSUID added to it, without stealing a URN that already belongs to another contact.