### PR TITLE
Add url quick reply support for Line, Viber and VK, and location for VK

### DIFF
--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -139,6 +139,11 @@ type QuickReply struct {
 	Extra string `json:"extra,omitempty"`
 }
 
+// RequiresExtra returns whether quick replies of this type need an extra value - a form ID or a URL - to be sendable
+func (qr QuickReply) RequiresExtra() bool {
+	return qr.Type == QuickReplyTypeForm || qr.Type == QuickReplyTypeURL
+}
+
 func (qr QuickReply) GetText() string {
 	if qr.Type == QuickReplyTypeLocation && qr.Text == "" {
 		return "Send Location"

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -256,6 +256,7 @@ type QuickReplyItem struct {
 		Type  string `json:"type"`
 		Label string `json:"label"`
 		Text  string `json:"text,omitempty"`
+		URI   string `json:"uri,omitempty"`
 	} `json:"action"`
 }
 
@@ -342,7 +343,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	// all msg parts in JSON
 	var jsonMsgs []string
 	parts := handlers.SplitMsgByChannel(msg.Channel(), msg.Text(), maxMsgLength)
-	qrs := msg.QuickReplies()
+	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeURL)
 
 	attachments, err := handlers.ResolveAttachments(ctx, h.Backend(), msg.Attachments(), mediaSupport, false, clog)
 	if err != nil {
@@ -393,6 +394,11 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 					item.Action.Type = "message"
 					item.Action.Label = qr.GetText()
 					item.Action.Text = qr.GetText()
+					items = append(items, item)
+				case models.QuickReplyTypeURL:
+					item.Action.Type = "uri"
+					item.Action.Label = qr.GetText()
+					item.Action.URI = qr.Extra
 					items = append(items, item)
 				}
 

--- a/handlers/line/handler_test.go
+++ b/handlers/line/handler_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/courier/v26/utils/clogs"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
@@ -516,6 +517,54 @@ var defaultSendTestCases = []OutgoingTestCase{
 			{
 				Body: `{"to":"uabcdefghij","messages":[{"type":"text","text":"Where are you?","quickReply":{"items":[{"type":"action","action":{"type":"location","label":"Share Pin"}},{"type":"action","action":{"type":"message","label":"No","text":"No"}}]}}]}`,
 			},
+		},
+	},
+	{
+		Label:           "URI Action Quick Reply",
+		MsgText:         "Read more?",
+		MsgURN:          "line:uabcdefghij",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit", Extra: "http://example.com"}, {Type: "text", Text: "No"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.line.me/v2/bot/message/push": {httpx.NewMockResponse(200, nil, []byte(`{}`))},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Body: `{"to":"uabcdefghij","messages":[{"type":"text","text":"Read more?","quickReply":{"items":[{"type":"action","action":{"type":"uri","label":"Visit","uri":"http://example.com"}},{"type":"action","action":{"type":"message","label":"No","text":"No"}}]}}]}`,
+			},
+		},
+	},
+	{
+		Label:           "Quick Reply, URI Action without a URL is dropped",
+		MsgText:         "Read more?",
+		MsgURN:          "line:uabcdefghij",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit"}, {Type: "text", Text: "No"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.line.me/v2/bot/message/push": {httpx.NewMockResponse(200, nil, []byte(`{}`))},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Body: `{"to":"uabcdefghij","messages":[{"type":"text","text":"Read more?","quickReply":{"items":[{"type":"action","action":{"type":"message","label":"No","text":"No"}}]}}]}`,
+			},
+		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type url is missing its extra value and can't be sent"},
+		},
+	},
+	{
+		Label:           "Quick Reply, unsupported types ignored",
+		MsgText:         "Are you happy?",
+		MsgURN:          "line:uabcdefghij",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}, {Type: "text", Text: "Yes"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.line.me/v2/bot/message/push": {httpx.NewMockResponse(200, nil, []byte(`{}`))},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Body: `{"to":"uabcdefghij","messages":[{"type":"text","text":"Are you happy?","quickReply":{"items":[{"type":"action","action":{"type":"message","label":"Yes","text":"Yes"}}]}}]}`,
+			},
+		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
 		},
 	},
 	{

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -60,15 +60,17 @@ func FilterQuickRepliesByType(qrs []models.QuickReply, types ...string) []models
 	return t
 }
 
-// FilterSupportedQuickReplies returns quick replies of the given types only, logging an error for each one dropped
-// because the channel can't render its type.
+// FilterSupportedQuickReplies returns quick replies of the given types only, logging a channel error for each one
+// dropped - either because the channel can't render its type, or because it's missing the extra value its type needs.
 func FilterSupportedQuickReplies(qrs []models.QuickReply, clog *courier.ChannelLog, types ...string) []models.QuickReply {
 	t := make([]models.QuickReply, 0, len(qrs))
 	for _, qr := range qrs {
-		if slices.Contains(types, qr.Type) {
-			t = append(t, qr)
-		} else {
+		if !slices.Contains(types, qr.Type) {
 			clog.Error(&clogs.Error{Message: fmt.Sprintf("quick reply of type %s isn't supported by this channel and can't be sent", qr.Type)})
+		} else if qr.RequiresExtra() && qr.Extra == "" {
+			clog.Error(&clogs.Error{Message: fmt.Sprintf("quick reply of type %s is missing its extra value and can't be sent", qr.Type)})
+		} else {
+			t = append(t, qr)
 		}
 	}
 	return t

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -355,8 +355,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		return courier.ErrChannelConfig
 	}
 
-	// figure out whether we have a keyboard to send as well - we only support text and location quick replies
-	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation)
+	// figure out whether we have a keyboard to send as well
+	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeURL)
 	var keyboard *Keyboard
 
 	if len(qrs) > 0 {

--- a/handlers/viber/handler_test.go
+++ b/handlers/viber/handler_test.go
@@ -129,7 +129,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		Label:           "Quick Reply, unsupported types ignored",
 		MsgText:         "Are you happy?",
 		MsgURN:          "viber:xy5/5y6O81+/kbWHpLhBoA==",
-		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}, {Type: "text", Text: "Yes"}, {Type: "url", Extra: "http://example.com"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}, {Type: "text", Text: "Yes"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"https://chatapi.viber.com/pa/send_message": {
 				httpx.NewMockResponse(200, nil, []byte(`{"status":0,"status_message":"ok","message_token":4987381194038857789}`)),
@@ -141,14 +141,46 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedLogErrors: []*clogs.Error{
 			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
-			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
+		},
+	},
+	{
+		Label:           "Quick Reply, URL Type",
+		MsgText:         "Read more?",
+		MsgURN:          "viber:xy5/5y6O81+/kbWHpLhBoA==",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit", Extra: "http://example.com"}, {Type: "text", Text: "No"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://chatapi.viber.com/pa/send_message": {
+				httpx.NewMockResponse(200, nil, []byte(`{"status":0,"status_message":"ok","message_token":4987381194038857789}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Content-Type": "application/json", "Accept": "application/json"},
+			Body:    `{"auth_token":"Token","receiver":"xy5/5y6O81+/kbWHpLhBoA==","text":"Read more?","type":"text","tracking_data":"0191e180-7d60-7000-aded-7d8b151cbd5b","keyboard":{"Type":"keyboard","DefaultHeight":false,"Buttons":[{"ActionType":"open-url","ActionBody":"http://example.com","Text":"Visit","TextSize":"regular","Columns":"3"},{"ActionType":"reply","ActionBody":"No","Text":"No","TextSize":"regular","Columns":"3"}]}}`,
+		}},
+	},
+	{
+		Label:           "Quick Reply, URL Type without a URL is dropped",
+		MsgText:         "Are you happy?",
+		MsgURN:          "viber:xy5/5y6O81+/kbWHpLhBoA==",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit"}, {Type: "text", Text: "Yes"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://chatapi.viber.com/pa/send_message": {
+				httpx.NewMockResponse(200, nil, []byte(`{"status":0,"status_message":"ok","message_token":4987381194038857789}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Content-Type": "application/json", "Accept": "application/json"},
+			Body:    `{"auth_token":"Token","receiver":"xy5/5y6O81+/kbWHpLhBoA==","text":"Are you happy?","type":"text","tracking_data":"0191e180-7d60-7000-aded-7d8b151cbd5b","keyboard":{"Type":"keyboard","DefaultHeight":false,"Buttons":[{"ActionType":"reply","ActionBody":"Yes","Text":"Yes","TextSize":"regular","Columns":"6"}]}}`,
+		}},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type url is missing its extra value and can't be sent"},
 		},
 	},
 	{
 		Label:           "Quick Reply, only unsupported types means no keyboard",
 		MsgText:         "Are you happy?",
 		MsgURN:          "viber:xy5/5y6O81+/kbWHpLhBoA==",
-		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}, {Type: "url", Extra: "http://example.com"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"https://chatapi.viber.com/pa/send_message": {
 				httpx.NewMockResponse(200, nil, []byte(`{"status":0,"status_message":"ok","message_token":4987381194038857789}`)),
@@ -160,7 +192,6 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedLogErrors: []*clogs.Error{
 			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
-			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
 		},
 	},
 	{

--- a/handlers/viber/keyboard.go
+++ b/handlers/viber/keyboard.go
@@ -46,17 +46,21 @@ func NewKeyboardFromReplies(replies []models.QuickReply, buttonConfig map[string
 		for j := range rows[i] {
 			cols := 6 / len(rows[i])
 
-			actionType := "reply"
-			if rows[i][j].Type == models.QuickReplyTypeLocation {
-				actionType = "location-picker"
-			}
-
 			actionText := rows[i][j].GetText()
+
+			// for open-url buttons the action body is the URL itself, for the rest it's the button text
+			actionType, actionBody := "reply", actionText
+			switch rows[i][j].Type {
+			case models.QuickReplyTypeLocation:
+				actionType = "location-picker"
+			case models.QuickReplyTypeURL:
+				actionType, actionBody = "open-url", rows[i][j].Extra
+			}
 
 			button := KeyboardButton{
 				ActionType: actionType,
 				TextSize:   "regular",
-				ActionBody: actionText,
+				ActionBody: actionBody,
 				Text:       html.EscapeString(actionText),
 				Columns:    fmt.Sprint(cols),
 			}

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -435,8 +435,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	params.Set(paramMessage, text)
 	params.Set(paramAttachments, attachments)
 
-	// we only support text quick replies
-	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText)
+	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeURL)
 	if len(qrs) != 0 {
 		keyboard := NewKeyboardFromReplies(qrs)
 

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -223,6 +223,8 @@ const keyboardJson = `{"one_time":true,"buttons":[[{"action":{"type":"text","lab
 
 const singleButtonKeyboardJson = `{"one_time":true,"buttons":[[{"action":{"type":"text","label":"A","payload":"\"A\""},"color":"primary"}]],"inline":false}`
 
+const locationAndURLKeyboardJson = `{"one_time":true,"buttons":[[{"action":{"type":"location","payload":"\"Send Location\""}},{"action":{"type":"open_link","label":"Visit","link":"http://example.com","payload":"\"Visit\""},"color":"primary"}]],"inline":false}`
+
 var testCases = []IncomingTestCase{
 	{
 		Label:                "Receive Message",
@@ -497,7 +499,7 @@ var outgoingCases = []OutgoingTestCase{
 		Label:           "Send keyboard, unsupported types ignored",
 		MsgText:         "Send keyboard",
 		MsgURN:          "vk:123456789",
-		MsgQuickReplies: []models.QuickReply{{Type: "location"}, {Type: "text", Text: "A"}, {Type: "form", Extra: "1234"}, {Type: "url", Extra: "http://example.com"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "A"}, {Type: "form", Extra: "1234"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"https://api.vk.com/method/messages.send.json?*": {
 				httpx.NewMockResponse(200, nil, []byte(`{"response": 1}`)),
@@ -509,9 +511,44 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedLogErrors: []*clogs.Error{
-			{Message: "quick reply of type location isn't supported by this channel and can't be sent"},
 			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
-			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
+		},
+		ExpectedExtIDs: []string{"1"},
+	},
+	{
+		Label:           "Send keyboard, location and URL types",
+		MsgText:         "Send keyboard",
+		MsgURN:          "vk:123456789",
+		MsgQuickReplies: []models.QuickReply{{Type: "location"}, {Type: "url", Text: "Visit", Extra: "http://example.com"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.vk.com/method/messages.send.json?*": {
+				httpx.NewMockResponse(200, nil, []byte(`{"response": 1}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "keyboard": {locationAndURLKeyboardJson}, "message": {"Send keyboard"}, "random_id": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}, "user_id": {"123456789"}, "v": {"5.103"}},
+			},
+		},
+		ExpectedExtIDs: []string{"1"},
+	},
+	{
+		Label:           "Send keyboard, URL type without a URL is dropped",
+		MsgText:         "Send keyboard",
+		MsgURN:          "vk:123456789",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit"}, {Type: "text", Text: "A"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.vk.com/method/messages.send.json?*": {
+				httpx.NewMockResponse(200, nil, []byte(`{"response": 1}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "keyboard": {singleButtonKeyboardJson}, "message": {"Send keyboard"}, "random_id": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}, "user_id": {"123456789"}, "v": {"5.103"}},
+			},
+		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type url is missing its extra value and can't be sent"},
 		},
 		ExpectedExtIDs: []string{"1"},
 	},
@@ -519,7 +556,7 @@ var outgoingCases = []OutgoingTestCase{
 		Label:           "Send keyboard, only unsupported types means no keyboard",
 		MsgText:         "Send keyboard",
 		MsgURN:          "vk:123456789",
-		MsgQuickReplies: []models.QuickReply{{Type: "location"}, {Type: "form", Extra: "1234"}, {Type: "url", Extra: "http://example.com"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"https://api.vk.com/method/messages.send.json?*": {
 				httpx.NewMockResponse(200, nil, []byte(`{"response": 1}`)),
@@ -531,9 +568,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedLogErrors: []*clogs.Error{
-			{Message: "quick reply of type location isn't supported by this channel and can't be sent"},
 			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
-			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
 		},
 		ExpectedExtIDs: []string{"1"},
 	},

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -223,7 +223,9 @@ const keyboardJson = `{"one_time":true,"buttons":[[{"action":{"type":"text","lab
 
 const singleButtonKeyboardJson = `{"one_time":true,"buttons":[[{"action":{"type":"text","label":"A","payload":"\"A\""},"color":"primary"}]],"inline":false}`
 
-const locationAndURLKeyboardJson = `{"one_time":true,"buttons":[[{"action":{"type":"location","payload":"\"Send Location\""}},{"action":{"type":"open_link","label":"Visit","link":"http://example.com","payload":"\"Visit\""},"color":"primary"}]],"inline":false}`
+const locationAndURLKeyboardJson = `{"one_time":true,"buttons":[[{"action":{"type":"location","payload":"\"Send Location\""}}],[{"action":{"type":"open_link","label":"Visit","link":"http://example.com","payload":"\"Visit\""},"color":"primary"}]],"inline":false}`
+
+const locationSplitsRowKeyboardJson = `{"one_time":true,"buttons":[[{"action":{"type":"text","label":"A","payload":"\"A\""},"color":"primary"}],[{"action":{"type":"location","payload":"\"Send Location\""}}],[{"action":{"type":"text","label":"B","payload":"\"B\""},"color":"primary"}]],"inline":false}`
 
 var testCases = []IncomingTestCase{
 	{
@@ -528,6 +530,23 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{
 				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "keyboard": {locationAndURLKeyboardJson}, "message": {"Send keyboard"}, "random_id": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}, "user_id": {"123456789"}, "v": {"5.103"}},
+			},
+		},
+		ExpectedExtIDs: []string{"1"},
+	},
+	{
+		Label:           "Send keyboard, location type takes a row of its own",
+		MsgText:         "Send keyboard",
+		MsgURN:          "vk:123456789",
+		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "A"}, {Type: "location"}, {Type: "text", Text: "B"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.vk.com/method/messages.send.json?*": {
+				httpx.NewMockResponse(200, nil, []byte(`{"response": 1}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "keyboard": {locationSplitsRowKeyboardJson}, "message": {"Send keyboard"}, "random_id": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}, "user_id": {"123456789"}, "v": {"5.103"}},
 			},
 		},
 		ExpectedExtIDs: []string{"1"},

--- a/handlers/vk/keyboard.go
+++ b/handlers/vk/keyboard.go
@@ -23,9 +23,37 @@ type ButtonAction struct {
 	Payload string `json:"payload"`
 }
 
+// splitOutLocations re-organizes rows so that each location reply gets a row to itself, as VK rejects a keyboard
+// which puts a location button on a row with anything else.
+func splitOutLocations(rows [][]models.QuickReply) [][]models.QuickReply {
+	split := make([][]models.QuickReply, 0, len(rows))
+
+	for _, row := range rows {
+		cur := make([]models.QuickReply, 0, len(row))
+
+		for _, qr := range row {
+			if qr.Type != models.QuickReplyTypeLocation {
+				cur = append(cur, qr)
+				continue
+			}
+			if len(cur) > 0 {
+				split = append(split, cur)
+				cur = make([]models.QuickReply, 0, len(row))
+			}
+			split = append(split, []models.QuickReply{qr})
+		}
+
+		if len(cur) > 0 {
+			split = append(split, cur)
+		}
+	}
+
+	return split
+}
+
 // NewKeyboardFromReplies creates a keyboard from the given quick replies
 func NewKeyboardFromReplies(replies []models.QuickReply) *Keyboard {
-	rows := models.QuickRepliesToRows(replies, 10, 30, 2)
+	rows := splitOutLocations(models.QuickRepliesToRows(replies, 10, 30, 2))
 	buttons := make([][]ButtonPayload, len(rows))
 
 	for i := range rows {

--- a/handlers/vk/keyboard.go
+++ b/handlers/vk/keyboard.go
@@ -13,12 +13,13 @@ type Keyboard struct {
 
 type ButtonPayload struct {
 	Action ButtonAction `json:"action"`
-	Color  string       `json:"color"`
+	Color  string       `json:"color,omitempty"`
 }
 
 type ButtonAction struct {
 	Type    string `json:"type"`
-	Label   string `json:"label"`
+	Label   string `json:"label,omitempty"`
+	Link    string `json:"link,omitempty"`
 	Payload string `json:"payload"`
 }
 
@@ -30,10 +31,23 @@ func NewKeyboardFromReplies(replies []models.QuickReply) *Keyboard {
 	for i := range rows {
 		buttons[i] = make([]ButtonPayload, len(rows[i]))
 		for j := range rows[i] {
-			buttons[i][j].Action.Label = rows[i][j].GetText()
-			buttons[i][j].Action.Type = "text"
-			buttons[i][j].Action.Payload = string(jsonx.MustMarshal(rows[i][j].GetText()))
-			buttons[i][j].Color = "primary"
+			qr := rows[i][j]
+			buttons[i][j].Action.Payload = string(jsonx.MustMarshal(qr.GetText()))
+
+			switch qr.Type {
+			case models.QuickReplyTypeLocation:
+				// location buttons carry no label or color and always take up the whole row width
+				buttons[i][j].Action.Type = "location"
+			case models.QuickReplyTypeURL:
+				buttons[i][j].Action.Type = "open_link"
+				buttons[i][j].Action.Label = qr.GetText()
+				buttons[i][j].Action.Link = qr.Extra
+				buttons[i][j].Color = "primary"
+			default:
+				buttons[i][j].Action.Type = "text"
+				buttons[i][j].Action.Label = qr.GetText()
+				buttons[i][j].Color = "primary"
+			}
 		}
 	}
 


### PR DESCRIPTION
## What

An audit of quick reply support against the vendor docs found that several channels have button types we simply weren't using. This closes the four gaps that were small additions to code paths that already existed:

| Channel | Type added | Rendered as |
|---|---|---|
| Line | url | `uri` action in the quick reply item |
| Viber | url | `open-url` action type, URL in `ActionBody` |
| VK | url | `open_link` action with a `link` field |
| VK | location | `location` action |

VK's location button carries no label or colour and always takes the full row width, so it's serialised accordingly — `Label` and `Color` are now `omitempty`.

## Supporting changes

`FilterSupportedQuickReplies` now also drops quick replies whose type requires an extra value but doesn't have one, backed by a new `QuickReply.RequiresExtra()`. Without this a url quick reply with no URL would render as a button pointing nowhere — the same class of bug as the dead "Open Link" buttons fixed in #1078. The WhatsApp handlers already did this via `FilterURLQuickReplies`; this generalises it so all four channels get the check.

Line now routes its quick replies through `FilterSupportedQuickReplies` as well, so a type it can't render is logged rather than silently skipped by its switch statement.

## Why

Before this, a `url` quick reply sent to a Line, Viber or VK contact was dropped even though all three platforms support link buttons natively, and a `location` quick reply on VK was dropped despite VK having a location action. That made the support matrix look like a platform limitation when it was an implementation gap.

## Notes for reviewers

- **The payload shapes are verified against vendor documentation, not against live sends.** The tests assert we produce the documented JSON, not that each platform accepts it. VK's location button is the one most worth smoke-testing — its "no label, always full width" behaviour is documented in client libraries rather than VK's own API reference, which I wasn't able to reach directly.
- VK requires a location button to occupy a row on its own — the reference `vk_api` client raises rather than letting one share a row, so a mixed row risks the send being refused outright. `NewKeyboardFromReplies` runs the output of `QuickRepliesToRows` through a `splitOutLocations` pass to guarantee this. (An earlier revision of this description called it appearance-only; that was wrong, and the review caught it.)
- Telegram was deliberately left out of scope. It could support form quick replies via `KeyboardButton.web_app`, but its url support lives on `InlineKeyboardButton`, and a message carries either a reply keyboard or an inline keyboard — never both — so mixing text and url quick replies in one message needs a design decision rather than an implementation.
- Facebook and Instagram remain text-only by genuine platform limitation; Meta removed the location quick reply content type in 2019.

## Testing

Link-rendering and missing-URL cases for each of the three channels, plus VK location cases covering both a location reply on its own and one between two text replies (`[A, location, B]` -> three rows), which checks the row splitting mid-row rather than only at the edges. The four cases added in #1078 that asserted these types were *dropped* have been rewritten to use `form` as the unsupported type, since it's the only type none of the three can render. Full suite passes.
