### PR TITLE
Throttle sustained chat actions to their declared interval

### DIFF
--- a/chat_actions.go
+++ b/chat_actions.go
@@ -54,6 +54,10 @@ type sendChatActionResponse struct {
 // Handles a chat action send request. Callers should treat supported=false as "stop sending for this
 // conversation" and any error response as "stop sending until a new typing session starts" - a failed send
 // means no indicator is showing, and this bounds how many error logs a broken channel can generate.
+//
+// Sustained actions (interval > 0) are throttled per conversation: repeats within the interval are
+// reported as success without a send, so callers can relay actions at whatever cadence suits them and the
+// platform still sees at most one send per interval.
 func sendChatAction(ctx context.Context, s *Server, r *http.Request) (*sendChatActionResponse, error) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -82,6 +86,23 @@ func sendChatAction(ctx context.Context, s *Server, r *http.Request) (*sendChatA
 		return &sendChatActionResponse{Supported: false}, nil
 	}
 
+	resp := &sendChatActionResponse{Supported: true, Interval: int(interval / time.Second)}
+
+	// sustained actions are throttled to their interval with a valkey key that expires when the platform
+	// needs a resend - one-shot actions (interval 0) always go through
+	throttleKey := fmt.Sprintf("chat-actions:%s|%s|%s", ch.UUID(), sa.URN.Identity(), sa.Action)
+	if interval > 0 {
+		rc := s.rt.VK.Get()
+		reply, err := rc.Do("SET", throttleKey, "1", "EX", int(interval/time.Second), "NX")
+		rc.Close()
+		if err != nil {
+			// a valkey problem shouldn't break chat actions so proceed unthrottled
+			slog.Error("error checking chat action throttle", "error", err, "key", throttleKey)
+		} else if reply == nil {
+			return resp, nil // already sent within the interval
+		}
+	}
+
 	clog := NewChannelLogForChatActionSend(ch, handler.RedactValues(ch))
 
 	err = handler.SendChatAction(ctx, ch, &sa.ChatActionSend, clog)
@@ -95,11 +116,18 @@ func sendChatAction(ctx context.Context, s *Server, r *http.Request) (*sendChatA
 	}
 
 	if err != nil {
+		// a failed send didn't show an indicator, so clear the throttle rather than suppressing the next
+		// attempt - e.g. a new typing session starting within the interval
+		if interval > 0 {
+			rc := s.rt.VK.Get()
+			if _, delErr := rc.Do("DEL", throttleKey); delErr != nil {
+				slog.Error("error clearing chat action throttle", "error", delErr, "key", throttleKey)
+			}
+			rc.Close()
+		}
+
 		return nil, fmt.Errorf("error sending %s action on channel %s: %w", sa.Action, ch.UUID(), err)
 	}
 
-	return &sendChatActionResponse{
-		Supported: true,
-		Interval:  int(interval / time.Second),
-	}, nil
+	return resp, nil
 }

--- a/chat_actions.go
+++ b/chat_actions.go
@@ -86,14 +86,16 @@ func sendChatAction(ctx context.Context, s *Server, r *http.Request) (*sendChatA
 		return &sendChatActionResponse{Supported: false}, nil
 	}
 
-	resp := &sendChatActionResponse{Supported: true, Interval: int(interval / time.Second)}
+	intervalSecs := int(interval / time.Second)
+	resp := &sendChatActionResponse{Supported: true, Interval: intervalSecs}
 
 	// sustained actions are throttled to their interval with a valkey key that expires when the platform
-	// needs a resend - one-shot actions (interval 0) always go through
+	// needs a resend - one-shot actions (interval 0, or anything below our 1 second resolution) always
+	// go through
 	throttleKey := fmt.Sprintf("chat-actions:%s|%s|%s", ch.UUID(), sa.URN.Identity(), sa.Action)
-	if interval > 0 {
+	if intervalSecs > 0 {
 		rc := s.rt.VK.Get()
-		reply, err := rc.Do("SET", throttleKey, "1", "EX", int(interval/time.Second), "NX")
+		reply, err := rc.Do("SET", throttleKey, "1", "EX", intervalSecs, "NX")
 		rc.Close()
 		if err != nil {
 			// a valkey problem shouldn't break chat actions so proceed unthrottled
@@ -118,7 +120,7 @@ func sendChatAction(ctx context.Context, s *Server, r *http.Request) (*sendChatA
 	if err != nil {
 		// a failed send didn't show an indicator, so clear the throttle rather than suppressing the next
 		// attempt - e.g. a new typing session starting within the interval
-		if interval > 0 {
+		if intervalSecs > 0 {
 			rc := s.rt.VK.Get()
 			if _, delErr := rc.Do("DEL", throttleKey); delErr != nil {
 				slog.Error("error clearing chat action throttle", "error", delErr, "key", throttleKey)

--- a/chat_actions_test.go
+++ b/chat_actions_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/courier/v26/testsuite"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
@@ -16,10 +17,12 @@ import (
 )
 
 func TestSendChatAction(t *testing.T) {
-	cfg := runtime.NewDefaultConfig()
-	cfg.AuthToken = "sesame"
-	cfg.InternetPort = 8180
-	cfg.InternalPort = 8181
+	_, rt := testsuite.Runtime(t) // throttling needs a real valkey
+	rt.Config.AuthToken = "sesame"
+	rt.Config.InternetPort = 8180
+	rt.Config.InternalPort = 8181
+
+	testsuite.ResetValkey(t, rt)
 
 	mb := test.NewMockBackend()
 	mockChannel := test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
@@ -29,10 +32,11 @@ func TestSendChatAction(t *testing.T) {
 	brokenChannel := test.NewMockChannel("53e5aafa-8155-449d-9009-fcb30d54bd26", "XX", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
 	mb.AddChannel(brokenChannel)
 
-	server := courier.NewServer(runtime.NewTestRuntime(cfg), mb)
+	server := courier.NewServer(rt, mb)
 	server.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"http://mock.com/action": {
 			httpx.NewMockResponse(200, nil, []byte(`OK`)),
+			httpx.NewMockResponse(502, nil, []byte(`bad gateway`)),
 			httpx.NewMockResponse(502, nil, []byte(`bad gateway`)),
 		},
 	})
@@ -88,8 +92,15 @@ func TestSendChatAction(t *testing.T) {
 	// successful sends don't write channel logs
 	assert.Len(t, mb.WrittenChannelLogs(), 0)
 
-	// a send error returns an error response and writes a channel log
+	// repeating within the interval for the same conversation is throttled - reported as success but no
+	// send is made (the mock transport's next response isn't consumed)
 	statusCode, respBody = submit(`{"action": "typing_started", "channel_uuid": "e4bb1578-29da-4fa5-a214-9da19dd24230", "channel_type": "MCK", "urn": "tel:+250788123123"}`, "sesame")
+	assert.Equal(t, 200, statusCode)
+	assert.JSONEq(t, `{"supported": true, "interval": 10}`, string(respBody))
+	assert.Len(t, mb.WrittenChannelLogs(), 0)
+
+	// a send error (different URN so not throttled) returns an error response and writes a channel log
+	statusCode, respBody = submit(`{"action": "typing_started", "channel_uuid": "e4bb1578-29da-4fa5-a214-9da19dd24230", "channel_type": "MCK", "urn": "tel:+250788123124"}`, "sesame")
 	assert.Equal(t, 400, statusCode)
 	assert.Contains(t, string(respBody), `channel connection failed`)
 
@@ -98,6 +109,13 @@ func TestSendChatAction(t *testing.T) {
 	assert.Equal(t, courier.ChannelLogTypeChatActionSend, clog.Type)
 	assert.Len(t, clog.HttpLogs, 1)
 	assert.Equal(t, "http://mock.com/action", clog.HttpLogs[0].URL)
+
+	// and clears the throttle, so a retry for that conversation attempts another send (consuming the
+	// second 502 mock) instead of being suppressed as a success
+	statusCode, respBody = submit(`{"action": "typing_started", "channel_uuid": "e4bb1578-29da-4fa5-a214-9da19dd24230", "channel_type": "MCK", "urn": "tel:+250788123124"}`, "sesame")
+	assert.Equal(t, 400, statusCode)
+	assert.Contains(t, string(respBody), `channel connection failed`)
+	assert.Len(t, mb.WrittenChannelLogs(), 2)
 }
 
 func TestChannelInfo(t *testing.T) {


### PR DESCRIPTION
## What changed

`POST /ci/chat_action/send` now throttles sustained actions (those with a non-zero resend interval, e.g. `typing_started`) per conversation: a repeat for the same channel + URN + action within the interval is reported as success without a platform send, gated by a valkey key whose TTL is the interval. One-shot actions (interval 0, e.g. `mark_read`) are never throttled.

If a send fails, the throttle key is cleared so the failure doesn't suppress the next attempt — e.g. a new typing session starting within the interval.

## Why

Callers relaying chat actions (such as agent typing signals arriving at a UI-driven cadence) shouldn't need to know or cache per-channel intervals. With the throttle inside courier, callers can forward pulses at whatever rate suits them and each platform still sees at most one send per interval per conversation — cadence knowledge stays with the handlers that declare it.

## Notes for review

- A valkey error logs and proceeds unthrottled: a cache outage shouldn't break chat actions, and the worst case is transiently unthrottled sends.
- A throttled response is indistinguishable from a successful send (`{"supported": true, "interval": N}`), which is intentional — the caller contract is unchanged.
- The test moves to `testsuite.Runtime` since throttling needs a real valkey pool (`runtime.NewTestRuntime` deliberately has none), and adds coverage for both the suppressed-repeat and cleared-on-error paths.