### PR TITLE
Add typing event support to Facebook and Instagram channels

### DIFF
--- a/event_send.go
+++ b/event_send.go
@@ -111,7 +111,9 @@ func sendEvent(ctx context.Context, s *Server, r *http.Request) (*sendEventRespo
 	}
 
 	// a typing stopped event ends the typing session, so clear any typing started throttle - otherwise
-	// a new session starting within the interval would have its first typing started suppressed
+	// a new session starting within the interval would have its first typing started suppressed. This is
+	// intentionally unconditional on the send outcome: if the stop fails the indicator times out on its
+	// own, and an extra typing started is harmless where a suppressed one isn't.
 	if event.Type() == events.TypeTypingStopped {
 		startedKey := fmt.Sprintf("event-sends:%s|%s|%s", ch.UUID(), urn.Identity(), events.TypeTypingStarted)
 		rc := s.rt.VK.Get()

--- a/event_send.go
+++ b/event_send.go
@@ -110,6 +110,17 @@ func sendEvent(ctx context.Context, s *Server, r *http.Request) (*sendEventRespo
 		}
 	}
 
+	// a typing stopped event ends the typing session, so clear any typing started throttle - otherwise
+	// a new session starting within the interval would have its first typing started suppressed
+	if event.Type() == events.TypeTypingStopped {
+		startedKey := fmt.Sprintf("event-sends:%s|%s|%s", ch.UUID(), urn.Identity(), events.TypeTypingStarted)
+		rc := s.rt.VK.Get()
+		if _, err := rc.Do("DEL", startedKey); err != nil {
+			slog.Error("error clearing event send throttle", "error", err, "key", startedKey)
+		}
+		rc.Close()
+	}
+
 	clog := NewChannelLogForEventSend(ch, handler.RedactValues(ch))
 
 	err = handler.SendEvent(ctx, ch, event, clog)

--- a/event_send_test.go
+++ b/event_send_test.go
@@ -27,6 +27,10 @@ func TestSendEvent(t *testing.T) {
 	mockChannel := test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
 	mb.AddChannel(mockChannel)
 
+	// add a channel that also supports typing stopped events
+	stoppableChannel := test.NewMockChannel("f8be89c7-58b5-4d3c-8e5c-c0d049f4d43b", "MCK", "2021", "US", []string{urns.Phone.Prefix}, map[string]any{"supports_stop": true})
+	mb.AddChannel(stoppableChannel)
+
 	// add a channel whose type has no handler registered and thus can't send events
 	brokenChannel := test.NewMockChannel("53e5aafa-8155-449d-9009-fcb30d54bd26", "XX", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
 	mb.AddChannel(brokenChannel)
@@ -37,6 +41,9 @@ func TestSendEvent(t *testing.T) {
 			httpx.NewMockResponse(200, nil, []byte(`OK`)),
 			httpx.NewMockResponse(502, nil, []byte(`bad gateway`)),
 			httpx.NewMockResponse(502, nil, []byte(`bad gateway`)),
+			httpx.NewMockResponse(200, nil, []byte(`OK`)),
+			httpx.NewMockResponse(200, nil, []byte(`OK`)),
+			httpx.NewMockResponse(200, nil, []byte(`OK`)),
 		},
 	})
 	require.NoError(t, server.Start())
@@ -147,4 +154,24 @@ func TestSendEvent(t *testing.T) {
 	assert.Equal(t, 400, statusCode)
 	assert.Contains(t, string(respBody), `channel connection failed`)
 	assert.Len(t, mb.WrittenChannelLogs(), 2)
+
+	// a typing started on the stoppable channel is sent and throttled as usual
+	statusCode, respBody = submit(typingEvent("MCK", "typing_started", "outgoing", "f8be89c7-58b5-4d3c-8e5c-c0d049f4d43b", "tel:+250788123123"), "sesame")
+	assert.Equal(t, 200, statusCode)
+	assert.JSONEq(t, `{"supported": true, "interval": 10}`, string(respBody))
+	statusCode, respBody = submit(typingEvent("MCK", "typing_started", "outgoing", "f8be89c7-58b5-4d3c-8e5c-c0d049f4d43b", "tel:+250788123123"), "sesame")
+	assert.Equal(t, 200, statusCode)
+	assert.JSONEq(t, `{"supported": true, "interval": 10}`, string(respBody))
+
+	// a typing stopped is a one-shot send (no interval in response) which ends the typing session...
+	statusCode, respBody = submit(typingEvent("MCK", "typing_stopped", "outgoing", "f8be89c7-58b5-4d3c-8e5c-c0d049f4d43b", "tel:+250788123123"), "sesame")
+	assert.Equal(t, 200, statusCode)
+	assert.JSONEq(t, `{"supported": true}`, string(respBody))
+
+	// ...clearing the started throttle so a new typing session isn't suppressed - this send consumes the
+	// last mock response, which repeating within the interval wouldn't
+	statusCode, respBody = submit(typingEvent("MCK", "typing_started", "outgoing", "f8be89c7-58b5-4d3c-8e5c-c0d049f4d43b", "tel:+250788123123"), "sesame")
+	assert.Equal(t, 200, statusCode)
+	assert.JSONEq(t, `{"supported": true, "interval": 10}`, string(respBody))
+	assert.Len(t, mb.WrittenChannelLogs(), 2) // and all of that succeeded so no new channel logs
 }

--- a/handlers/meta/facebook_test.go
+++ b/handlers/meta/facebook_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/core/events"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -617,6 +619,63 @@ func TestFacebookOutgoing(t *testing.T) {
 	checkRedacted := []string{"wac_admin_system_user_token", "missing_facebook_app_secret", "missing_facebook_webhook_secret", "a123"}
 
 	RunOutgoingTestCases(t, channel, newHandler("FBA", "Facebook"), facebookOutgoingTests, checkRedacted, nil)
+}
+
+func TestFacebookSendEvent(t *testing.T) {
+	channel := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "FBA", "12345", "", []string{urns.Facebook.Prefix}, map[string]any{models.ConfigAuthToken: "a123"})
+
+	mb := test.NewMockBackend()
+	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), mb)
+
+	h := newHandler("FBA", "Facebook").(*handler)
+	h.Initialize(s)
+
+	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"https://graph.facebook.com/v22.0/me/messages*": {
+			httpx.NewMockResponse(200, nil, []byte(`{"recipient_id": "5678"}`)),
+			httpx.NewMockResponse(200, nil, []byte(`{"recipient_id": "5678"}`)),
+			httpx.NewMockResponse(400, nil, []byte(`{"error": {"message": "Invalid user", "code": 100}}`)),
+			httpx.MockConnectionError,
+		},
+	})
+
+	// typing events are supported on both Facebook and Instagram channels, including explicit stop
+	expected := map[string]time.Duration{events.TypeTypingStarted: 15 * time.Second, events.TypeTypingStopped: 0}
+	assert.Equal(t, expected, h.SendableEvents(channel))
+	assert.Equal(t, expected, newHandler("IG", "Instagram").(*handler).SendableEvents(channel))
+
+	channelRef := assets.NewChannelReference("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "Facebook")
+
+	// a typing started event is sent as a typing_on sender action
+	clog := courier.NewChannelLogForEventSend(channel, nil)
+	err := h.SendEvent(context.Background(), channel, events.NewTypingStarted(events.DirectionOutgoing, channelRef, "facebook:5678", ""), clog)
+	assert.NoError(t, err)
+	assert.Len(t, clog.HttpLogs, 1)
+	assert.Equal(t, "https://graph.facebook.com/v22.0/me/messages?access_token=a123", clog.HttpLogs[0].URL)
+	assert.Contains(t, clog.HttpLogs[0].Request, `{"recipient":{"id":"5678"},"sender_action":"typing_on"}`)
+
+	// and a typing stopped event as a typing_off sender action
+	err = h.SendEvent(context.Background(), channel, events.NewTypingStopped(events.DirectionOutgoing, channelRef, "facebook:5678", ""), clog)
+	assert.NoError(t, err)
+	assert.Len(t, clog.HttpLogs, 2)
+	assert.Contains(t, clog.HttpLogs[1].Request, `{"recipient":{"id":"5678"},"sender_action":"typing_off"}`)
+
+	// an error response is a response error
+	err = h.SendEvent(context.Background(), channel, events.NewTypingStarted(events.DirectionOutgoing, channelRef, "facebook:5678", ""), clog)
+	assert.Equal(t, courier.ErrResponseStatus, err)
+
+	// as is a connection error
+	err = h.SendEvent(context.Background(), channel, events.NewTypingStarted(events.DirectionOutgoing, channelRef, "facebook:5678", ""), clog)
+	assert.Equal(t, courier.ErrConnectionFailed, err)
+
+	// a channel without an auth token config can't send
+	noAuth := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "FBA", "12345", "", []string{urns.Facebook.Prefix}, nil)
+	err = h.SendEvent(context.Background(), noAuth, events.NewTypingStarted(events.DirectionOutgoing, channelRef, "facebook:5678", ""), clog)
+	assert.Equal(t, courier.ErrChannelConfig, err)
+
+	// nor can an event type the handler doesn't know how to send
+	err = h.SendEvent(context.Background(), channel, events.NewContactLanguageChanged("eng"), clog)
+	assert.ErrorContains(t, err, "unsupported event type: contact_language_changed")
 }
 
 func TestSigning(t *testing.T) {

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -737,21 +737,86 @@ func (h *handler) sendWhatsAppMsg(ctx context.Context, msg courier.MsgOut, res *
 }
 
 // WhatsApp displays typing indicators for up to 25 seconds or until a reply is sent. Messenger and
-// Instagram do support typing indicators but via sender actions - not yet implemented.
+// Instagram display them for up to 20 seconds and are the rare platforms with an explicit off action.
 var sendableEvents = map[models.ChannelType]map[string]time.Duration{
+	"FBA": {events.TypeTypingStarted: 15 * time.Second, events.TypeTypingStopped: 0},
+	"IG":  {events.TypeTypingStarted: 15 * time.Second, events.TypeTypingStopped: 0},
 	"WAC": {events.TypeTypingStarted: 20 * time.Second},
 }
 
-// SendableEvents declares support for typing indicators on WhatsApp channels
+// SendableEvents declares support for typing indicators
 func (h *handler) SendableEvents(courier.Channel) map[string]time.Duration {
 	return sendableEvents[h.ChannelType()]
 }
 
-// SendEvent sends a typing started event as a typing indicator, which WhatsApp implements as marking
+func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event events.Event, clog *courier.ChannelLog) error {
+	if h.ChannelType() == "FBA" || h.ChannelType() == "IG" {
+		return h.sendFacebookInstagramEvent(ctx, ch, event, clog)
+	} else if h.ChannelType() == "WAC" {
+		return h.sendWhatsAppEvent(ctx, ch, event, clog)
+	}
+
+	return fmt.Errorf("unsupported channel type")
+}
+
+// Sends typing started/stopped events as typing_on/typing_off sender actions.
+// See https://developers.facebook.com/docs/messenger-platform/send-messages/sender-actions
+func (h *handler) sendFacebookInstagramEvent(ctx context.Context, ch courier.Channel, event events.Event, clog *courier.ChannelLog) error {
+	var urn urns.URN
+	var action string
+	switch typed := event.(type) {
+	case *events.TypingStarted:
+		urn, action = typed.URN, "typing_on"
+	case *events.TypingStopped:
+		urn, action = typed.URN, "typing_off"
+	default:
+		return fmt.Errorf("unsupported event type: %s", event.Type())
+	}
+
+	accessToken := ch.StringConfigForKey(models.ConfigAuthToken, "")
+	if accessToken == "" {
+		return courier.ErrChannelConfig
+	}
+
+	// sender action requests can only contain the recipient and the action
+	payload := &struct {
+		Recipient struct {
+			ID string `json:"id"`
+		} `json:"recipient"`
+		SenderAction string `json:"sender_action"`
+	}{SenderAction: action}
+	payload.Recipient.ID = urn.Path()
+
+	msgURL, _ := url.Parse(sendURL)
+	query := url.Values{}
+	query.Set("access_token", accessToken)
+	msgURL.RawQuery = query.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, msgURL.String(), bytes.NewReader(jsonx.MustMarshal(payload)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, respBody, err := h.RequestHTTP(req, clog)
+	if err != nil || resp.StatusCode/100 == 5 {
+		return courier.ErrConnectionFailed
+	}
+
+	respPayload := &messenger.SendResponse{}
+	if err := json.Unmarshal(respBody, respPayload); err != nil || resp.StatusCode/100 != 2 || respPayload.Error.Code != 0 {
+		return courier.ErrResponseStatus
+	}
+
+	return nil
+}
+
+// Sends a typing started event as a typing indicator, which WhatsApp implements as marking
 // the referenced incoming message as read with a typing_indicator field - so it also marks messages as
 // read, which is acceptable because we only send one when a reply is being composed.
 // See https://developers.facebook.com/docs/whatsapp/cloud-api/typing-indicators
-func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event events.Event, clog *courier.ChannelLog) error {
+func (h *handler) sendWhatsAppEvent(ctx context.Context, ch courier.Channel, event events.Event, clog *courier.ChannelLog) error {
 	typing, ok := event.(*events.TypingStarted)
 	if !ok {
 		return fmt.Errorf("unsupported event type: %s", event.Type())

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -990,9 +990,8 @@ func TestWhatsAppSendEvent(t *testing.T) {
 		},
 	})
 
-	// typing indicators are supported on WhatsApp channels, but not Facebook/Instagram
+	// typing indicators are supported on WhatsApp channels, but there's no explicit stop
 	assert.Equal(t, map[string]time.Duration{events.TypeTypingStarted: 20 * time.Second}, h.SendableEvents(channel))
-	assert.Nil(t, newHandler("FBA", "Facebook").(*handler).SendableEvents(channel))
 
 	channelRef := assets.NewChannelReference("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WhatsApp")
 	typing := events.NewTypingStarted(events.DirectionOutgoing, channelRef, "whatsapp:5511987654321", "wamid.HBgMNTU3")

--- a/test/handler.go
+++ b/test/handler.go
@@ -92,8 +92,12 @@ func (h *mockHandler) SendEvent(ctx context.Context, ch courier.Channel, event e
 	return nil
 }
 
-// SendableEvents declares support for typing indicators with a 10 second resend interval
-func (h *mockHandler) SendableEvents(courier.Channel) map[string]time.Duration {
+// SendableEvents declares support for typing started with a 10 second resend interval, plus typing
+// stopped for channels configured with supports_stop - so tests can cover both capability cases
+func (h *mockHandler) SendableEvents(ch courier.Channel) map[string]time.Duration {
+	if ch.BoolConfigForKey("supports_stop", false) {
+		return map[string]time.Duration{events.TypeTypingStarted: 10 * time.Second, events.TypeTypingStopped: 0}
+	}
 	return map[string]time.Duration{events.TypeTypingStarted: 10 * time.Second}
 }
 


### PR DESCRIPTION
FBA and IG channels now declare and send typing events:

- `typing_started` is sent as a `typing_on` sender action, with a 15 second resend interval (Messenger/Instagram display the indicator for up to 20 seconds)
- `typing_stopped` is sent as a `typing_off` sender action as a one-shot - these are among the few platforms with an explicit off action

Since a stop can now actually hide the indicator, the event send endpoint clears the `typing_started` throttle for the conversation when a `typing_stopped` is sent, so a new typing session starting within the interval isn't suppressed.

Sender action requests use a dedicated payload because they may only contain `recipient` and `sender_action` (https://developers.facebook.com/docs/messenger-platform/send-messages/sender-actions).