### PR TITLE
Add typing event support to 360Dialog and Twilio WhatsApp channels

### DIFF
--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/buger/jsonparser"
 	"github.com/nyaruka/courier/v26"
@@ -18,6 +19,7 @@ import (
 	"github.com/nyaruka/courier/v26/handlers/meta/whatsapp"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/core/events"
 )
 
 const (
@@ -299,6 +301,59 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		} else {
 			res.SetNewURN(userIDURN)
 		}
+	}
+
+	return nil
+}
+
+// WhatsApp displays typing indicators for up to 25 seconds or until a reply is sent
+var sendableEvents = map[string]time.Duration{events.TypeTypingStarted: 20 * time.Second}
+
+// SendableEvents declares support for typing indicators
+func (h *handler) SendableEvents(courier.Channel) map[string]time.Duration {
+	return sendableEvents
+}
+
+// SendEvent sends a typing started event as a typing indicator, which WhatsApp implements as marking
+// the referenced incoming message as read with a typing_indicator field - so it also marks messages as
+// read, which is acceptable because we only send one when a reply is being composed.
+// See https://developers.facebook.com/docs/whatsapp/cloud-api/typing-indicators
+func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event events.Event, clog *courier.ChannelLog) error {
+	typing, ok := event.(*events.TypingStarted)
+	if !ok {
+		return fmt.Errorf("unsupported event type: %s", event.Type())
+	}
+	if typing.MsgExternalID == "" {
+		return fmt.Errorf("%s event requires msg_external_id", event.Type())
+	}
+
+	accessToken := ch.StringConfigForKey(models.ConfigAuthToken, "")
+	baseURL, err := url.Parse(ch.StringConfigForKey(models.ConfigBaseURL, ""))
+	if accessToken == "" || err != nil {
+		return courier.ErrChannelConfig
+	}
+	sendURL, _ := baseURL.Parse("/messages")
+
+	payload := whatsapp.NewTypingRequest(typing.MsgExternalID)
+
+	req, err := http.NewRequest(http.MethodPost, sendURL.String(), bytes.NewReader(jsonx.MustMarshal(payload)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set(d3AuthorizationKey, accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, respBody, err := h.RequestHTTP(req, clog)
+	if err != nil || resp.StatusCode/100 == 5 {
+		return courier.ErrConnectionFailed
+	}
+
+	response := &struct {
+		Success bool `json:"success"`
+	}{}
+	if err := json.Unmarshal(respBody, response); err != nil || resp.StatusCode/100 != 2 || !response.Success {
+		return courier.ErrResponseStatus
 	}
 
 	return nil

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -12,10 +12,13 @@ import (
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/utils/clogs"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/core/events"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -921,4 +924,60 @@ func TestOutgoing(t *testing.T) {
 	checkRedacted := []string{"the-auth-token"}
 
 	RunOutgoingTestCases(t, ChannelWAC, newWAHandler(models.ChannelType("D3C"), "360Dialog"), SendTestCasesD3C, checkRedacted, nil)
+}
+
+func TestSendEvent(t *testing.T) {
+	channel := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "D3C", "12345_ID", "", []string{urns.WhatsApp.Prefix}, map[string]any{
+		"auth_token": "the-auth-token",
+		"base_url":   "https://waba-v2.360dialog.io",
+	})
+
+	mb := test.NewMockBackend()
+	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), mb)
+
+	h := newWAHandler(models.ChannelType("D3C"), "360Dialog").(*handler)
+	h.Initialize(s)
+
+	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"https://waba-v2.360dialog.io/messages": {
+			httpx.NewMockResponse(200, nil, []byte(`{"success": true}`)),
+			httpx.NewMockResponse(400, nil, []byte(`{"error": {"message": "(#131009) Parameter value is not valid", "code": 131009}}`)),
+			httpx.MockConnectionError,
+		},
+	})
+
+	// typing indicators are supported but there's no explicit stop
+	assert.Equal(t, map[string]time.Duration{events.TypeTypingStarted: 20 * time.Second}, h.SendableEvents(channel))
+
+	channelRef := assets.NewChannelReference("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "360Dialog")
+	typing := events.NewTypingStarted(events.DirectionOutgoing, channelRef, "whatsapp:250788123123", "wamid.HBgMNTU3")
+
+	// a typing indicator is sent as a mark-as-read call with a typing_indicator field
+	clog := courier.NewChannelLogForEventSend(channel, nil)
+	err := h.SendEvent(context.Background(), channel, typing, clog)
+	assert.NoError(t, err)
+	assert.Len(t, clog.HttpLogs, 1)
+	assert.Equal(t, "https://waba-v2.360dialog.io/messages", clog.HttpLogs[0].URL)
+	assert.Contains(t, clog.HttpLogs[0].Request, `{"messaging_product":"whatsapp","status":"read","message_id":"wamid.HBgMNTU3","typing_indicator":{"type":"text"}}`)
+
+	// an error response is a response error
+	err = h.SendEvent(context.Background(), channel, typing, clog)
+	assert.Equal(t, courier.ErrResponseStatus, err)
+
+	// as is a connection error
+	err = h.SendEvent(context.Background(), channel, typing, clog)
+	assert.Equal(t, courier.ErrConnectionFailed, err)
+
+	// an event without a msg external ID can't be sent
+	err = h.SendEvent(context.Background(), channel, events.NewTypingStarted(events.DirectionOutgoing, channelRef, "whatsapp:250788123123", ""), clog)
+	assert.ErrorContains(t, err, "requires msg_external_id")
+
+	// a channel without an auth token config can't send
+	noAuth := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "D3C", "12345_ID", "", []string{urns.WhatsApp.Prefix}, map[string]any{"base_url": "https://waba-v2.360dialog.io"})
+	err = h.SendEvent(context.Background(), noAuth, typing, clog)
+	assert.Equal(t, courier.ErrChannelConfig, err)
+
+	// nor can an event type the handler doesn't declare support for
+	err = h.SendEvent(context.Background(), channel, events.NewTypingStopped(events.DirectionOutgoing, channelRef, "whatsapp:250788123123", ""), clog)
+	assert.ErrorContains(t, err, "unsupported event type: typing_stopped")
 }

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -825,20 +825,7 @@ func (h *handler) sendWhatsAppEvent(ctx context.Context, ch courier.Channel, eve
 		return fmt.Errorf("%s event requires msg_external_id", event.Type())
 	}
 
-	type typingIndicator struct {
-		Type string `json:"type"`
-	}
-	payload := &struct {
-		MessagingProduct string          `json:"messaging_product"`
-		Status           string          `json:"status"`
-		MessageID        string          `json:"message_id"`
-		TypingIndicator  typingIndicator `json:"typing_indicator"`
-	}{
-		MessagingProduct: "whatsapp",
-		Status:           "read",
-		MessageID:        typing.MsgExternalID,
-		TypingIndicator:  typingIndicator{Type: "text"},
-	}
+	payload := whatsapp.NewTypingRequest(typing.MsgExternalID)
 
 	base, _ := url.Parse(graphURL)
 	path, _ := url.Parse(fmt.Sprintf("/%s/messages", ch.Address()))

--- a/handlers/meta/whatsapp/api.go
+++ b/handlers/meta/whatsapp/api.go
@@ -349,6 +349,24 @@ type SendResponse struct {
 	} `json:"error"`
 }
 
+// A request to mark an incoming message as read and show a typing indicator, which lasts until a reply
+// is sent or 25 seconds pass. See https://developers.facebook.com/docs/whatsapp/cloud-api/typing-indicators
+type TypingRequest struct {
+	MessagingProduct string `json:"messaging_product"`
+	Status           string `json:"status"`
+	MessageID        string `json:"message_id"`
+	TypingIndicator  struct {
+		Type string `json:"type"`
+	} `json:"typing_indicator"`
+}
+
+// NewTypingRequest creates a typing indicator request referencing the given incoming message
+func NewTypingRequest(msgID string) *TypingRequest {
+	r := &TypingRequest{MessagingProduct: "whatsapp", Status: "read", MessageID: msgID}
+	r.TypingIndicator.Type = "text"
+	return r
+}
+
 // UserID returns the user_id from the first contact in the response if present.
 func (r *SendResponse) UserID() string {
 	if len(r.Contacts) > 0 && r.Contacts[0].UserID != "" {

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha1"
 	_ "embed"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/buger/jsonparser"
 	"github.com/nyaruka/courier/v26"
@@ -30,6 +32,7 @@ import (
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
+	"github.com/nyaruka/goflow/core/events"
 )
 
 const (
@@ -47,6 +50,8 @@ const (
 var (
 	maxMsgLength  = 1600
 	twilioBaseURL = "https://api.twilio.com"
+
+	typingIndicatorURL = "https://messaging.twilio.com/v3/Indicators/Typing.json"
 
 	//go:embed errors.json
 	errorCodes []byte
@@ -423,6 +428,63 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 			}
 		}
 
+	}
+
+	return nil
+}
+
+// WhatsApp displays typing indicators for up to 25 seconds or until a reply is sent - other channel
+// types have no typing indicator support
+var sendableEvents = map[models.ChannelType]map[string]time.Duration{
+	"TWA": {events.TypeTypingStarted: 20 * time.Second},
+}
+
+// SendableEvents declares support for typing indicators on WhatsApp channels
+func (h *handler) SendableEvents(courier.Channel) map[string]time.Duration {
+	return sendableEvents[h.ChannelType()]
+}
+
+// SendEvent sends a typing started event as a typing indicator, which Twilio implements as marking the
+// referenced incoming message as read and displaying an indicator until a reply is sent.
+// See https://www.twilio.com/docs/whatsapp/api/typing-indicators-resource
+func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event events.Event, clog *courier.ChannelLog) error {
+	typing, ok := event.(*events.TypingStarted)
+	if !ok {
+		return fmt.Errorf("unsupported event type: %s", event.Type())
+	}
+	if typing.MsgExternalID == "" {
+		return fmt.Errorf("%s event requires msg_external_id", event.Type())
+	}
+
+	accountSID := ch.StringConfigForKey(configAccountSID, "")
+	accountToken := ch.StringConfigForKey(models.ConfigAuthToken, "")
+	if accountSID == "" || accountToken == "" {
+		return courier.ErrChannelConfig
+	}
+
+	payload := &struct {
+		Channel   string `json:"channel"`
+		MessageID string `json:"messageId"`
+	}{Channel: "WHATSAPP", MessageID: typing.MsgExternalID}
+
+	req, err := http.NewRequest(http.MethodPost, typingIndicatorURL, bytes.NewReader(jsonx.MustMarshal(payload)))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(accountSID, accountToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, respBody, err := h.RequestHTTP(req, clog)
+	if err != nil || resp.StatusCode/100 == 5 {
+		return courier.ErrConnectionFailed
+	}
+
+	response := &struct {
+		Success bool `json:"success"`
+	}{}
+	if err := json.Unmarshal(respBody, response); err != nil || resp.StatusCode/100 != 2 || !response.Success {
+		return courier.ErrResponseStatus
 	}
 
 	return nil

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -5,16 +5,20 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"fmt"
 
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/utils/clogs"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/core/events"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1444,4 +1448,64 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	req, _ = swHandler.BuildAttachmentRequest(context.Background(), swChannel, "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "", req.Header.Get("Authorization"))
+}
+
+func TestSendEvent(t *testing.T) {
+	channel := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "TWA", "+12065551212", "US",
+		[]string{urns.WhatsApp.Prefix},
+		map[string]any{
+			configAccountSID:       "accountSID",
+			models.ConfigAuthToken: "authToken",
+		},
+	)
+
+	mb := test.NewMockBackend()
+	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), mb)
+
+	h := newTWIMLHandler("TWA", "Twilio Whatsapp", true).(*handler)
+	h.Initialize(s)
+
+	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"https://messaging.twilio.com/v3/Indicators/Typing.json": {
+			httpx.NewMockResponse(200, nil, []byte(`{"success": true}`)),
+			httpx.NewMockResponse(400, nil, []byte(`{"code": 21211, "message": "Invalid message SID"}`)),
+			httpx.MockConnectionError,
+		},
+	})
+
+	// typing indicators are supported on Twilio WhatsApp channels but no other TWIML channel types
+	assert.Equal(t, map[string]time.Duration{events.TypeTypingStarted: 20 * time.Second}, h.SendableEvents(channel))
+	assert.Nil(t, newTWIMLHandler("T", "Twilio", true).(*handler).SendableEvents(channel))
+
+	channelRef := assets.NewChannelReference("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "Twilio Whatsapp")
+	typing := events.NewTypingStarted(events.DirectionOutgoing, channelRef, "whatsapp:12065551212", "SMabcdef1234567890abcdef1234567890")
+
+	// a typing indicator is sent as a typing indicators resource call referencing the incoming message
+	clog := courier.NewChannelLogForEventSend(channel, nil)
+	err := h.SendEvent(context.Background(), channel, typing, clog)
+	assert.NoError(t, err)
+	assert.Len(t, clog.HttpLogs, 1)
+	assert.Equal(t, "https://messaging.twilio.com/v3/Indicators/Typing.json", clog.HttpLogs[0].URL)
+	assert.Contains(t, clog.HttpLogs[0].Request, `{"channel":"WHATSAPP","messageId":"SMabcdef1234567890abcdef1234567890"}`)
+
+	// an error response is a response error
+	err = h.SendEvent(context.Background(), channel, typing, clog)
+	assert.Equal(t, courier.ErrResponseStatus, err)
+
+	// as is a connection error
+	err = h.SendEvent(context.Background(), channel, typing, clog)
+	assert.Equal(t, courier.ErrConnectionFailed, err)
+
+	// an event without a msg external ID can't be sent
+	err = h.SendEvent(context.Background(), channel, events.NewTypingStarted(events.DirectionOutgoing, channelRef, "whatsapp:12065551212", ""), clog)
+	assert.ErrorContains(t, err, "requires msg_external_id")
+
+	// a channel without complete auth config can't send
+	noAuth := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "TWA", "+12065551212", "US", []string{urns.WhatsApp.Prefix}, map[string]any{})
+	err = h.SendEvent(context.Background(), noAuth, typing, clog)
+	assert.Equal(t, courier.ErrChannelConfig, err)
+
+	// nor can an event type the handler doesn't declare support for
+	err = h.SendEvent(context.Background(), channel, events.NewTypingStopped(events.DirectionOutgoing, channelRef, "whatsapp:12065551212", ""), clog)
+	assert.ErrorContains(t, err, "unsupported event type: typing_stopped")
 }


### PR DESCRIPTION
D3C and TWA channels now declare and send `typing_started` events (20 second resend interval, both platforms display the indicator for up to 25 seconds or until a reply is sent, with no explicit stop):

- D3C uses the same WhatsApp Cloud API mark-as-read + `typing_indicator` call as WAC, sent to the channel's configured base URL - the payload is now a shared `whatsapp.TypingRequest` used by both handlers
- TWA uses Twilio's [Typing Indicators resource](https://www.twilio.com/docs/whatsapp/api/typing-indicators-resource) (public beta), referencing the inbound message SID - only the TWA channel type declares support, other TWIML types are unchanged

As with WAC, both platforms mark the referenced incoming message as read as a side effect, which is acceptable since we only send typing indicators while a reply is being composed.