### PR TITLE
Increase max message length to 4096 for WhatsApp Cloud

### DIFF
--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -40,6 +40,9 @@ var (
 	// max for the body
 	maxMsgLength = 1000
 
+	// max for the body of WhatsApp messages
+	maxMsgLengthWAC = 4096
+
 	// Sticker ID substitutions
 	stickerIDToEmoji = map[int64]string{
 		369239263222822: "👍", // small
@@ -712,7 +715,7 @@ func (h *handler) sendWhatsAppMsg(ctx context.Context, msg courier.MsgOut, res *
 	path, _ := url.Parse(fmt.Sprintf("/%s/messages", msg.Channel().Address()))
 	wacPhoneURL := base.ResolveReference(path)
 
-	requestPayloads, err := whatsapp.GetMsgPayloads(ctx, msg, maxMsgLength, clog)
+	requestPayloads, err := whatsapp.GetMsgPayloads(ctx, msg, maxMsgLengthWAC, clog)
 	if err != nil {
 		return err
 	}

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -1076,7 +1076,7 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 
 func TestWhatsAppOutgoing(t *testing.T) {
 	// shorter max msg length for testing
-	maxMsgLength = 100
+	maxMsgLengthWAC = 100
 
 	var channel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WAC", "12345_ID", "", []string{urns.WhatsApp.Prefix}, map[string]any{models.ConfigAuthToken: "a123"})
 

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -42,14 +42,24 @@ func (p SendRequest) withTemplate(templating *models.Templating) SendRequest {
 	return p
 }
 
+// maxCaptionAndBodyLength is the limit for media captions and interactive message bodies, which is lower than the
+// limit for plain text bodies
+const maxCaptionAndBodyLength = 1024
+
 // buildContentPayloads constructs payloads for a non-template message with text, attachments, and quick replies.
 func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.ChannelLog) ([]SendRequest, error) {
-	msgParts := splitText(msg, maxMsgLength)
 	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
 	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
 	formQRs := FilterFormQuickReplies(msg.QuickReplies(), clog)
 	urlQRs := FilterURLQuickReplies(msg.QuickReplies(), clog)
 	menuButton := handlers.GetText("Menu", msg.Locale())
+
+	// if text could end up as a media caption or an interactive message body, use their lower length limit
+	if len(msg.Attachments()) > 0 || len(qrs) > 0 || len(locationQRs) > 0 || len(formQRs) > 0 || len(urlQRs) > 0 {
+		maxMsgLength = min(maxMsgLength, maxCaptionAndBodyLength)
+	}
+
+	msgParts := splitText(msg, maxMsgLength)
 
 	qrsAsList := shouldUseList(qrs)
 

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -3,6 +3,7 @@ package whatsapp_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/nyaruka/courier/v26"
@@ -382,6 +383,48 @@ func TestGetMsgPayloads(t *testing.T) {
 				assert.Equal(t, "text", payloads[0].Type)
 				assert.Len(t, clog.Errors, 1)
 				assert.Equal(t, "URL quick reply is missing a URL and can't be sent", clog.Errors[0].Message)
+			},
+		},
+		{
+			label:                 "Text between 1024 and 4096 without attachments or QRs - should be a single text message",
+			text:                  strings.Repeat("x", 2000),
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "text",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, 2000, len(payloads[0].Text.Body))
+			},
+		},
+		{
+			label:                 "Text between 1024 and 4096 with QRs - should split so interactive body stays within 1024",
+			text:                  strings.Repeat("x", 2000),
+			quickReplies:          []models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "text", Text: "No"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 2,
+			expectedType:          "text",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
+				assert.Equal(t, 2, len(payloads))
+				assert.Equal(t, "text", payloads[0].Type)
+				assert.Equal(t, "interactive", payloads[1].Type)
+				assert.LessOrEqual(t, len(payloads[1].Interactive.Body.Text), 1024)
+			},
+		},
+		{
+			label:                 "Text between 1024 and 4096 with attachment - should split so nothing exceeds caption limit",
+			text:                  strings.Repeat("x", 2000),
+			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 3,
+			expectedType:          "image",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *courier.ChannelLog) {
+				assert.Equal(t, 3, len(payloads))
+				assert.Equal(t, "image", payloads[0].Type)
+				assert.Equal(t, "", payloads[0].Image.Caption)
+				assert.Equal(t, "text", payloads[1].Type)
+				assert.Equal(t, "text", payloads[2].Type)
+				assert.LessOrEqual(t, len(payloads[1].Text.Body), 1024)
+				assert.LessOrEqual(t, len(payloads[2].Text.Body), 1024)
 			},
 		},
 	}


### PR DESCRIPTION
WhatsApp Cloud API supports text bodies up to 4096 characters, but the handler was splitting messages at the 1000 character limit shared with Facebook Messenger and Instagram. This adds a separate limit for WhatsApp Cloud so longer messages are sent as a single message instead of being split unnecessarily. Messenger and Instagram keep the existing 1000 character limit.