### PR TITLE
Add form quick reply support for Telegram using Mini Apps

### DIFF
--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/utils"
+	"github.com/nyaruka/courier/v26/utils/clogs"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/core/events"
@@ -128,7 +129,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 			webAppPayload = json.RawMessage(raw)
 		} else {
 			text = payload.Message.WebAppData.Data
-			courier.LogRequestError(r, channel, errors.New("web_app_data data is not a valid JSON object"))
+			clog.Error(&clogs.Error{Message: "web_app_data data is not a valid JSON object"})
 		}
 	}
 

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -88,6 +88,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 
 	// deal with attachments
 	mediaURL := ""
+	var webAppPayload json.RawMessage
 	if len(payload.Message.Photo) > 0 {
 		// grab the largest photo less than 100k
 		photo := payload.Message.Photo[0]
@@ -118,6 +119,17 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 			phone = fmt.Sprintf("(%s)", payload.Message.Contact.PhoneNumber)
 		}
 		text = utils.JoinNonEmpty(" ", payload.Message.Contact.FirstName, payload.Message.Contact.LastName, phone)
+	} else if payload.Message.WebAppData != nil {
+		// data sent back from a Mini App opened by a form quick reply.. which we require to be a JSON object that
+		// becomes our structured payload, falling back to treating it as plain text if it isn't
+		raw := strings.TrimSpace(payload.Message.WebAppData.Data)
+		if strings.HasPrefix(raw, "{") && json.Valid([]byte(raw)) {
+			text = payload.Message.WebAppData.ButtonText
+			webAppPayload = json.RawMessage(raw)
+		} else {
+			text = payload.Message.WebAppData.Data
+			courier.LogRequestError(r, channel, errors.New("web_app_data data is not a valid JSON object"))
+		}
 	}
 
 	// we had an error downloading media
@@ -131,6 +143,10 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	if mediaURL != "" {
 		msg.WithAttachment(mediaURL)
 	}
+	if webAppPayload != nil {
+		msg.WithPayload(webAppPayload)
+	}
+
 	// and finally write our message
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
@@ -201,8 +217,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		caption = msg.Text()
 	}
 
-	// figure out whether we have a keyboard to send as well - we only support text and location quick replies
-	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation)
+	// figure out whether we have a keyboard to send as well - form replies open the URL in Extra as a Mini App
+	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeForm)
 	var keyboard *ReplyKeyboardMarkup
 	if len(qrs) > 0 {
 		keyboard = NewKeyboardFromReplies(qrs)
@@ -450,5 +466,9 @@ type moPayload struct {
 			FirstName   string `json:"first_name"`
 			LastName    string `json:"last_name"`
 		}
+		WebAppData *struct {
+			Data       string `json:"data"`
+			ButtonText string `json:"button_text"`
+		} `json:"web_app_data"`
 	} `json:"message"`
 }

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -521,6 +521,58 @@ var contactMsg = `
     }
 }`
 
+var webAppDataMsg = `
+{
+    "update_id": 900946537,
+    "message": {
+        "message_id": 97,
+        "from": {
+            "id": 3527065,
+            "first_name": "Nic",
+            "last_name": "Pottier",
+            "username": "Nicpottier"
+        },
+        "chat": {
+            "id": 3527065,
+            "first_name": "Nic",
+            "last_name": "Pottier",
+            "username": "Nicpottier",
+            "type": "private"
+        },
+        "date": 1493845755,
+        "web_app_data": {
+            "data": "{\"first_name\": \"Bob\", \"age\": \"32\"}",
+            "button_text": "Register"
+        }
+    }
+}`
+
+var webAppDataNonJSONMsg = `
+{
+    "update_id": 900946538,
+    "message": {
+        "message_id": 98,
+        "from": {
+            "id": 3527065,
+            "first_name": "Nic",
+            "last_name": "Pottier",
+            "username": "Nicpottier"
+        },
+        "chat": {
+            "id": 3527065,
+            "first_name": "Nic",
+            "last_name": "Pottier",
+            "username": "Nicpottier",
+            "type": "private"
+        },
+        "date": 1493845755,
+        "web_app_data": {
+            "data": "bob,32",
+            "button_text": "Register"
+        }
+    }
+}`
+
 var testCases = []IncomingTestCase{
 	{
 
@@ -662,6 +714,31 @@ var testCases = []IncomingTestCase{
 		ExpectedMsgText:      Sp("Adolf Taxi (0788531373)"),
 		ExpectedURN:          "telegram:3527065#nicpottier",
 		ExpectedExternalID:   "96",
+		ExpectedDate:         time.Date(2017, 5, 3, 21, 9, 15, 0, time.UTC),
+	},
+	{
+		Label:                "Receive WebApp Data",
+		URL:                  "/c/tg/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive/",
+		Data:                 webAppDataMsg,
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: "Accepted",
+		ExpectedContactName:  Sp("Nic Pottier"),
+		ExpectedMsgText:      Sp("Register"),
+		ExpectedPayload:      `{"first_name": "Bob", "age": "32"}`,
+		ExpectedURN:          "telegram:3527065#nicpottier",
+		ExpectedExternalID:   "97",
+		ExpectedDate:         time.Date(2017, 5, 3, 21, 9, 15, 0, time.UTC),
+	},
+	{
+		Label:                "Receive WebApp Data non-JSON",
+		URL:                  "/c/tg/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive/",
+		Data:                 webAppDataNonJSONMsg,
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: "Accepted",
+		ExpectedContactName:  Sp("Nic Pottier"),
+		ExpectedMsgText:      Sp("bob,32"),
+		ExpectedURN:          "telegram:3527065#nicpottier",
+		ExpectedExternalID:   "98",
 		ExpectedDate:         time.Date(2017, 5, 3, 21, 9, 15, 0, time.UTC),
 	},
 	{
@@ -831,10 +908,43 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
+		Label:           "Quick Reply, form type opens Mini App",
+		MsgText:         "Please register",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Register", Extra: "https://example.com/form"}, {Type: "text", Text: "Skip"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
+		Label:           "Quick Reply, form type without a URL is dropped",
+		MsgText:         "Please register",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Register"}, {Type: "text", Text: "Skip"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type form is missing its extra value and can't be sent"},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
 		Label:           "Quick Reply, unsupported types ignored",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",
-		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}, {Type: "text", Text: "Yes"}, {Type: "url", Extra: "http://example.com"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "url", Extra: "http://example.com"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
@@ -844,7 +954,6 @@ var outgoingCases = []OutgoingTestCase{
 			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Yes"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
 		},
 		ExpectedLogErrors: []*clogs.Error{
-			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
 			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
 		},
 		ExpectedExtIDs: []string{"133"},
@@ -853,7 +962,7 @@ var outgoingCases = []OutgoingTestCase{
 		Label:           "Quick Reply, only unsupported types means no keyboard",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",
-		MsgQuickReplies: []models.QuickReply{{Type: "form", Extra: "1234"}, {Type: "url", Extra: "http://example.com"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Extra: "http://example.com"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
@@ -863,7 +972,6 @@ var outgoingCases = []OutgoingTestCase{
 			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
 		},
 		ExpectedLogErrors: []*clogs.Error{
-			{Message: "quick reply of type form isn't supported by this channel and can't be sent"},
 			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
 		},
 		ExpectedExtIDs: []string{"133"},

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -740,6 +740,7 @@ var testCases = []IncomingTestCase{
 		ExpectedURN:          "telegram:3527065#nicpottier",
 		ExpectedExternalID:   "98",
 		ExpectedDate:         time.Date(2017, 5, 3, 21, 9, 15, 0, time.UTC),
+		ExpectedErrors:       []*clogs.Error{{Message: "web_app_data data is not a valid JSON object"}},
 	},
 	{
 		Label:                "Receive Empty",

--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -4,11 +4,17 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 )
 
+// WebAppInfo describes a Mini App to be launched, see https://core.telegram.org/bots/api/#webappinfo
+type WebAppInfo struct {
+	URL string `json:"url"`
+}
+
 // KeyboardButton is button on a keyboard, see https://core.telegram.org/bots/api/#keyboardbutton
 type KeyboardButton struct {
-	Text            string `json:"text"`
-	RequestContact  bool   `json:"request_contact,omitempty"`
-	RequestLocation bool   `json:"request_location,omitempty"`
+	Text            string      `json:"text"`
+	RequestContact  bool        `json:"request_contact,omitempty"`
+	RequestLocation bool        `json:"request_location,omitempty"`
+	WebApp          *WebAppInfo `json:"web_app,omitempty"`
 }
 
 // ReplyKeyboardMarkup models a keyboard, see https://core.telegram.org/bots/api/#replykeyboardmarkup
@@ -27,10 +33,15 @@ func NewKeyboardFromReplies(replies []models.QuickReply) *ReplyKeyboardMarkup {
 		keyboard[i] = make([]KeyboardButton, len(rows[i]))
 		for j := range rows[i] {
 			keyboard[i][j].Text = rows[i][j].GetText()
-			if rows[i][j].Type == models.QuickReplyTypeLocation {
-				keyboard[i][j].RequestLocation = true
-			}
 
+			// a button can specify at most one of these optional fields, but each reply is its own button so text,
+			// location and form replies can all appear on the same keyboard
+			switch rows[i][j].Type {
+			case models.QuickReplyTypeLocation:
+				keyboard[i][j].RequestLocation = true
+			case models.QuickReplyTypeForm:
+				keyboard[i][j].WebApp = &WebAppInfo{URL: rows[i][j].Extra}
+			}
 		}
 	}
 

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -74,6 +74,16 @@ func TestKeyboardFromReplies(t *testing.T) {
 				true, true,
 			},
 		},
+		{
+
+			[]models.QuickReply{{Type: "form", Extra: "https://example.com/form"}, {Type: "text", Text: "Skip"}},
+			&telegram.ReplyKeyboardMarkup{
+				[][]telegram.KeyboardButton{
+					{{Text: "Open Form", WebApp: &telegram.WebAppInfo{URL: "https://example.com/form"}}, {Text: "Skip"}},
+				},
+				true, true,
+			},
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
## What

A `form` quick reply sent to a Telegram channel now renders as a `web_app` keyboard button that opens the URL in the reply's extra value as a Telegram Mini App. Since each reply is its own button on the reply keyboard we already build, text, location and form replies all coexist on one keyboard — nothing needs to be prioritised or dropped.

On the receive side, data the Mini App sends back via `Telegram.WebApp.sendData()` arrives as a `web_app_data` message, which the handler now parses:

- **JSON object** → becomes the incoming message's structured payload (via `WithPayload`, the same mechanism WhatsApp flow replies use), with the button text as the message text.
- **Anything else** → treated as plain message text, with a logged request error, since returning a JSON object is the documented requirement for Mini Apps used this way.

## Why

This is the follow-up to #1079's audit: Telegram's `KeyboardButton.web_app` is a close structural analogue to WhatsApp Flows — a button that opens a hosted form whose answers come back as a structured response — and it fits the reply keyboard courier already builds, so form support needed no new message types.

Unlike WhatsApp, where `Extra` is a Meta-hosted Flow ID, on Telegram it's the Mini App URL. That's intentional: the advanced quick reply types are an escape hatch for channel-specific features, so the meaning of the extra value is defined per channel and will be documented as such.

## Notes for reviewers

- A form reply without a URL is dropped and logged by the `RequiresExtra` check that landed in #1079 — no new validation needed here.
- `url` quick replies remain unsupported on Telegram: link buttons only exist on inline keyboards, which can't be combined with the reply keyboard in a single message. The test cases that previously used `form` as Telegram's unsupported-type example now use `url`.
- **Verified against the Bot API docs, not a live bot.** Two things worth a manual smoke test before this reaches users: the docs don't require BotFather domain registration for `web_app` keyboard buttons (the `/setdomain` requirement belongs to the Login Widget), but that's an absence of a stated requirement rather than an explicit guarantee; and the full `sendData` round trip (button → Mini App → `web_app_data` message) hasn't been exercised end to end.
- `sendData` only works for Mini Apps opened from reply keyboard buttons — which is exactly what we build — not inline buttons, so the send and receive halves are consistent.

## Testing

Keyboard-level rendering of the `web_app` button; outgoing cases for a form reply alongside a text reply and for a form reply missing its URL; incoming `web_app_data` cases with JSON and non-JSON data, asserting the structured payload lands on the message in the JSON case. Full suite passes.