### PR TITLE
Allow cmd entry points to take customized config defaults

### DIFF
--- a/cmd/courier/main.go
+++ b/cmd/courier/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/nyaruka/courier/v26/cmd"
+	"github.com/nyaruka/courier/v26/runtime"
 
 	// load available backends
 	_ "github.com/nyaruka/courier/v26/backends/rapidpro"
@@ -70,5 +71,5 @@ var (
 )
 
 func main() {
-	cmd.Run(cmd.Service(version, date))
+	cmd.Run(cmd.Service(runtime.NewDefaultConfig(), version, date))
 }

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -22,9 +22,13 @@ import (
 // timeouts should be set a bit above this so the watchdog fires first.
 const shutdownTimeout = 90 * time.Second
 
-// Service starts the courier service, blocks until a termination signal is received, then stops it.
-func Service(version, date string) error {
-	cfg := runtime.LoadConfig()
+// Service starts the courier service, blocks until a termination signal is received, then stops it. Configuration
+// is loaded on top of the given defaults, e.g. runtime.NewDefaultConfig().
+func Service(defaults *runtime.Config, version, date string) error {
+	cfg, err := runtime.LoadConfig(defaults)
+	if err != nil {
+		return err
+	}
 	cfg.Version = version
 
 	// configure our logger

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"fmt"
-	"log"
 	"log/slog"
 	"net"
 	"net/url"
@@ -95,17 +94,22 @@ func NewDefaultConfig() *Config {
 	}
 }
 
-func LoadConfig() *Config {
-	cfg := NewDefaultConfig()
+// LoadConfig loads configuration from a config file, environment variables and command line args, on top of the
+// given base config, e.g. NewDefaultConfig().
+func LoadConfig(cfg *Config, args ...string) (*Config, error) {
 	loader := ezconf.NewLoader(cfg, "courier", "Courier - A fast message broker for SMS and IP messages", []string{"config.toml"})
-	loader.MustLoad()
-
-	// ensure config is valid
-	if err := cfg.Validate(); err != nil {
-		log.Fatalf("invalid config: %s", err)
+	if len(args) > 0 { // allow tests to pass in args
+		loader.SetArgs(args...)
+	}
+	if err := loader.Load(); err != nil {
+		return nil, err
 	}
 
-	return cfg
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	return cfg, nil
 }
 
 // Validate validates the config

--- a/runtime/config_test.go
+++ b/runtime/config_test.go
@@ -1,6 +1,7 @@
 package runtime_test
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/nyaruka/courier/v26/runtime"
@@ -23,11 +24,13 @@ func TestLoadConfig(t *testing.T) {
 	base := runtime.NewDefaultConfig()
 	base.Domain = "example.com"
 	base.DisallowedNetworks = append(base.DisallowedNetworks, `192.0.2.0/24`)
+	base.LogLevel = slog.LevelError
 
 	cfg, err := runtime.LoadConfig(base, `--log-level=warn`)
 	assert.NoError(t, err)
 	assert.Equal(t, "example.com", cfg.Domain)
 	assert.Contains(t, cfg.DisallowedNetworks, `192.0.2.0/24`)
+	assert.Equal(t, slog.LevelWarn, cfg.LogLevel)
 
 	// but explicitly set values still take precedence
 	base = runtime.NewDefaultConfig()

--- a/runtime/config_test.go
+++ b/runtime/config_test.go
@@ -18,6 +18,32 @@ var invalidConfigTestCases = []struct {
 	{config: &runtime.Config{DB: "postgres://temba:temba@postgres/temba?sslmode=disable", Valkey: "valkey://valkey:6379/15", SendProxyURL: "not-a-url"}, expectedError: "Field validation for 'SendProxyURL' failed on the 'http_url' tag"},
 }
 
+func TestLoadConfig(t *testing.T) {
+	// caller can customize the base config..
+	base := runtime.NewDefaultConfig()
+	base.Domain = "example.com"
+	base.DisallowedNetworks = append(base.DisallowedNetworks, `192.0.2.0/24`)
+
+	cfg, err := runtime.LoadConfig(base, `--log-level=warn`)
+	assert.NoError(t, err)
+	assert.Equal(t, "example.com", cfg.Domain)
+	assert.Contains(t, cfg.DisallowedNetworks, `192.0.2.0/24`)
+
+	// but explicitly set values still take precedence
+	base = runtime.NewDefaultConfig()
+	base.Domain = "example.com"
+	base.DisallowedNetworks = append(base.DisallowedNetworks, `192.0.2.0/24`)
+
+	cfg, err = runtime.LoadConfig(base, `--domain=temba.io`)
+	assert.NoError(t, err)
+	assert.Equal(t, "temba.io", cfg.Domain)
+	assert.Contains(t, cfg.DisallowedNetworks, `192.0.2.0/24`)
+
+	// invalid values are rejected
+	_, err = runtime.LoadConfig(runtime.NewDefaultConfig(), `--disallowed-networks="127.0.0.1`)
+	assert.Error(t, err)
+}
+
 func TestConfigValidate(t *testing.T) {
 	for _, tc := range invalidConfigTestCases {
 		err := tc.config.Validate()


### PR DESCRIPTION
## Summary

Lets callers of the `cmd` entry points provide their own config defaults. `cmd.Service` now takes a base config and `runtime.LoadConfig` loads config file / env / command line values on top of it, so embedders can customize default config values — mirroring the same change recently made in mailroom (nyaruka/mailroom#1183). Values set explicitly via file/env/args still take precedence over the passed-in defaults.

## Changes

- `runtime.LoadConfig(cfg *Config, args ...string) (*Config, error)` — takes the base config instead of always starting from `NewDefaultConfig()`, accepts optional args for tests, and returns an error instead of calling `log.Fatalf` so entry points report config problems through the normal error path
- `cmd.Service(defaults *runtime.Config, version, date string)` — takes the base config and passes it to `LoadConfig`
- `cmd/courier/main.go` — passes `runtime.NewDefaultConfig()`

## Test plan

- New `TestLoadConfig` covers: customized base values (including an appended `DisallowedNetworks` entry) surviving loading, explicitly set values overriding customized base values, and invalid values still being rejected
- Full test suite passes