### PR TITLE
Ignore quick replies of types a channel doesn't support

### DIFF
--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -127,6 +127,7 @@ const (
 )
 
 const (
+	QuickReplyTypeText     = "text"
 	QuickReplyTypeLocation = "location"
 	QuickReplyTypeForm     = "form"
 	QuickReplyTypeURL      = "url"

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -404,7 +404,7 @@ func buildQuickRepliesResponse(quickReplies []models.QuickReply, sendMethod stri
 		quickReplies = []models.QuickReply{}
 	}
 
-	quickReplies = handlers.FilterQuickRepliesByType(quickReplies, "text")
+	quickReplies = handlers.FilterQuickRepliesByType(quickReplies, models.QuickReplyTypeText)
 
 	if (sendMethod == http.MethodPost || sendMethod == http.MethodPut) && contentType == contentJSON {
 		return string(jsonx.MustMarshal(handlers.TextOnlyQuickReplies(quickReplies)))

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -502,7 +502,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 		// include any quick replies on the last piece we send
 		if i == (len(msgParts)+len(msg.Attachments()))-1 {
-			qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), "text")
+			qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
 			for _, qr := range qrs {
 				payload.Message.QuickReplies = append(payload.Message.QuickReplies, mtQuickReply{qr.Text, qr.Text, "text"})
 			}

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -385,11 +385,11 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 			for _, qr := range qrs {
 				item := QuickReplyItem{Type: "action"}
 				switch qr.Type {
-				case "location":
+				case models.QuickReplyTypeLocation:
 					item.Action.Type = "location"
 					item.Action.Label = qr.GetText()
 					items = append(items, item)
-				case "text":
+				case models.QuickReplyTypeText:
 					item.Action.Type = "message"
 					item.Action.Label = qr.GetText()
 					item.Action.Text = qr.GetText()

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -660,7 +660,7 @@ func (h *handler) sendFacebookInstagramMsg(ctx context.Context, msg courier.MsgO
 
 		// include any quick replies on the last piece we send
 		if part.IsLast {
-			qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), "text")
+			qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
 			for _, qr := range qrs {
 				payload.Message.QuickReplies = append(payload.Message.QuickReplies, messenger.QuickReply{Title: qr.Text, Payload: qr.Text, ContentType: "text"})
 			}

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -45,7 +45,7 @@ func (p SendRequest) withTemplate(templating *models.Templating) SendRequest {
 // buildContentPayloads constructs payloads for a non-template message with text, attachments, and quick replies.
 func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.ChannelLog) ([]SendRequest, error) {
 	msgParts := splitText(msg, maxMsgLength)
-	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), "text")
+	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
 	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
 	formQRs := FilterFormQuickReplies(msg.QuickReplies(), clog)
 	urlQRs := FilterURLQuickReplies(msg.QuickReplies(), clog)

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -202,7 +202,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 
 	// figure out whether we have a keyboard to send as well - we only support text and location quick replies
-	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText, models.QuickReplyTypeLocation)
+	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation)
 	var keyboard *ReplyKeyboardMarkup
 	if len(qrs) > 0 {
 		keyboard = NewKeyboardFromReplies(qrs)

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -201,8 +201,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		caption = msg.Text()
 	}
 
-	// figure out whether we have a keyboard to send as well
-	qrs := msg.QuickReplies()
+	// figure out whether we have a keyboard to send as well - we only support text and location quick replies
+	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText, models.QuickReplyTypeLocation)
 	var keyboard *ReplyKeyboardMarkup
 	if len(qrs) > 0 {
 		keyboard = NewKeyboardFromReplies(qrs)

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -843,6 +843,10 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Yes"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
 		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
+			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
+		},
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
@@ -857,6 +861,10 @@ var outgoingCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
+			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -831,6 +831,36 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
+		Label:           "Quick Reply, unsupported types ignored",
+		MsgText:         "Are you happy?",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}, {Type: "text", Text: "Yes"}, {Type: "url", Extra: "http://example.com"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Yes"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
+		Label:           "Quick Reply, only unsupported types means no keyboard",
+		MsgText:         "Are you happy?",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}, {Type: "url", Extra: "http://example.com"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
 		Label:           "Quick Reply with multiple attachments",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -498,7 +498,7 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 
 	parts := handlers.SplitMsgByChannel(msg.Channel(), msg.Text(), maxMsgLength)
 
-	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), "text")
+	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
 	qrsAsList := false
 	for i, qr := range qrs {
 		if i > 2 || qr.Extra != "" {

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/utils"
+	"github.com/nyaruka/courier/v26/utils/clogs"
 )
 
 var (
@@ -54,6 +55,20 @@ func FilterQuickRepliesByType(qrs []models.QuickReply, types ...string) []models
 	for _, qr := range qrs {
 		if slices.Contains(types, qr.Type) {
 			t = append(t, qr)
+		}
+	}
+	return t
+}
+
+// FilterSupportedQuickReplies returns quick replies of the given types only, logging an error for each one dropped
+// because the channel can't render its type.
+func FilterSupportedQuickReplies(qrs []models.QuickReply, clog *courier.ChannelLog, types ...string) []models.QuickReply {
+	t := make([]models.QuickReply, 0, len(qrs))
+	for _, qr := range qrs {
+		if slices.Contains(types, qr.Type) {
+			t = append(t, qr)
+		} else {
+			clog.Error(&clogs.Error{Message: fmt.Sprintf("quick reply of type %s isn't supported by this channel and can't be sent", qr.Type)})
 		}
 	}
 	return t

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/nyaruka/courier/v26"
@@ -40,18 +41,18 @@ func SplitAttachment(attachment string) (string, string) {
 func TextOnlyQuickReplies(qrs []models.QuickReply) []string {
 	t := make([]string, 0, len(qrs))
 	for _, qr := range qrs {
-		if qr.Type == "text" {
+		if qr.Type == models.QuickReplyTypeText {
 			t = append(t, qr.Text)
 		}
 	}
 	return t
 }
 
-// FilterQuickRepliesByType returns quick replies of some type only
-func FilterQuickRepliesByType(qrs []models.QuickReply, type_ string) []models.QuickReply {
+// FilterQuickRepliesByType returns quick replies of the given types only
+func FilterQuickRepliesByType(qrs []models.QuickReply, types ...string) []models.QuickReply {
 	t := make([]models.QuickReply, 0, len(qrs))
 	for _, qr := range qrs {
-		if qr.Type == type_ {
+		if slices.Contains(types, qr.Type) {
 			t = append(t, qr)
 		}
 	}

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -355,8 +355,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		return courier.ErrChannelConfig
 	}
 
-	// figure out whether we have a keyboard to send as well
-	qrs := msg.QuickReplies()
+	// figure out whether we have a keyboard to send as well - we only support text and location quick replies
+	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText, models.QuickReplyTypeLocation)
 	var keyboard *Keyboard
 
 	if len(qrs) > 0 {

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -356,7 +356,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 
 	// figure out whether we have a keyboard to send as well - we only support text and location quick replies
-	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText, models.QuickReplyTypeLocation)
+	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation)
 	var keyboard *Keyboard
 
 	if len(qrs) > 0 {

--- a/handlers/viber/handler_test.go
+++ b/handlers/viber/handler_test.go
@@ -125,6 +125,36 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 	},
 	{
+		Label:           "Quick Reply, unsupported types ignored",
+		MsgText:         "Are you happy?",
+		MsgURN:          "viber:xy5/5y6O81+/kbWHpLhBoA==",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}, {Type: "text", Text: "Yes"}, {Type: "url", Extra: "http://example.com"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://chatapi.viber.com/pa/send_message": {
+				httpx.NewMockResponse(200, nil, []byte(`{"status":0,"status_message":"ok","message_token":4987381194038857789}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Content-Type": "application/json", "Accept": "application/json"},
+			Body:    `{"auth_token":"Token","receiver":"xy5/5y6O81+/kbWHpLhBoA==","text":"Are you happy?","type":"text","tracking_data":"0191e180-7d60-7000-aded-7d8b151cbd5b","keyboard":{"Type":"keyboard","DefaultHeight":false,"Buttons":[{"ActionType":"reply","ActionBody":"Yes","Text":"Yes","TextSize":"regular","Columns":"6"}]}}`,
+		}},
+	},
+	{
+		Label:           "Quick Reply, only unsupported types means no keyboard",
+		MsgText:         "Are you happy?",
+		MsgURN:          "viber:xy5/5y6O81+/kbWHpLhBoA==",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}, {Type: "url", Extra: "http://example.com"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://chatapi.viber.com/pa/send_message": {
+				httpx.NewMockResponse(200, nil, []byte(`{"status":0,"status_message":"ok","message_token":4987381194038857789}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Content-Type": "application/json", "Accept": "application/json"},
+			Body:    `{"auth_token":"Token","receiver":"xy5/5y6O81+/kbWHpLhBoA==","text":"Are you happy?","type":"text","tracking_data":"0191e180-7d60-7000-aded-7d8b151cbd5b"}`,
+		}},
+	},
+	{
 		Label:          "Send Attachment",
 		MsgText:        "My pic!",
 		MsgURN:         "viber:xy5/5y6O81+/kbWHpLhBoA==",

--- a/handlers/viber/handler_test.go
+++ b/handlers/viber/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/courier/v26/utils/clogs"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -138,6 +139,10 @@ var defaultSendTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Content-Type": "application/json", "Accept": "application/json"},
 			Body:    `{"auth_token":"Token","receiver":"xy5/5y6O81+/kbWHpLhBoA==","text":"Are you happy?","type":"text","tracking_data":"0191e180-7d60-7000-aded-7d8b151cbd5b","keyboard":{"Type":"keyboard","DefaultHeight":false,"Buttons":[{"ActionType":"reply","ActionBody":"Yes","Text":"Yes","TextSize":"regular","Columns":"6"}]}}`,
 		}},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
+			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
+		},
 	},
 	{
 		Label:           "Quick Reply, only unsupported types means no keyboard",
@@ -153,6 +158,10 @@ var defaultSendTestCases = []OutgoingTestCase{
 			Headers: map[string]string{"Content-Type": "application/json", "Accept": "application/json"},
 			Body:    `{"auth_token":"Token","receiver":"xy5/5y6O81+/kbWHpLhBoA==","text":"Are you happy?","type":"text","tracking_data":"0191e180-7d60-7000-aded-7d8b151cbd5b"}`,
 		}},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
+			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
+		},
 	},
 	{
 		Label:          "Send Attachment",

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -435,7 +435,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	params.Set(paramMessage, text)
 	params.Set(paramAttachments, attachments)
 
-	qrs := msg.QuickReplies()
+	// we only support text quick replies
+	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
 	if len(qrs) != 0 {
 		keyboard := NewKeyboardFromReplies(qrs)
 

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -436,7 +436,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	params.Set(paramAttachments, attachments)
 
 	// we only support text quick replies
-	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
+	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText)
 	if len(qrs) != 0 {
 		keyboard := NewKeyboardFromReplies(qrs)
 

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -220,6 +220,8 @@ const msgKeyboard = `{
 
 const keyboardJson = `{"one_time":true,"buttons":[[{"action":{"type":"text","label":"A","payload":"\"A\""},"color":"primary"},{"action":{"type":"text","label":"B","payload":"\"B\""},"color":"primary"},{"action":{"type":"text","label":"C","payload":"\"C\""},"color":"primary"},{"action":{"type":"text","label":"D","payload":"\"D\""},"color":"primary"},{"action":{"type":"text","label":"E","payload":"\"E\""},"color":"primary"}]],"inline":false}`
 
+const singleButtonKeyboardJson = `{"one_time":true,"buttons":[[{"action":{"type":"text","label":"A","payload":"\"A\""},"color":"primary"}]],"inline":false}`
+
 var testCases = []IncomingTestCase{
 	{
 		Label:                "Receive Message",
@@ -486,6 +488,40 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{
 				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "keyboard": {keyboardJson}, "message": {"Send keyboard"}, "random_id": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}, "user_id": {"123456789"}, "v": {"5.103"}},
+			},
+		},
+		ExpectedExtIDs: []string{"1"},
+	},
+	{
+		Label:           "Send keyboard, unsupported types ignored",
+		MsgText:         "Send keyboard",
+		MsgURN:          "vk:123456789",
+		MsgQuickReplies: []models.QuickReply{{Type: "location"}, {Type: "text", Text: "A"}, {Type: "form", Extra: "1234"}, {Type: "url", Extra: "http://example.com"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.vk.com/method/messages.send.json?*": {
+				httpx.NewMockResponse(200, nil, []byte(`{"response": 1}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "keyboard": {singleButtonKeyboardJson}, "message": {"Send keyboard"}, "random_id": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}, "user_id": {"123456789"}, "v": {"5.103"}},
+			},
+		},
+		ExpectedExtIDs: []string{"1"},
+	},
+	{
+		Label:           "Send keyboard, only unsupported types means no keyboard",
+		MsgText:         "Send keyboard",
+		MsgURN:          "vk:123456789",
+		MsgQuickReplies: []models.QuickReply{{Type: "location"}, {Type: "form", Extra: "1234"}, {Type: "url", Extra: "http://example.com"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.vk.com/method/messages.send.json?*": {
+				httpx.NewMockResponse(200, nil, []byte(`{"response": 1}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "message": {"Send keyboard"}, "random_id": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}, "user_id": {"123456789"}, "v": {"5.103"}},
 			},
 		},
 		ExpectedExtIDs: []string{"1"},

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/courier/v26/utils/clogs"
 )
 
 const (
@@ -507,6 +508,11 @@ var outgoingCases = []OutgoingTestCase{
 				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "keyboard": {singleButtonKeyboardJson}, "message": {"Send keyboard"}, "random_id": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}, "user_id": {"123456789"}, "v": {"5.103"}},
 			},
 		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type location isn't supported by this channel and can't be sent"},
+			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
+			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
+		},
 		ExpectedExtIDs: []string{"1"},
 	},
 	{
@@ -523,6 +529,11 @@ var outgoingCases = []OutgoingTestCase{
 			{
 				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "message": {"Send keyboard"}, "random_id": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}, "user_id": {"123456789"}, "v": {"5.103"}},
 			},
+		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type location isn't supported by this channel and can't be sent"},
+			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
+			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
 		},
 		ExpectedExtIDs: []string{"1"},
 	},


### PR DESCRIPTION
## What

The Telegram, Viber and VK handlers passed `msg.QuickReplies()` straight to their keyboard builders, which iterate every reply and only special-case `location` (VK doesn't even do that). Anything else fell through to a plain text button labelled with the fallback text from `QuickReply.GetText()`.

So a `form` or `url` quick reply sent to one of these channels rendered as a dead button reading "Open Form" / "Open Link", and tapping it sent that literal string back as the contact's reply. On VK a `location` reply did the same with "Send Location".

These handlers now filter to the types they can actually render, before the keyboard is built:

| Handler | Supported |
|---|---|
| Telegram | `text`, `location` |
| Viber | `text`, `location` |
| VK | `text` |

Filtering happens in the handler rather than the keyboard builder so that a message whose quick replies are *all* unsupported sends no keyboard at all, instead of an empty one.

`FilterQuickRepliesByType` is now variadic (`types ...string`) so a handler can name several supported types in one call. All existing single-type call sites are unaffected.

Also adds a `QuickReplyTypeText` constant alongside the existing location/form/url ones and uses it for the quick reply type comparisons that were still on a string literal — including Line's switch, which had literal `"location"` and `"text"` cases. Other `"text"` literals in these files are the channels' own message/content types and were left alone.

## Why

This matches what the other handlers already do — Line switches explicitly on type and drops anything unrecognised, and the text-only handlers all filter through `FilterQuickRepliesByType(..., "text")`. Telegram/Viber/VK were the outliers: the fallback wasn't deliberate, it just predates the form and url types being added, and no test covered it.

## Notes for reviewers

- **This is a behaviour change for anyone relying on the old fallback.** A flow sending a `url` quick reply to a Telegram contact previously showed an "Open Link" button; it now shows nothing. That's the correct outcome, but it may look like a regression to a flow author who built around it.
- These handlers drop unsupported types silently. The WhatsApp handlers log a channel error when a form/url reply can't be sent — I kept these consistent with Line and the text-only handlers instead, but happy to add logging if you'd prefer.

## Testing

Two cases added per handler — unsupported types mixed with supported ones (dropped, supported ones still render), and only unsupported types (Telegram sends `{"remove_keyboard":true}`, Viber omits `keyboard` from the body, VK omits the `keyboard` param). Full suite passes.