### PR TITLE
Add support for WhatsApp flow (nfm) replies with structured payloads

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -1057,6 +1057,26 @@ func (ts *BackendTestSuite) TestWriteMsg() {
 		"new_contact":     contact.IsNew_,
 		"new_urn":         map[string]any{"value": "tel:+12065559999", "action": "append"},
 	})
+
+	testsuite.ResetValkey(ts.T(), ts.b.rt)
+
+	// check that msg with payload is queued with that field included
+	msg8 := ts.b.NewIncomingMsg(ctx, knChannel, urn, "hello with payload", "", clog).(*MsgIn)
+	msg8.WithPayload(json.RawMessage(`{"first_name": "Bob", "age": 32}`))
+	err = ts.b.WriteMsg(ctx, msg8, clog)
+	ts.NoError(err)
+
+	ts.assertQueuedContactTask(msg8.ContactID_, "msg_received", map[string]any{
+		"channel_id":      float64(10),
+		"msg_uuid":        string(msg8.UUID()),
+		"msg_external_id": msg8.ExternalID(),
+		"urn":             msg8.URN().String(),
+		"urn_id":          float64(msg8.ContactURNID_),
+		"text":            msg8.Text(),
+		"attachments":     nil,
+		"new_contact":     contact.IsNew_,
+		"payload":         map[string]any{"first_name": "Bob", "age": float64(32)},
+	})
 }
 
 func (ts *BackendTestSuite) TestWriteMsgWithAttachments() {

--- a/backends/rapidpro/mailroom.go
+++ b/backends/rapidpro/mailroom.go
@@ -29,6 +29,9 @@ func queueMsgHandling(ctx context.Context, rc redis.Conn, c *models.Contact, m *
 	if m.NewURN_ != nil {
 		body["new_urn"] = m.NewURN_
 	}
+	if len(m.Payload_) > 0 {
+		body["payload"] = m.Payload_
+	}
 
 	return queueMailroomTask(ctx, rc, "msg_received", m.OrgID_, m.ContactID_, body)
 }

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -29,6 +30,7 @@ type MsgIn struct {
 	ContactName_   string             `json:"contact_name"`
 	URNAuthTokens_ map[string]string  `json:"auth_tokens"`
 	NewURN_        *models.NewURNSpec `json:"new_urn,omitempty"`
+	Payload_       json.RawMessage    `json:"payload,omitempty"`
 
 	channel   *models.Channel
 	duplicate bool
@@ -51,6 +53,7 @@ func (m *MsgIn) WithNewURN(urn urns.URN, action models.NewURNAction) courier.Msg
 	m.NewURN_ = &models.NewURNSpec{Value: urn, Action: action}
 	return m
 }
+func (m *MsgIn) WithPayload(payload json.RawMessage) courier.MsgIn { m.Payload_ = payload; return m }
 
 func (m *MsgIn) hash() string {
 	hash := sha1.Sum([]byte(m.Text_ + "|" + strings.Join(m.Attachments_, "|")))

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -159,6 +160,8 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 
 				if payload := waMsg.ExtractPayload(); payload != nil {
 					event.WithPayload(payload)
+				} else if waMsg.Interactive.Type == "nfm_reply" && waMsg.Interactive.NFMReply.ResponseJSON != "" {
+					courier.LogRequestError(r, channel, errors.New("nfm_reply response_json is not a valid JSON object"))
 				}
 
 				// if we have a user_id, add it as secondary BSUID URN

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -157,6 +157,10 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					event.WithAttachment(mediaURL)
 				}
 
+				if payload := waMsg.ExtractPayload(); payload != nil {
+					event.WithPayload(payload)
+				}
+
 				// if we have a user_id, add it as secondary BSUID URN
 				if waMsg.FromUserID != "" {
 					userIDURN, urnErr := urns.New(urns.BSUID, waMsg.FromUserID)

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -278,6 +278,20 @@ var testCasesD3C = []IncomingTestCase{
 		ExpectedExternalID:    "external_id",
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
 	},
+	{
+		Label:                 "Receive Valid Interactive Flow Reply Message",
+		URL:                   d3CReceiveURL,
+		Data:                  string(test.ReadFile("../meta/testdata/wac/nfm_reply.json")),
+		ExpectedRespStatus:    200,
+		ExpectedBodyContains:  "Handled",
+		NoQueueErrorCheck:     true,
+		NoInvalidChannelCheck: true,
+		ExpectedMsgText:       Sp("Sent"),
+		ExpectedPayload:       `{"flow_token": "fl0w+t0k3n", "first_name": "Bob", "age": "32"}`,
+		ExpectedURN:           "whatsapp:5678",
+		ExpectedExternalID:    "external_id",
+		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
+	},
 }
 
 func buildMockD3MediaService(testChannels []courier.Channel, testCases []IncomingTestCase) *httptest.Server {

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -300,6 +300,10 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					event.WithAttachment(mediaURL)
 				}
 
+				if payload := waMsg.ExtractPayload(); payload != nil {
+					event.WithPayload(payload)
+				}
+
 				// if we have a user_id, add it as secondary BSUID URN
 				if waMsg.FromUserID != "" {
 					userIDURN, urnErr := urns.New(urns.BSUID, waMsg.FromUserID)

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -302,6 +302,8 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 
 				if payload := waMsg.ExtractPayload(); payload != nil {
 					event.WithPayload(payload)
+				} else if waMsg.Interactive.Type == "nfm_reply" && waMsg.Interactive.NFMReply.ResponseJSON != "" {
+					courier.LogRequestError(r, channel, errors.New("nfm_reply response_json is not a valid JSON object"))
 				}
 
 				// if we have a user_id, add it as secondary BSUID URN

--- a/handlers/meta/testdata/wac/nfm_reply.json
+++ b/handlers/meta/testdata/wac/nfm_reply.json
@@ -1,0 +1,44 @@
+{
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "8856996819413533",
+            "changes": [
+                {
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "metadata": {
+                            "display_phone_number": "+250 788 123 200",
+                            "phone_number_id": "12345"
+                        },
+                        "contacts": [
+                            {
+                                "profile": {
+                                    "name": "Kerry Fisher"
+                                },
+                                "wa_id": "5678"
+                            }
+                        ],
+                        "messages": [
+                            {
+                                "from": "5678",
+                                "id": "external_id",
+                                "interactive": {
+                                    "type": "nfm_reply",
+                                    "nfm_reply": {
+                                        "name": "flow",
+                                        "body": "Sent",
+                                        "response_json": "{\"flow_token\": \"fl0w+t0k3n\", \"first_name\": \"Bob\", \"age\": \"32\"}"
+                                    }
+                                },
+                                "timestamp": "1454119029",
+                                "type": "interactive"
+                            }
+                        ]
+                    },
+                    "field": "messages"
+                }
+            ]
+        }
+    ]
+}

--- a/handlers/meta/testdata/wac/nfm_reply_non_object.json
+++ b/handlers/meta/testdata/wac/nfm_reply_non_object.json
@@ -1,0 +1,44 @@
+{
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "8856996819413533",
+            "changes": [
+                {
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "metadata": {
+                            "display_phone_number": "+250 788 123 200",
+                            "phone_number_id": "12345"
+                        },
+                        "contacts": [
+                            {
+                                "profile": {
+                                    "name": "Kerry Fisher"
+                                },
+                                "wa_id": "5678"
+                            }
+                        ],
+                        "messages": [
+                            {
+                                "from": "5678",
+                                "id": "external_id",
+                                "interactive": {
+                                    "type": "nfm_reply",
+                                    "nfm_reply": {
+                                        "name": "flow",
+                                        "body": "Sent",
+                                        "response_json": "[\"not\", \"an\", \"object\"]"
+                                    }
+                                },
+                                "timestamp": "1454119029",
+                                "type": "interactive"
+                            }
+                        ]
+                    },
+                    "field": "messages"
+                }
+            ]
+        }
+    ]
+}

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -302,6 +302,21 @@ var whatsappIncomingTests = []IncomingTestCase{
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
 		PrepRequest:           addValidSignature,
 	},
+	{
+		Label:                 "Receive Valid Interactive Flow Reply Message",
+		URL:                   whatappReceiveURL,
+		Data:                  string(test.ReadFile("./testdata/wac/nfm_reply.json")),
+		ExpectedRespStatus:    200,
+		ExpectedBodyContains:  "Handled",
+		NoQueueErrorCheck:     true,
+		NoInvalidChannelCheck: true,
+		ExpectedMsgText:       Sp("Sent"),
+		ExpectedPayload:       `{"flow_token": "fl0w+t0k3n", "first_name": "Bob", "age": "32"}`,
+		ExpectedURN:           "whatsapp:5678",
+		ExpectedExternalID:    "external_id",
+		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
+		PrepRequest:           addValidSignature,
+	},
 }
 
 func TestWhatsAppIncoming(t *testing.T) {

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -317,6 +317,20 @@ var whatsappIncomingTests = []IncomingTestCase{
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
 		PrepRequest:           addValidSignature,
 	},
+	{
+		Label:                 "Receive Interactive Flow Reply Message With Non-Object Response JSON",
+		URL:                   whatappReceiveURL,
+		Data:                  string(test.ReadFile("./testdata/wac/nfm_reply_non_object.json")),
+		ExpectedRespStatus:    200,
+		ExpectedBodyContains:  "Handled",
+		NoQueueErrorCheck:     true,
+		NoInvalidChannelCheck: true,
+		ExpectedMsgText:       Sp("Sent"),
+		ExpectedURN:           "whatsapp:5678",
+		ExpectedExternalID:    "external_id",
+		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
+		PrepRequest:           addValidSignature,
+	},
 }
 
 func TestWhatsAppIncoming(t *testing.T) {

--- a/handlers/meta/whatsapp/api.go
+++ b/handlers/meta/whatsapp/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/nyaruka/courier/v26"
@@ -191,10 +192,13 @@ func (m WAMessage) ExtractTextAndMedia() (string, string, string, error) {
 }
 
 // ExtractPayload returns the structured payload of this message if it has one - i.e. for a flow (nfm) reply, the
-// response JSON - or nil if it doesn't.
+// response JSON if it's a valid JSON object - or nil if it doesn't.
 func (m WAMessage) ExtractPayload() json.RawMessage {
-	if m.Type == "interactive" && m.Interactive.Type == "nfm_reply" && json.Valid([]byte(m.Interactive.NFMReply.ResponseJSON)) {
-		return json.RawMessage(m.Interactive.NFMReply.ResponseJSON)
+	if m.Type == "interactive" && m.Interactive.Type == "nfm_reply" {
+		raw := strings.TrimSpace(m.Interactive.NFMReply.ResponseJSON)
+		if strings.HasPrefix(raw, "{") && json.Valid([]byte(raw)) {
+			return json.RawMessage(raw)
+		}
 	}
 	return nil
 }

--- a/handlers/meta/whatsapp/api.go
+++ b/handlers/meta/whatsapp/api.go
@@ -1,6 +1,7 @@
 package whatsapp
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -97,6 +98,11 @@ type WAMessage struct {
 			ID    string `json:"id"`
 			Title string `json:"title"`
 		} `json:"list_reply,omitempty"`
+		NFMReply struct {
+			Name         string `json:"name"`
+			Body         string `json:"body"`
+			ResponseJSON string `json:"response_json"`
+		} `json:"nfm_reply,omitempty"`
 	} `json:"interactive,omitempty"`
 	Errors []WAError `json:"errors"`
 }
@@ -173,6 +179,8 @@ func (m WAMessage) ExtractTextAndMedia() (string, string, string, error) {
 		text = m.Interactive.ButtonReply.Title
 	} else if m.Type == "interactive" && m.Interactive.Type == "list_reply" {
 		text = m.Interactive.ListReply.Title
+	} else if m.Type == "interactive" && m.Interactive.Type == "nfm_reply" {
+		text = m.Interactive.NFMReply.Body
 	} else {
 		// we received a message type we do not support.
 		err = fmt.Errorf("unsupported message type %s", m.Type)
@@ -180,6 +188,15 @@ func (m WAMessage) ExtractTextAndMedia() (string, string, string, error) {
 
 	return text, mediaURL, mediaID, err
 
+}
+
+// ExtractPayload returns the structured payload of this message if it has one - i.e. for a flow (nfm) reply, the
+// response JSON - or nil if it doesn't.
+func (m WAMessage) ExtractPayload() json.RawMessage {
+	if m.Type == "interactive" && m.Interactive.Type == "nfm_reply" && json.Valid([]byte(m.Interactive.NFMReply.ResponseJSON)) {
+		return json.RawMessage(m.Interactive.NFMReply.ResponseJSON)
+	}
+	return nil
 }
 
 type WAStatus struct {

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -66,6 +66,7 @@ type IncomingTestCase struct {
 	ExpectedURN           urns.URN
 	ExpectedURNAuthTokens map[urns.URN]map[string]string
 	ExpectedAttachments   []string
+	ExpectedPayload       string
 	ExpectedDate          time.Time
 	ExpectedExternalID    string
 	ExpectedMsgID         int64
@@ -184,6 +185,11 @@ func RunIncomingTestCases(t *testing.T, channels []courier.Channel, handler cour
 				}
 				if len(tc.ExpectedAttachments) > 0 {
 					assert.Equal(t, tc.ExpectedAttachments, msg.Attachments())
+				}
+				if tc.ExpectedPayload != "" {
+					assert.JSONEq(t, tc.ExpectedPayload, string(msg.Payload()))
+				} else {
+					assert.Nil(t, msg.Payload())
 				}
 				if !tc.ExpectedDate.IsZero() {
 					assert.Equal(t, tc.ExpectedDate.Local(), msg.ReceivedOn().Local())

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,6 +1,7 @@
 package courier
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/nyaruka/courier/v26/core/models"
@@ -84,6 +85,7 @@ type MsgIn interface {
 	WithURNAuthTokens(tokens map[string]string) MsgIn
 	WithReceivedOn(date time.Time) MsgIn
 	WithNewURN(urn urns.URN, action models.NewURNAction) MsgIn
+	WithPayload(payload json.RawMessage) MsgIn
 }
 
 // StatusUpdate represents a status update on a message

--- a/test/msg.go
+++ b/test/msg.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/nyaruka/courier/v26"
@@ -37,6 +38,7 @@ type MockMsg struct {
 	receivedOn *time.Time
 	sentOn     *time.Time
 	newURN     *models.NewURNSpec
+	payload    json.RawMessage
 }
 
 func NewMockMsg(uuid models.MsgUUID, channel courier.Channel, urn urns.URN, text string, attachments []string) *MockMsg {
@@ -90,6 +92,11 @@ func (m *MockMsg) WithNewURN(urn urns.URN, action models.NewURNAction) courier.M
 	return m
 }
 func (m *MockMsg) NewURN() *models.NewURNSpec { return m.newURN }
+func (m *MockMsg) WithPayload(payload json.RawMessage) courier.MsgIn {
+	m.payload = payload
+	return m
+}
+func (m *MockMsg) Payload() json.RawMessage { return m.payload }
 
 // used to create outgoing messages for testing
 func (m *MockMsg) WithUUID(uuid models.MsgUUID) courier.MsgOut        { m.uuid = uuid; return m }


### PR DESCRIPTION
Incoming interactive messages of type `nfm_reply` (WhatsApp Flows / channel form submissions) were previously dropped as unsupported. This adds support for them in the WhatsApp Cloud API handlers (WAC and D3C):

* The `response_json` from the reply is parsed and attached to the incoming message as an opaque JSON payload, which is included as an optional `payload` field on the `msg_received` task queued to mailroom (omitted when there is no payload). The payload must be a JSON object - anything else is dropped and logged. It is not persisted on the msg in the database - it only rides the queued task. Requires nyaruka/mailroom#1165 on the mailroom side to expose it as `@input.payload`.
* Msg text is set from the reply's `body` (typically "Sent"), consistent with how button and list replies use their titles.

The legacy WhatsApp handler is a disabled stub so was left untouched.