### PR TITLE
Add support for sending form quick replies as WhatsApp flow messages

### DIFF
--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -126,7 +126,10 @@ const (
 	MsgOriginChat      MsgOrigin = "chat"
 )
 
-const QuickReplyTypeLocation = "location"
+const (
+	QuickReplyTypeLocation = "location"
+	QuickReplyTypeForm     = "form"
+)
 
 type QuickReply struct {
 	Type  string `json:"type"            validate:"required"`
@@ -137,6 +140,9 @@ type QuickReply struct {
 func (qr QuickReply) GetText() string {
 	if qr.Type == QuickReplyTypeLocation && qr.Text == "" {
 		return "Send Location"
+	}
+	if qr.Type == QuickReplyTypeForm && qr.Text == "" {
+		return "Open Form"
 	}
 	return qr.Text
 }

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -795,6 +795,21 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
 	},
 	{
+		Label:           "Interactive with form",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://waba-v2.360dialog.io/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:   "Link Sending",
 		MsgText: "Link Sending https://link.com",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -851,6 +851,70 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
 	},
 	{
+		Label:           "Interactive with form",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with form, with extra quick replies ignored and default CTA",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "123456"}, {Type: "text", Text: "Yes"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Open Form"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with form, with attachment",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456"}},
+		MsgAttachments:  []string{"image/jpeg:https://foo.bar/image.jpg"},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"image","image":{"link":"https://foo.bar/image.jpg"}}`},
+			{Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now"}}}}`},
+		},
+		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with form missing form ID, sent as text",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"text","text":{"body":"Interactive form msg","preview_url":false}}`,
+		}},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*clogs.Error{{Message: "form quick reply is missing a form ID and can't be sent"}},
+	},
+	{
 		Label:   "Link Sending",
 		MsgText: "Link Sending https://link.com",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/meta/whatsapp/api.go
+++ b/handlers/meta/whatsapp/api.go
@@ -308,29 +308,41 @@ type Template struct {
 	Components []*Component `json:"components,omitempty"`
 }
 
+// see https://developers.facebook.com/docs/whatsapp/flows/gettingstarted/sendingaflow
+type FlowParameters struct {
+	FlowMessageVersion string `json:"flow_message_version"`
+	FlowID             string `json:"flow_id"`
+	FlowCTA            string `json:"flow_cta"`
+}
+
+type Header struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	Video    *Media `json:"video,omitempty"`
+	Image    *Media `json:"image,omitempty"`
+	Document *Media `json:"document,omitempty"`
+}
+
+type Action struct {
+	Name       string          `json:"name,omitempty"`
+	Button     string          `json:"button,omitempty"`
+	Sections   []Section       `json:"sections,omitempty"`
+	Buttons    []Button        `json:"buttons,omitempty"`
+	Parameters *FlowParameters `json:"parameters,omitempty"`
+}
+
 // see https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages#interactive-object
 // e.g. https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages#interactive-messages
 type Interactive struct {
-	Type   string `json:"type"`
-	Header *struct {
-		Type     string `json:"type"`
-		Text     string `json:"text,omitempty"`
-		Video    *Media `json:"video,omitempty"`
-		Image    *Media `json:"image,omitempty"`
-		Document *Media `json:"document,omitempty"`
-	} `json:"header,omitempty"`
-	Body struct {
+	Type   string  `json:"type"`
+	Header *Header `json:"header,omitempty"`
+	Body   struct {
 		Text string `json:"text"`
 	} `json:"body" validate:"required"`
 	Footer *struct {
 		Text string `json:"text"`
 	} `json:"footer,omitempty"`
-	Action *struct {
-		Name     string    `json:"name,omitempty"`
-		Button   string    `json:"button,omitempty"`
-		Sections []Section `json:"sections,omitempty"`
-		Buttons  []Button  `json:"buttons,omitempty"`
-	} `json:"action,omitempty"`
+	Action *Action `json:"action,omitempty"`
 }
 
 // see https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-messages#request-syntax

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -46,7 +46,8 @@ func (p SendRequest) withTemplate(templating *models.Templating) SendRequest {
 func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.ChannelLog) ([]SendRequest, error) {
 	msgParts := splitText(msg, maxMsgLength)
 	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), "text")
-	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), "location")
+	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
+	formQRs := FilterFormQuickReplies(msg.QuickReplies(), clog)
 	menuButton := handlers.GetText("Menu", msg.Locale())
 
 	qrsAsList := shouldUseList(qrs)
@@ -61,7 +62,7 @@ func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.Ch
 
 	// determine if the attachment can be used as a header in an interactive message
 	hasHeaderAttachment := false
-	if len(msg.Attachments()) > 0 && len(qrs) > 0 && len(qrs) <= 3 && len(locationQRs) == 0 && !qrsAsList {
+	if len(msg.Attachments()) > 0 && len(qrs) > 0 && len(qrs) <= 3 && len(locationQRs) == 0 && len(formQRs) == 0 && !qrsAsList {
 		attType, _ := handlers.SplitAttachment(msg.Attachments()[0])
 		attType = strings.Split(attType, "/")[0]
 		// only certain media types can be used as an interactive header
@@ -81,7 +82,7 @@ func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.Ch
 		attType = strings.Split(attType, "/")[0]
 
 		// only non-audio single attachment messages can have captions
-		if attType != "audio" && len(msgParts) == 1 && len(msg.Attachments()) == 1 && len(qrs) == 0 && len(locationQRs) == 0 {
+		if attType != "audio" && len(msgParts) == 1 && len(msg.Attachments()) == 1 && len(qrs) == 0 && len(locationQRs) == 0 && len(formQRs) == 0 {
 			caption = msgParts[0]
 		}
 
@@ -103,6 +104,9 @@ func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.Ch
 		switch {
 		case isLastPart && len(locationQRs) > 0:
 			payloads = append(payloads, buildLocationRequestPayload(msg, part))
+
+		case isLastPart && len(formQRs) > 0:
+			payloads = append(payloads, buildFlowPayload(msg, part, formQRs[0]))
 
 		case isLastPart && len(qrs) > 0 && !qrsAsList:
 			ps, err := buildButtonPayload(msg, part, qrs, hasHeaderAttachment)
@@ -176,18 +180,41 @@ func buildMediaPayload(msg courier.MsgOut, attachmentIdx int, caption string) (S
 	return p, nil
 }
 
+// FilterFormQuickReplies returns quick replies of type "form" that have an extra value (the form ID), logging an
+// error for any that don't since they can't be sent.
+func FilterFormQuickReplies(qrs []models.QuickReply, clog *courier.ChannelLog) []models.QuickReply {
+	f := make([]models.QuickReply, 0, len(qrs))
+	for _, qr := range handlers.FilterQuickRepliesByType(qrs, models.QuickReplyTypeForm) {
+		if qr.Extra == "" {
+			clog.Error(&clogs.Error{Message: "form quick reply is missing a form ID and can't be sent"})
+			continue
+		}
+		f = append(f, qr)
+	}
+	return f
+}
+
 func buildLocationRequestPayload(msg courier.MsgOut, body string) SendRequest {
 	p := newBasePayload(msg)
 	p.Type = "interactive"
 	interactive := Interactive{Type: "location_request_message", Body: struct {
 		Text string `json:"text"`
 	}{Text: body}}
-	interactive.Action = &struct {
-		Name     string    `json:"name,omitempty"`
-		Button   string    `json:"button,omitempty"`
-		Sections []Section `json:"sections,omitempty"`
-		Buttons  []Button  `json:"buttons,omitempty"`
-	}{Name: "send_location"}
+	interactive.Action = &Action{Name: "send_location"}
+	p.Interactive = &interactive
+	return p
+}
+
+func buildFlowPayload(msg courier.MsgOut, body string, qr models.QuickReply) SendRequest {
+	p := newBasePayload(msg)
+	p.Type = "interactive"
+	interactive := Interactive{Type: "flow", Body: struct {
+		Text string `json:"text"`
+	}{Text: body}}
+	interactive.Action = &Action{
+		Name:       "flow",
+		Parameters: &FlowParameters{FlowMessageVersion: "3", FlowID: qr.Extra, FlowCTA: qr.GetText()},
+	}
 	p.Interactive = &interactive
 	return p
 }
@@ -220,42 +247,19 @@ func buildButtonPayload(msg courier.MsgOut, body string, qrs []models.QuickReply
 
 		switch attType {
 		case "image":
-			interactive.Header = &struct {
-				Type     string `json:"type"`
-				Text     string `json:"text,omitempty"`
-				Video    *Media `json:"video,omitempty"`
-				Image    *Media `json:"image,omitempty"`
-				Document *Media `json:"document,omitempty"`
-			}{Type: "image", Image: &Media{Link: attURL}}
+			interactive.Header = &Header{Type: "image", Image: &Media{Link: attURL}}
 		case "video":
-			interactive.Header = &struct {
-				Type     string `json:"type"`
-				Text     string `json:"text,omitempty"`
-				Video    *Media `json:"video,omitempty"`
-				Image    *Media `json:"image,omitempty"`
-				Document *Media `json:"document,omitempty"`
-			}{Type: "video", Video: &Media{Link: attURL}}
+			interactive.Header = &Header{Type: "video", Video: &Media{Link: attURL}}
 		case "document":
 			filename, err := utils.BasePathForURL(attURL)
 			if err != nil {
 				return nil, err
 			}
-			interactive.Header = &struct {
-				Type     string `json:"type"`
-				Text     string `json:"text,omitempty"`
-				Video    *Media `json:"video,omitempty"`
-				Image    *Media `json:"image,omitempty"`
-				Document *Media `json:"document,omitempty"`
-			}{Type: "document", Document: &Media{Link: attURL, Filename: filename}}
+			interactive.Header = &Header{Type: "document", Document: &Media{Link: attURL, Filename: filename}}
 		}
 	}
 
-	interactive.Action = &struct {
-		Name     string    `json:"name,omitempty"`
-		Button   string    `json:"button,omitempty"`
-		Sections []Section `json:"sections,omitempty"`
-		Buttons  []Button  `json:"buttons,omitempty"`
-	}{Buttons: buildButtons(qrs)}
+	interactive.Action = &Action{Buttons: buildButtons(qrs)}
 	p.Interactive = &interactive
 	payloads = append(payloads, p)
 	return payloads, nil
@@ -278,12 +282,7 @@ func buildListPayload(msg courier.MsgOut, body string, qrs []models.QuickReply, 
 		}
 	}
 
-	interactive.Action = &struct {
-		Name     string    `json:"name,omitempty"`
-		Button   string    `json:"button,omitempty"`
-		Sections []Section `json:"sections,omitempty"`
-		Buttons  []Button  `json:"buttons,omitempty"`
-	}{Button: menuButton, Sections: []Section{section}}
+	interactive.Action = &Action{Button: menuButton, Sections: []Section{section}}
 	p.Interactive = &interactive
 	return p
 }

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -324,6 +324,36 @@ func TestGetMsgPayloads(t *testing.T) {
 				assert.Empty(t, payloads[0].To)
 			},
 		},
+		{
+			label:                 "Form QR - should use flow interactive, other QRs ignored",
+			text:                  "Book an appointment",
+			quickReplies:          []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456"}, {Type: "text", Text: "Yes"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "interactive", payloads[0].Type)
+				assert.Equal(t, "flow", payloads[0].Interactive.Type)
+				assert.Equal(t, "Book an appointment", payloads[0].Interactive.Body.Text)
+				assert.Equal(t, "flow", payloads[0].Interactive.Action.Name)
+				assert.Equal(t, &whatsapp.FlowParameters{FlowMessageVersion: "3", FlowID: "123456", FlowCTA: "Book now"}, payloads[0].Interactive.Action.Parameters)
+			},
+		},
+		{
+			label:                 "Form QR without form ID - should be ignored and logged",
+			text:                  "Book an appointment",
+			quickReplies:          []models.QuickReply{{Type: "form", Text: "Book now"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "text",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "text", payloads[0].Type)
+				assert.Len(t, clog.Errors, 1)
+				assert.Equal(t, "form quick reply is missing a form ID and can't be sent", clog.Errors[0].Message)
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -403,10 +403,11 @@ type mtInteractivePayload struct {
 			Text string `json:"text"`
 		} `json:"footer,omitempty"`
 		Action struct {
-			Name     string      `json:"name,omitempty"`
-			Button   string      `json:"button,omitempty"`
-			Sections []mtSection `json:"sections,omitempty"`
-			Buttons  []mtButton  `json:"buttons,omitempty"`
+			Name       string                   `json:"name,omitempty"`
+			Button     string                   `json:"button,omitempty"`
+			Sections   []mtSection              `json:"sections,omitempty"`
+			Buttons    []mtButton               `json:"buttons,omitempty"`
+			Parameters *whatsapp.FlowParameters `json:"parameters,omitempty"`
 		} `json:"action" validate:"required"`
 	} `json:"interactive"`
 }
@@ -505,9 +506,10 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 		}
 	}
 
-	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), "location")
+	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
+	formQRs := whatsapp.FilterFormQuickReplies(msg.QuickReplies(), clog)
 
-	isInteractiveMsg := len(msg.QuickReplies()) > 0
+	isInteractiveMsg := len(qrs) > 0 || len(locationQRs) > 0 || len(formQRs) > 0
 
 	textAsCaption := false
 
@@ -620,6 +622,18 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 						payload.Interactive.Action.Name = "send_location"
 						payloads = append(payloads, payload)
 
+					} else if len(formQRs) > 0 {
+						qr := formQRs[0]
+						payload.Interactive.Type = "flow"
+						payload.Interactive.Body.Text = part
+						payload.Interactive.Action.Name = "flow"
+						payload.Interactive.Action.Parameters = &whatsapp.FlowParameters{
+							FlowMessageVersion: "3",
+							FlowID:             qr.Extra,
+							FlowCTA:            qr.GetText(),
+						}
+						payloads = append(payloads, payload)
+
 					} else if !qrsAsList { // we show buttons
 						payload.Interactive.Type = "button"
 						payload.Interactive.Body.Text = part
@@ -724,6 +738,18 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 							payload.Interactive.Type = "location_request_message"
 							payload.Interactive.Body.Text = part
 							payload.Interactive.Action.Name = "send_location"
+							payloads = append(payloads, payload)
+
+						} else if len(formQRs) > 0 {
+							qr := formQRs[0]
+							payload.Interactive.Type = "flow"
+							payload.Interactive.Body.Text = part
+							payload.Interactive.Action.Name = "flow"
+							payload.Interactive.Action.Parameters = &whatsapp.FlowParameters{
+								FlowMessageVersion: "3",
+								FlowID:             qr.Extra,
+								FlowCTA:            qr.GetText(),
+							}
 							payloads = append(payloads, payload)
 
 						} else if !qrsAsList { // we show buttons

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -1062,6 +1062,21 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
+		Label:           "Interactive with form",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:   "Error Channel Contact Pair limit hit",
 		MsgText: "Pair limit",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/courier/v26/utils/clogs"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/urns"
@@ -1075,6 +1076,37 @@ var defaultSendTestCases = []OutgoingTestCase{
 			Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now"}}}}`,
 		}},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with form, with extra quick replies ignored and default CTA",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "123456"}, {Type: "text", Text: "Yes"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Open Form"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with form missing form ID, sent as text",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"to":"250788123123","type":"text","text":{"body":"Interactive form msg"}}`,
+		}},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*clogs.Error{{Message: "form quick reply is missing a form ID and can't be sent"}},
 	},
 	{
 		Label:   "Error Channel Contact Pair limit hit",


### PR DESCRIPTION
Adds outgoing support for the `form` quick reply type (goflow ≥ v0.286.0): `text` is the CTA button label, `extra` is the channel-specific form ID (a WhatsApp flow ID).

On the WhatsApp Cloud, Dialog360 and Turn handlers, a form quick reply is now sent as an interactive **flow** message:

```json
{
  "type": "interactive",
  "interactive": {
    "type": "flow",
    "body": {"text": "..."},
    "action": {
      "name": "flow",
      "parameters": {"flow_message_version": "3", "flow_id": "123456", "flow_cta": "Book now"}
    }
  }
}
```

This is the outgoing counterpart to the existing incoming `nfm_reply` handling.

Details:
* `location` still takes precedence over `form`, which takes precedence over text quick replies; extra quick replies are ignored (same pattern as location requests). Only the first form quick reply is used.
* A form quick reply with no form ID can't be sent — it's dropped with a channel log error and the message falls back to plain text.
* An empty CTA label defaults to "Open Form" via `QuickReply.GetText()`, mirroring location's "Send Location".
* The anonymous `Header`/`Action` structs on `Interactive` were promoted to named types so the action can carry flow parameters without repeating struct literals.
* Turn's `isInteractiveMsg` is now based on usable quick replies only, so unsendable quick replies fall back to plain text instead of producing an empty button payload.

Other handlers continue to ignore form quick replies. Note that mailroom needs a goflow bump to ≥ v0.286.0 before it will emit this type.