### PR TITLE
Add typing event support to LINE, VK and WeChat channels

### DIFF
--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -19,12 +19,15 @@ import (
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/core/events"
 )
 
 var (
 	replySendURL = "https://api.line.me/v2/bot/message/reply"
 	pushSendURL  = "https://api.line.me/v2/bot/message/push"
+	loadingURL   = "https://api.line.me/v2/bot/chat/loading/start"
 	mediaDataURL = "https://api-data.line.me/v2/bot/message"
 	maxMsgLength = 2000
 	maxMsgSend   = 5
@@ -282,6 +285,52 @@ type mtPayload struct {
 
 type mtResponse struct {
 	Message string `json:"message"`
+}
+
+// LINE displays its loading indicator for the requested number of seconds or until a reply is sent,
+// and only supports it in 1:1 chats
+var sendableEvents = map[string]time.Duration{events.TypeTypingStarted: 15 * time.Second}
+
+// SendableEvents declares support for typing indicators
+func (h *handler) SendableEvents(courier.Channel) map[string]time.Duration {
+	return sendableEvents
+}
+
+// SendEvent sends a typing started event to the contact as a loading indicator, see
+// https://developers.line.biz/en/docs/messaging-api/use-loading-indicator/
+func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event events.Event, clog *courier.ChannelLog) error {
+	typing, ok := event.(*events.TypingStarted)
+	if !ok {
+		return fmt.Errorf("unsupported event type: %s", event.Type())
+	}
+
+	authToken := ch.StringConfigForKey(models.ConfigAuthToken, "")
+	if authToken == "" {
+		return courier.ErrChannelConfig
+	}
+
+	payload := &struct {
+		ChatID         string `json:"chatId"`
+		LoadingSeconds int    `json:"loadingSeconds"`
+	}{ChatID: typing.URN.Path(), LoadingSeconds: 20}
+
+	req, err := http.NewRequest(http.MethodPost, loadingURL, bytes.NewReader(jsonx.MustMarshal(payload)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
+
+	resp, _, err := h.RequestHTTP(req, clog)
+	if err != nil || resp.StatusCode/100 == 5 {
+		return courier.ErrConnectionFailed
+	}
+	if resp.StatusCode/100 != 2 {
+		return courier.ErrResponseStatus
+	}
+
+	return nil
 }
 
 func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.SendResult, clog *courier.ChannelLog) error {

--- a/handlers/line/handler_test.go
+++ b/handlers/line/handler_test.go
@@ -9,9 +9,12 @@ import (
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/core/events"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -623,4 +626,52 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	req, _ := lnHandler.BuildAttachmentRequest(context.Background(), testChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer the-auth-token", req.Header.Get("Authorization"))
+}
+
+func TestSendEvent(t *testing.T) {
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "LN", "2020", "US", []string{urns.Line.Prefix}, map[string]any{"auth_token": "AccessToken"})
+
+	mb := test.NewMockBackend()
+	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), mb)
+	h := newHandler().(*handler)
+	h.Initialize(s)
+
+	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"https://api.line.me/v2/bot/chat/loading/start": {
+			httpx.NewMockResponse(202, nil, []byte(`{}`)),
+			httpx.NewMockResponse(400, nil, []byte(`{"message": "The property, 'chatId', in the request body is invalid"}`)),
+			httpx.MockConnectionError,
+		},
+	})
+
+	// typing indicators are supported but there's no explicit stop
+	assert.Equal(t, map[string]time.Duration{events.TypeTypingStarted: 15 * time.Second}, h.SendableEvents(ch))
+
+	channelRef := assets.NewChannelReference("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "LINE")
+	typing := events.NewTypingStarted(events.DirectionOutgoing, channelRef, "line:uabcdefghij", "")
+
+	// a typing started event is sent as a loading indicator
+	clog := courier.NewChannelLogForEventSend(ch, nil)
+	err := h.SendEvent(context.Background(), ch, typing, clog)
+	assert.NoError(t, err)
+	assert.Len(t, clog.HttpLogs, 1)
+	assert.Equal(t, "https://api.line.me/v2/bot/chat/loading/start", clog.HttpLogs[0].URL)
+	assert.Contains(t, clog.HttpLogs[0].Request, `{"chatId":"uabcdefghij","loadingSeconds":20}`)
+
+	// an error response is a response error
+	err = h.SendEvent(context.Background(), ch, typing, clog)
+	assert.Equal(t, courier.ErrResponseStatus, err)
+
+	// as is a connection error
+	err = h.SendEvent(context.Background(), ch, typing, clog)
+	assert.Equal(t, courier.ErrConnectionFailed, err)
+
+	// a channel without an auth token config can't send
+	noAuth := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "LN", "2020", "US", []string{urns.Line.Prefix}, nil)
+	err = h.SendEvent(context.Background(), noAuth, typing, clog)
+	assert.Equal(t, courier.ErrChannelConfig, err)
+
+	// nor can an event type the handler doesn't declare support for
+	err = h.SendEvent(context.Background(), ch, events.NewTypingStopped(events.DirectionOutgoing, channelRef, "line:uabcdefghij", ""), clog)
+	assert.ErrorContains(t, err, "unsupported event type: typing_stopped")
 }

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/core/events"
 )
 
 var (
@@ -50,6 +51,10 @@ var (
 	// get user
 	actionGetUser = "/users.get.json"
 	paramUserIds  = "user_ids"
+
+	// set activity
+	actionSetActivity = "/messages.setActivity.json"
+	paramType         = "type"
 
 	// send message
 	actionSendMessage = "/messages.send.json"
@@ -373,6 +378,52 @@ func takeFirstAttachmentUrl(payload moNewMessagePayload) string {
 		}
 	}
 	return ""
+}
+
+// VK displays typing activity for up to 10 seconds or until a message is sent
+var sendableEvents = map[string]time.Duration{events.TypeTypingStarted: 8 * time.Second}
+
+// SendableEvents declares support for typing indicators
+func (h *handler) SendableEvents(courier.Channel) map[string]time.Duration {
+	return sendableEvents
+}
+
+// SendEvent sends a typing started event to the contact as a typing activity, see
+// https://dev.vk.com/en/method/messages.setActivity
+func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event events.Event, clog *courier.ChannelLog) error {
+	typing, ok := event.(*events.TypingStarted)
+	if !ok {
+		return fmt.Errorf("unsupported event type: %s", event.Type())
+	}
+
+	if ch.StringConfigForKey(models.ConfigAuthToken, "") == "" {
+		return courier.ErrChannelConfig
+	}
+
+	params := buildApiBaseParams(ch)
+	params.Set(paramUserId, typing.URN.Path())
+	params.Set(paramType, "typing")
+
+	req, err := http.NewRequest(http.MethodPost, apiBaseURL+actionSetActivity, nil)
+	if err != nil {
+		return err
+	}
+	req.URL.RawQuery = params.Encode()
+
+	resp, respBody, err := h.RequestHTTP(req, clog)
+	if err != nil || resp.StatusCode/100 == 5 {
+		return courier.ErrConnectionFailed
+	}
+	if resp.StatusCode/100 != 2 {
+		return courier.ErrResponseStatus
+	}
+
+	// VK reports errors in a 200 response, success is {"response": 1}
+	if _, err := jsonparser.GetInt(respBody, responseOutgoingMessageKey); err != nil {
+		return courier.ErrResponseStatus
+	}
+
+	return nil
 }
 
 func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.SendResult, clog *courier.ChannelLog) error {

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/core/events"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nyaruka/courier/v26"
@@ -524,4 +526,58 @@ var outgoingCases = []OutgoingTestCase{
 
 func TestOutgoing(t *testing.T) {
 	RunOutgoingTestCases(t, testChannels[0], newHandler(), outgoingCases, []string{"token123xyz", "abc123xyz"}, nil)
+}
+
+func TestSendEvent(t *testing.T) {
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "VK", "2020", "US", []string{urns.VK.Prefix}, map[string]any{models.ConfigAuthToken: "token123xyz"})
+
+	mb := test.NewMockBackend()
+	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()), mb)
+	h := newHandler().(*handler)
+	h.Initialize(s)
+
+	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"https://api.vk.com/method/messages.setActivity.json*": {
+			httpx.NewMockResponse(200, nil, []byte(`{"response": 1}`)),
+			httpx.NewMockResponse(200, nil, []byte(`{"error": {"error_code": 5, "error_msg": "User authorization failed"}}`)),
+			httpx.NewMockResponse(400, nil, []byte(`bad request`)),
+			httpx.MockConnectionError,
+		},
+	})
+
+	// typing indicators are supported but there's no explicit stop
+	assert.Equal(t, map[string]time.Duration{events.TypeTypingStarted: 8 * time.Second}, h.SendableEvents(ch))
+
+	channelRef := assets.NewChannelReference("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "VK")
+	typing := events.NewTypingStarted(events.DirectionOutgoing, channelRef, "vk:123456789", "")
+
+	// a typing started event is sent as a typing activity
+	clog := courier.NewChannelLogForEventSend(ch, nil)
+	err := h.SendEvent(context.Background(), ch, typing, clog)
+	assert.NoError(t, err)
+	assert.Len(t, clog.HttpLogs, 1)
+	assert.Contains(t, clog.HttpLogs[0].URL, "https://api.vk.com/method/messages.setActivity.json")
+	assert.Contains(t, clog.HttpLogs[0].URL, "type=typing")
+	assert.Contains(t, clog.HttpLogs[0].URL, "user_id=123456789")
+
+	// a VK error in a 200 response is a response error
+	err = h.SendEvent(context.Background(), ch, typing, clog)
+	assert.Equal(t, courier.ErrResponseStatus, err)
+
+	// as is a non-2XX response
+	err = h.SendEvent(context.Background(), ch, typing, clog)
+	assert.Equal(t, courier.ErrResponseStatus, err)
+
+	// and a connection error is a connection error
+	err = h.SendEvent(context.Background(), ch, typing, clog)
+	assert.Equal(t, courier.ErrConnectionFailed, err)
+
+	// a channel without an auth token config can't send
+	noAuth := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "VK", "2020", "US", []string{urns.VK.Prefix}, nil)
+	err = h.SendEvent(context.Background(), noAuth, typing, clog)
+	assert.Equal(t, courier.ErrChannelConfig, err)
+
+	// nor can an event type the handler doesn't declare support for
+	err = h.SendEvent(context.Background(), ch, events.NewTypingStopped(events.DirectionOutgoing, channelRef, "vk:123456789", ""), clog)
+	assert.ErrorContains(t, err, "unsupported event type: typing_stopped")
 }

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/core/events"
 )
 
 var (
@@ -211,6 +212,74 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		if err != nil || resp.StatusCode/100 == 5 {
 			return courier.ErrConnectionFailed
 		}
+	}
+
+	return nil
+}
+
+// WeChat displays typing status for up to 15 seconds or until a reply is sent, and has an explicit
+// cancel command
+var sendableEvents = map[string]time.Duration{
+	events.TypeTypingStarted: 12 * time.Second,
+	events.TypeTypingStopped: 0,
+}
+
+// SendableEvents declares support for typing indicators
+func (h *handler) SendableEvents(courier.Channel) map[string]time.Duration {
+	return sendableEvents
+}
+
+// SendEvent sends typing started/stopped events as Typing/CancelTyping customer service commands, see
+// https://developers.weixin.qq.com/doc/offiaccount/Message_Management/Service_Center_messages.html
+func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event events.Event, clog *courier.ChannelLog) error {
+	var urn urns.URN
+	var command string
+	switch typed := event.(type) {
+	case *events.TypingStarted:
+		urn, command = typed.URN, "Typing"
+	case *events.TypingStopped:
+		urn, command = typed.URN, "CancelTyping"
+	default:
+		return fmt.Errorf("unsupported event type: %s", event.Type())
+	}
+
+	accessToken, err := h.getAccessToken(ch, clog)
+	if err != nil {
+		return err
+	}
+
+	form := url.Values{
+		"access_token": []string{accessToken},
+	}
+	typingURL, _ := url.Parse(fmt.Sprintf("%s/%s", sendURL, "message/custom/typing"))
+	typingURL.RawQuery = form.Encode()
+
+	payload := &struct {
+		ToUser  string `json:"touser"`
+		Command string `json:"command"`
+	}{ToUser: urn.Path(), Command: command}
+
+	requestBody := &bytes.Buffer{}
+	json.NewEncoder(requestBody).Encode(payload)
+
+	req, err := http.NewRequest(http.MethodPost, typingURL.String(), requestBody)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, respBody, err := h.RequestHTTP(req, clog)
+	if err != nil || resp.StatusCode/100 == 5 {
+		return courier.ErrConnectionFailed
+	}
+	if resp.StatusCode/100 != 2 {
+		return courier.ErrResponseStatus
+	}
+
+	// WeChat reports errors in a 200 response, success is errcode 0
+	if errcode, err := jsonparser.GetInt(respBody, "errcode"); err != nil || errcode != 0 {
+		return courier.ErrResponseStatus
 	}
 
 	return nil

--- a/handlers/wechat/handler_test.go
+++ b/handlers/wechat/handler_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/core/events"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -384,4 +386,69 @@ func TestOutgoing(t *testing.T) {
 	maxMsgLength = 160
 	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WC", "2020", "US", []string{urns.WeChat.Prefix}, map[string]any{configAppSecret: "secret123", configAppID: "app-id"})
 	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"secret123"}, setupBackend)
+}
+
+func TestSendEvent(t *testing.T) {
+	// other tests repoint sendURL at mock servers, so pin it for this test
+	defer func(u string) { sendURL = u }(sendURL)
+	sendURL = "https://api.weixin.qq.com/cgi-bin"
+
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WC", "2020", "US", []string{urns.WeChat.Prefix}, map[string]any{configAppSecret: "secret123", configAppID: "app-id"})
+
+	mb := test.NewMockBackend()
+
+	// ensure there's a cached access token
+	rc := mb.RedisPool().Get()
+	defer rc.Close()
+	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
+
+	s := newServer(mb)
+	h := newHandler().(*handler)
+	h.Initialize(s)
+
+	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"https://api.weixin.qq.com/cgi-bin/message/custom/typing*": {
+			httpx.NewMockResponse(200, nil, []byte(`{"errcode": 0, "errmsg": "ok"}`)),
+			httpx.NewMockResponse(200, nil, []byte(`{"errcode": 0, "errmsg": "ok"}`)),
+			httpx.NewMockResponse(200, nil, []byte(`{"errcode": 45015, "errmsg": "response out of time limit"}`)),
+			httpx.NewMockResponse(400, nil, []byte(`bad request`)),
+			httpx.MockConnectionError,
+		},
+	})
+
+	// typing events are supported including explicit stop
+	assert.Equal(t, map[string]time.Duration{events.TypeTypingStarted: 12 * time.Second, events.TypeTypingStopped: 0}, h.SendableEvents(ch))
+
+	channelRef := assets.NewChannelReference("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WeChat")
+	typing := events.NewTypingStarted(events.DirectionOutgoing, channelRef, "wechat:abcde12345", "")
+
+	// a typing started event is sent as a Typing command
+	clog := courier.NewChannelLogForEventSend(ch, nil)
+	err := h.SendEvent(context.Background(), ch, typing, clog)
+	assert.NoError(t, err)
+	assert.Len(t, clog.HttpLogs, 1)
+	assert.Contains(t, clog.HttpLogs[0].URL, "https://api.weixin.qq.com/cgi-bin/message/custom/typing")
+	assert.Contains(t, clog.HttpLogs[0].Request, `{"touser":"abcde12345","command":"Typing"}`)
+
+	// and a typing stopped event as a CancelTyping command
+	err = h.SendEvent(context.Background(), ch, events.NewTypingStopped(events.DirectionOutgoing, channelRef, "wechat:abcde12345", ""), clog)
+	assert.NoError(t, err)
+	assert.Len(t, clog.HttpLogs, 2)
+	assert.Contains(t, clog.HttpLogs[1].Request, `{"touser":"abcde12345","command":"CancelTyping"}`)
+
+	// a WeChat error in a 200 response is a response error
+	err = h.SendEvent(context.Background(), ch, typing, clog)
+	assert.Equal(t, courier.ErrResponseStatus, err)
+
+	// as is a non-2XX response
+	err = h.SendEvent(context.Background(), ch, typing, clog)
+	assert.Equal(t, courier.ErrResponseStatus, err)
+
+	// and a connection error is a connection error
+	err = h.SendEvent(context.Background(), ch, typing, clog)
+	assert.Equal(t, courier.ErrConnectionFailed, err)
+
+	// an event type the handler doesn't declare support for can't be sent
+	err = h.SendEvent(context.Background(), ch, events.NewContactLanguageChanged("eng"), clog)
+	assert.ErrorContains(t, err, "unsupported event type: contact_language_changed")
 }


### PR DESCRIPTION
The last three channel types with platform support for outgoing typing indicators:

- **LN** sends `typing_started` as a [loading indicator](https://developers.line.biz/en/docs/messaging-api/use-loading-indicator/) with a 20 second TTL (LINE only supports these in 1:1 chats), 15 second resend interval
- **VK** sends `typing_started` as a `messages.setActivity` call with `type=typing` (~10 second display), 8 second resend interval - VK reports errors inside 200 responses so success requires the `response` key
- **WC** sends `typing_started`/`typing_stopped` as `Typing`/`CancelTyping` commands to the Official Account customer service typing endpoint (15 second display), 12 second resend interval with stop as a one-shot - like VK, success requires `errcode` 0 in the response

With this, every channel type whose platform supports outgoing typing indicators now implements them.