### PR TITLE
Add support for sending url quick replies as WhatsApp CTA URL button messages

### DIFF
--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -129,6 +129,7 @@ const (
 const (
 	QuickReplyTypeLocation = "location"
 	QuickReplyTypeForm     = "form"
+	QuickReplyTypeURL      = "url"
 )
 
 type QuickReply struct {
@@ -143,6 +144,9 @@ func (qr QuickReply) GetText() string {
 	}
 	if qr.Type == QuickReplyTypeForm && qr.Text == "" {
 		return "Open Form"
+	}
+	if qr.Type == QuickReplyTypeURL && qr.Text == "" {
+		return "Open Link"
 	}
 	return qr.Text
 }

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -810,6 +810,21 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
+		Label:           "Interactive with URL button",
+		MsgText:         "Interactive URL msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://waba-v2.360dialog.io/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"cta_url","body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Visit","url":"https://example.com"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:   "Link Sending",
 		MsgText: "Link Sending https://link.com",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -915,6 +915,70 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedLogErrors: []*clogs.Error{{Message: "form quick reply is missing a form ID and can't be sent"}},
 	},
 	{
+		Label:           "Interactive with URL button",
+		MsgText:         "Interactive URL msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"cta_url","body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Visit","url":"https://example.com"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with URL button, with extra quick replies ignored and default display text",
+		MsgText:         "Interactive URL msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Extra: "https://example.com"}, {Type: "text", Text: "Yes"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"cta_url","body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Open Link","url":"https://example.com"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with URL button, with attachment",
+		MsgText:         "Interactive URL msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}},
+		MsgAttachments:  []string{"image/jpeg:https://foo.bar/image.jpg"},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"image","image":{"link":"https://foo.bar/image.jpg"}}`},
+			{Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"cta_url","body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Visit","url":"https://example.com"}}}}`},
+		},
+		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with URL button missing URL, sent as text",
+		MsgText:         "Interactive URL msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"text","text":{"body":"Interactive URL msg","preview_url":false}}`,
+		}},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*clogs.Error{{Message: "URL quick reply is missing a URL and can't be sent"}},
+	},
+	{
 		Label:   "Link Sending",
 		MsgText: "Link Sending https://link.com",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/meta/whatsapp/api.go
+++ b/handlers/meta/whatsapp/api.go
@@ -308,11 +308,14 @@ type Template struct {
 	Components []*Component `json:"components,omitempty"`
 }
 
-// see https://developers.facebook.com/docs/whatsapp/flows/gettingstarted/sendingaflow
-type FlowParameters struct {
-	FlowMessageVersion string `json:"flow_message_version"`
-	FlowID             string `json:"flow_id"`
-	FlowCTA            string `json:"flow_cta"`
+// parameters for flow actions (https://developers.facebook.com/docs/whatsapp/flows/gettingstarted/sendingaflow)
+// and cta_url actions (https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-cta-url-messages)
+type ActionParameters struct {
+	FlowMessageVersion string `json:"flow_message_version,omitempty"`
+	FlowID             string `json:"flow_id,omitempty"`
+	FlowCTA            string `json:"flow_cta,omitempty"`
+	DisplayText        string `json:"display_text,omitempty"`
+	URL                string `json:"url,omitempty"`
 }
 
 type Header struct {
@@ -324,11 +327,11 @@ type Header struct {
 }
 
 type Action struct {
-	Name       string          `json:"name,omitempty"`
-	Button     string          `json:"button,omitempty"`
-	Sections   []Section       `json:"sections,omitempty"`
-	Buttons    []Button        `json:"buttons,omitempty"`
-	Parameters *FlowParameters `json:"parameters,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	Button     string            `json:"button,omitempty"`
+	Sections   []Section         `json:"sections,omitempty"`
+	Buttons    []Button          `json:"buttons,omitempty"`
+	Parameters *ActionParameters `json:"parameters,omitempty"`
 }
 
 // see https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages#interactive-object

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -48,6 +48,7 @@ func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.Ch
 	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), "text")
 	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
 	formQRs := FilterFormQuickReplies(msg.QuickReplies(), clog)
+	urlQRs := FilterURLQuickReplies(msg.QuickReplies(), clog)
 	menuButton := handlers.GetText("Menu", msg.Locale())
 
 	qrsAsList := shouldUseList(qrs)
@@ -62,7 +63,7 @@ func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.Ch
 
 	// determine if the attachment can be used as a header in an interactive message
 	hasHeaderAttachment := false
-	if len(msg.Attachments()) > 0 && len(qrs) > 0 && len(qrs) <= 3 && len(locationQRs) == 0 && len(formQRs) == 0 && !qrsAsList {
+	if len(msg.Attachments()) > 0 && len(qrs) > 0 && len(qrs) <= 3 && len(locationQRs) == 0 && len(formQRs) == 0 && len(urlQRs) == 0 && !qrsAsList {
 		attType, _ := handlers.SplitAttachment(msg.Attachments()[0])
 		attType = strings.Split(attType, "/")[0]
 		// only certain media types can be used as an interactive header
@@ -82,7 +83,7 @@ func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.Ch
 		attType = strings.Split(attType, "/")[0]
 
 		// only non-audio single attachment messages can have captions
-		if attType != "audio" && len(msgParts) == 1 && len(msg.Attachments()) == 1 && len(qrs) == 0 && len(locationQRs) == 0 && len(formQRs) == 0 {
+		if attType != "audio" && len(msgParts) == 1 && len(msg.Attachments()) == 1 && len(qrs) == 0 && len(locationQRs) == 0 && len(formQRs) == 0 && len(urlQRs) == 0 {
 			caption = msgParts[0]
 		}
 
@@ -107,6 +108,9 @@ func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.Ch
 
 		case isLastPart && len(formQRs) > 0:
 			payloads = append(payloads, buildFlowPayload(msg, part, formQRs[0]))
+
+		case isLastPart && len(urlQRs) > 0:
+			payloads = append(payloads, buildCTAURLPayload(msg, part, urlQRs[0]))
 
 		case isLastPart && len(qrs) > 0 && !qrsAsList:
 			ps, err := buildButtonPayload(msg, part, qrs, hasHeaderAttachment)
@@ -194,6 +198,20 @@ func FilterFormQuickReplies(qrs []models.QuickReply, clog *courier.ChannelLog) [
 	return f
 }
 
+// FilterURLQuickReplies returns quick replies of type "url" that have an extra value (the URL), logging an error for
+// any that don't since they can't be sent.
+func FilterURLQuickReplies(qrs []models.QuickReply, clog *courier.ChannelLog) []models.QuickReply {
+	f := make([]models.QuickReply, 0, len(qrs))
+	for _, qr := range handlers.FilterQuickRepliesByType(qrs, models.QuickReplyTypeURL) {
+		if qr.Extra == "" {
+			clog.Error(&clogs.Error{Message: "URL quick reply is missing a URL and can't be sent"})
+			continue
+		}
+		f = append(f, qr)
+	}
+	return f
+}
+
 func buildLocationRequestPayload(msg courier.MsgOut, body string) SendRequest {
 	p := newBasePayload(msg)
 	p.Type = "interactive"
@@ -213,7 +231,21 @@ func buildFlowPayload(msg courier.MsgOut, body string, qr models.QuickReply) Sen
 	}{Text: body}}
 	interactive.Action = &Action{
 		Name:       "flow",
-		Parameters: &FlowParameters{FlowMessageVersion: "3", FlowID: qr.Extra, FlowCTA: qr.GetText()},
+		Parameters: &ActionParameters{FlowMessageVersion: "3", FlowID: qr.Extra, FlowCTA: qr.GetText()},
+	}
+	p.Interactive = &interactive
+	return p
+}
+
+func buildCTAURLPayload(msg courier.MsgOut, body string, qr models.QuickReply) SendRequest {
+	p := newBasePayload(msg)
+	p.Type = "interactive"
+	interactive := Interactive{Type: "cta_url", Body: struct {
+		Text string `json:"text"`
+	}{Text: body}}
+	interactive.Action = &Action{
+		Name:       "cta_url",
+		Parameters: &ActionParameters{DisplayText: qr.GetText(), URL: qr.Extra},
 	}
 	p.Interactive = &interactive
 	return p

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -337,7 +337,7 @@ func TestGetMsgPayloads(t *testing.T) {
 				assert.Equal(t, "flow", payloads[0].Interactive.Type)
 				assert.Equal(t, "Book an appointment", payloads[0].Interactive.Body.Text)
 				assert.Equal(t, "flow", payloads[0].Interactive.Action.Name)
-				assert.Equal(t, &whatsapp.FlowParameters{FlowMessageVersion: "3", FlowID: "123456", FlowCTA: "Book now"}, payloads[0].Interactive.Action.Parameters)
+				assert.Equal(t, &whatsapp.ActionParameters{FlowMessageVersion: "3", FlowID: "123456", FlowCTA: "Book now"}, payloads[0].Interactive.Action.Parameters)
 			},
 		},
 		{
@@ -352,6 +352,36 @@ func TestGetMsgPayloads(t *testing.T) {
 				assert.Equal(t, "text", payloads[0].Type)
 				assert.Len(t, clog.Errors, 1)
 				assert.Equal(t, "form quick reply is missing a form ID and can't be sent", clog.Errors[0].Message)
+			},
+		},
+		{
+			label:                 "URL QR - should use cta_url interactive, other QRs ignored",
+			text:                  "Check out our site",
+			quickReplies:          []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}, {Type: "text", Text: "Yes"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "interactive", payloads[0].Type)
+				assert.Equal(t, "cta_url", payloads[0].Interactive.Type)
+				assert.Equal(t, "Check out our site", payloads[0].Interactive.Body.Text)
+				assert.Equal(t, "cta_url", payloads[0].Interactive.Action.Name)
+				assert.Equal(t, &whatsapp.ActionParameters{DisplayText: "Visit", URL: "https://example.com"}, payloads[0].Interactive.Action.Parameters)
+			},
+		},
+		{
+			label:                 "URL QR without URL - should be ignored and logged",
+			text:                  "Check out our site",
+			quickReplies:          []models.QuickReply{{Type: "url", Text: "Visit"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "text",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "text", payloads[0].Type)
+				assert.Len(t, clog.Errors, 1)
+				assert.Equal(t, "URL quick reply is missing a URL and can't be sent", clog.Errors[0].Message)
 			},
 		},
 	}

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -403,11 +403,11 @@ type mtInteractivePayload struct {
 			Text string `json:"text"`
 		} `json:"footer,omitempty"`
 		Action struct {
-			Name       string                   `json:"name,omitempty"`
-			Button     string                   `json:"button,omitempty"`
-			Sections   []mtSection              `json:"sections,omitempty"`
-			Buttons    []mtButton               `json:"buttons,omitempty"`
-			Parameters *whatsapp.FlowParameters `json:"parameters,omitempty"`
+			Name       string                     `json:"name,omitempty"`
+			Button     string                     `json:"button,omitempty"`
+			Sections   []mtSection                `json:"sections,omitempty"`
+			Buttons    []mtButton                 `json:"buttons,omitempty"`
+			Parameters *whatsapp.ActionParameters `json:"parameters,omitempty"`
 		} `json:"action" validate:"required"`
 	} `json:"interactive"`
 }
@@ -508,8 +508,9 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 
 	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
 	formQRs := whatsapp.FilterFormQuickReplies(msg.QuickReplies(), clog)
+	urlQRs := whatsapp.FilterURLQuickReplies(msg.QuickReplies(), clog)
 
-	isInteractiveMsg := len(qrs) > 0 || len(locationQRs) > 0 || len(formQRs) > 0
+	isInteractiveMsg := len(qrs) > 0 || len(locationQRs) > 0 || len(formQRs) > 0 || len(urlQRs) > 0
 
 	textAsCaption := false
 
@@ -627,10 +628,21 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 						payload.Interactive.Type = "flow"
 						payload.Interactive.Body.Text = part
 						payload.Interactive.Action.Name = "flow"
-						payload.Interactive.Action.Parameters = &whatsapp.FlowParameters{
+						payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
 							FlowMessageVersion: "3",
 							FlowID:             qr.Extra,
 							FlowCTA:            qr.GetText(),
+						}
+						payloads = append(payloads, payload)
+
+					} else if len(urlQRs) > 0 {
+						qr := urlQRs[0]
+						payload.Interactive.Type = "cta_url"
+						payload.Interactive.Body.Text = part
+						payload.Interactive.Action.Name = "cta_url"
+						payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
+							DisplayText: qr.GetText(),
+							URL:         qr.Extra,
 						}
 						payloads = append(payloads, payload)
 
@@ -745,10 +757,21 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 							payload.Interactive.Type = "flow"
 							payload.Interactive.Body.Text = part
 							payload.Interactive.Action.Name = "flow"
-							payload.Interactive.Action.Parameters = &whatsapp.FlowParameters{
+							payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
 								FlowMessageVersion: "3",
 								FlowID:             qr.Extra,
 								FlowCTA:            qr.GetText(),
+							}
+							payloads = append(payloads, payload)
+
+						} else if len(urlQRs) > 0 {
+							qr := urlQRs[0]
+							payload.Interactive.Type = "cta_url"
+							payload.Interactive.Body.Text = part
+							payload.Interactive.Action.Name = "cta_url"
+							payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
+								DisplayText: qr.GetText(),
+								URL:         qr.Extra,
 							}
 							payloads = append(payloads, payload)
 

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -1109,6 +1109,52 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedLogErrors: []*clogs.Error{{Message: "form quick reply is missing a form ID and can't be sent"}},
 	},
 	{
+		Label:           "Interactive with URL button",
+		MsgText:         "Interactive URL msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"cta_url","body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Visit","url":"https://example.com"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with URL button, with extra quick replies ignored and default display text",
+		MsgText:         "Interactive URL msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Extra: "https://example.com"}, {Type: "text", Text: "Yes"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"cta_url","body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Open Link","url":"https://example.com"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with URL button missing URL, sent as text",
+		MsgText:         "Interactive URL msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"to":"250788123123","type":"text","text":{"body":"Interactive URL msg"}}`,
+		}},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*clogs.Error{{Message: "URL quick reply is missing a URL and can't be sent"}},
+	},
+	{
 		Label:   "Error Channel Contact Pair limit hit",
 		MsgText: "Pair limit",
 		MsgURN:  "whatsapp:250788123123",


### PR DESCRIPTION
Adds outgoing support for the `url` quick reply type (goflow ≥ v0.287.0): `text` is the button label, `extra` is the URL to open.

On the WhatsApp Cloud, Dialog360 and Turn handlers, a URL quick reply is now sent as an interactive **cta_url** message:

```json
{
  "type": "interactive",
  "interactive": {
    "type": "cta_url",
    "body": {"text": "..."},
    "action": {
      "name": "cta_url",
      "parameters": {"display_text": "Visit", "url": "https://example.com"}
    }
  }
}
```

Details:
* Precedence follows the existing pattern: `location` > `form` > `url` > text quick replies; only the first URL quick reply is used and any other quick replies are ignored.
* A URL quick reply with no URL can't be sent — it's dropped with a channel log error and the message falls back to plain text.
* An empty button label defaults to "Open Link" via `QuickReply.GetText()`, mirroring form's "Open Form".
* `FlowParameters` is generalized to `ActionParameters` (all fields `omitempty`) so the interactive action parameters object can carry either flow or cta_url parameters.

Other handlers continue to ignore `url` quick replies. Note that mailroom needs a goflow bump to ≥ v0.287.0 before it will emit this type.