### PR TITLE
Install zstd before cache step so CI cache uses zstd compression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,13 @@ jobs:
           echo "gocache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
           echo "goversion=$(go env GOVERSION)" >> $GITHUB_OUTPUT
 
+      - name: Install zstd
+        # zstd must be installed before the cache step so actions/cache uses fast multithreaded
+        # zstd compression instead of falling back to single-threaded gzip
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends zstd
+
       - name: Cache Go modules and build cache
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
The Test job runs in a `golang:1.26-trixie` container which doesn't include the `zstd` binary, so `actions/cache` was silently falling back to single-threaded gzip for the multi-GB Go module/build cache. Installing `zstd` before the cache step lets `actions/cache` use fast multithreaded zstd compression for both restore and save.

Note: because `actions/cache` versions caches by compression method, the first run will be a full cache miss — a one-time cost.