### PR TITLE
Support sending to WhatsApp BSUIDs held as whatsapp URNs

### DIFF
--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -383,6 +383,23 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
+		Label:   "Plain Send with BSUID as whatsapp URN",
+		MsgText: "Simple Message",
+		MsgURN:  "whatsapp:US.1234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://waba-v2.360dialog.io/messages": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Path: "/messages",
+				Body: `{"messaging_product":"whatsapp","recipient_type":"individual","recipient":"US.1234","type":"text","text":{"body":"Simple Message","preview_url":false}}`,
+			},
+		},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:   "Plain Send with user_id in response",
 		MsgText: "Simple Message",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -375,6 +375,23 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
+		Label:   "Plain Send with BSUID as whatsapp URN",
+		MsgText: "Simple Message",
+		MsgURN:  "whatsapp:US.1234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Path: "/12345_ID/messages",
+				Body: `{"messaging_product":"whatsapp","recipient_type":"individual","recipient":"US.1234","type":"text","text":{"body":"Simple Message","preview_url":false}}`,
+			},
+		},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:   "Plain Send with user_id in response",
 		MsgText: "Simple Message",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -20,10 +20,11 @@ func GetMsgPayloads(ctx context.Context, msg courier.MsgOut, maxMsgLength int, c
 	return buildContentPayloads(msg, maxMsgLength, clog)
 }
 
-// RecipientFields returns the to and recipient field values for the given URN, using the recipient field for
-// business-scoped user ID (BSUID) URNs and the to field otherwise.
+// RecipientFields returns the to and recipient field values for the given URN. A business-scoped user ID -
+// a whatsapp URN in the CC.xxx form or a bsuid URN - goes in the recipient field; a phone number goes in the
+// to field.
 func RecipientFields(urn urns.URN) (to, recipient string) {
-	if urn.Scheme() == urns.BSUID.Prefix {
+	if urn.Scheme() == urns.BSUID.Prefix || urns.IsWhatsAppBSUID(urn) {
 		return "", urn.Path()
 	}
 	return urn.Path(), ""

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -16,6 +16,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRecipientFields(t *testing.T) {
+	tcs := []struct {
+		urn               urns.URN
+		expectedTo        string
+		expectedRecipient string
+	}{
+		{urn: "whatsapp:250788123123", expectedTo: "250788123123", expectedRecipient: ""},                       // phone number -> to
+		{urn: "whatsapp:US.13491208655302741918", expectedTo: "", expectedRecipient: "US.13491208655302741918"}, // BSUID -> recipient
+		{urn: "bsuid:US.13491208655302741918", expectedTo: "", expectedRecipient: "US.13491208655302741918"},    // legacy bsuid scheme -> recipient
+	}
+
+	for _, tc := range tcs {
+		to, recipient := whatsapp.RecipientFields(tc.urn)
+		assert.Equal(t, tc.expectedTo, to, "to mismatch for %s", tc.urn)
+		assert.Equal(t, tc.expectedRecipient, recipient, "recipient mismatch for %s", tc.urn)
+	}
+}
+
 func TestGetMsgPayloads(t *testing.T) {
 	ctx := context.Background()
 	maxMsgLength := 4096

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -638,6 +638,23 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
+		Label:   "Plain Send with BSUID as whatsapp URN",
+		MsgText: "Simple Message",
+		MsgURN:  "whatsapp:US.1234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Path: "/v1/messages",
+				Body: `{"recipient":"US.1234","type":"text","text":{"body":"Simple Message"}}`,
+			},
+		},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:   "Unicode Send",
 		MsgText: "☺",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -255,7 +255,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 
 		form := url.Values{
-			"To":             []string{fmt.Sprintf("%s:+%s", urns.WhatsApp.Prefix, msg.URN().Path())},
+			"To":             []string{whatsAppAddress(msg.URN())},
 			"StatusCallback": []string{callbackURL},
 			"ContentSid":     []string{msg.Templating().ExternalID},
 		}
@@ -373,7 +373,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 			// for whatsapp channels, we have to prepend whatsapp to the To and From
 			if channel.IsScheme(urns.WhatsApp) {
-				form["To"][0] = fmt.Sprintf("%s:+%s", urns.WhatsApp.Prefix, form["To"][0])
+				form["To"][0] = whatsAppAddress(msg.URN())
 				form["From"][0] = fmt.Sprintf("%s:%s", urns.WhatsApp.Prefix, form["From"][0])
 			}
 
@@ -538,6 +538,15 @@ func (h *handler) parseURN(channel courier.Channel, text string, country i18n.Co
 	}
 
 	return urns.ParsePhone(text, country, true, true)
+}
+
+// whatsAppAddress formats the given URN as a Twilio WhatsApp address: whatsapp:+<digits> for a phone number
+// or whatsapp:<CC.xxx> for a business-scoped user ID, which takes no leading +
+func whatsAppAddress(urn urns.URN) string {
+	if urn.Scheme() == urns.BSUID.Prefix || urns.IsWhatsAppBSUID(urn) {
+		return fmt.Sprintf("%s:%s", urns.WhatsApp.Prefix, urn.Path())
+	}
+	return fmt.Sprintf("%s:+%s", urns.WhatsApp.Prefix, urn.Path())
 }
 
 func (h *handler) baseURL(c courier.Channel) string {

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -1157,6 +1157,21 @@ var twaSendTestCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"1002"},
 	},
 	{
+		Label:   "Plain Send with BSUID as bsuid URN",
+		MsgText: "Simple Message ☺",
+		MsgURN:  "bsuid:US.1234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.twilio.com/2010-04-01/Accounts/accountSID/Messages.json": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "sid": "1002" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Form:    url.Values{"Body": {"Simple Message ☺"}, "To": {"whatsapp:US.1234"}, "From": {"whatsapp:+12065551212"}, "MessagingServiceSid": {"messageServiceSID"}, "StatusCallback": {"https://localhost/c/twa/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&action=callback"}},
+			Headers: map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
+		}},
+		ExpectedExtIDs: []string{"1002"},
+	},
+	{
 		Label:     "Template Send",
 		MsgText:   "templated message",
 		MsgURN:    "whatsapp:250788383383",

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -1142,6 +1142,21 @@ var twaSendTestCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"1002"},
 	},
 	{
+		Label:   "Plain Send with BSUID as whatsapp URN",
+		MsgText: "Simple Message ☺",
+		MsgURN:  "whatsapp:US.1234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.twilio.com/2010-04-01/Accounts/accountSID/Messages.json": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "sid": "1002" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Form:    url.Values{"Body": {"Simple Message ☺"}, "To": {"whatsapp:US.1234"}, "From": {"whatsapp:+12065551212"}, "MessagingServiceSid": {"messageServiceSID"}, "StatusCallback": {"https://localhost/c/twa/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&action=callback"}},
+			Headers: map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
+		}},
+		ExpectedExtIDs: []string{"1002"},
+	},
+	{
 		Label:     "Template Send",
 		MsgText:   "templated message",
 		MsgURN:    "whatsapp:250788383383",
@@ -1165,6 +1180,34 @@ var twaSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Form:    url.Values{"To": {"whatsapp:+250788383383"}, "From": {"whatsapp:+12065551212"}, "MessagingServiceSid": {"messageServiceSID"}, "StatusCallback": {"https://localhost/c/twa/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&action=callback"}, "ContentSid": {"ext_id_revive_issue"}, "ContentVariables": {"{\"1\":\"Chef\",\"2\":\"tomorrow\"}"}},
+			Headers: map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
+		}},
+		ExpectedExtIDs: []string{"1002"},
+	},
+	{
+		Label:     "Template Send with BSUID as whatsapp URN",
+		MsgText:   "templated message",
+		MsgURN:    "whatsapp:US.1234",
+		MsgLocale: "eng",
+		MsgTemplating: `{
+			"template": {"uuid": "171f8a4d-f725-46d7-85a6-11aceff0bfe3", "name": "revive_issue"},
+			"components": [
+				{"type": "body", "name": "body", "variables": {"1": 0, "2": 1}}
+			],
+			"variables": [
+				{"type": "text", "value": "Chef"},
+				{"type": "text" , "value": "tomorrow"}
+			],
+			"external_id": "ext_id_revive_issue",
+			"language": "en_US"
+		}`,
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.twilio.com/2010-04-01/Accounts/accountSID/Messages.json": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "sid": "1002" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Form:    url.Values{"To": {"whatsapp:US.1234"}, "From": {"whatsapp:+12065551212"}, "MessagingServiceSid": {"messageServiceSID"}, "StatusCallback": {"https://localhost/c/twa/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&action=callback"}, "ContentSid": {"ext_id_revive_issue"}, "ContentVariables": {"{\"1\":\"Chef\",\"2\":\"tomorrow\"}"}},
 			Headers: map[string]string{"Authorization": "Basic YWNjb3VudFNJRDphdXRoVG9rZW4="},
 		}},
 		ExpectedExtIDs: []string{"1002"},


### PR DESCRIPTION
## Summary

A `whatsapp` URN may hold either a phone number (all digits) or a business-scoped user ID (the `CC.xxx` form). This makes courier's send paths route by content so both forms are deliverable, as a first step toward whatsapp URNs carrying BSUIDs directly. URN validation for the dual-form `whatsapp` scheme already ships in gocommon v1.87+; receive-side behavior is unchanged (incoming BSUIDs are still stored via the `bsuid` scheme and the phone remains the primary URN).

## Changes

- `RecipientFields` (shared by the WAC, D3C and TRN handlers) now puts a BSUID — whether a `whatsapp` URN in BSUID form or a legacy `bsuid` URN — in the API `recipient` field, and a phone number in the `to` field.
- The TWA handler formats WhatsApp addresses via a new `whatsAppAddress` helper in both the plain and content-template send paths: `whatsapp:+<digits>` for phones, `whatsapp:CC.xxx` (no leading `+`) for BSUIDs, per Twilio's addressing. This also fixes sending to `bsuid` scheme URNs on TWA, which previously produced a bogus `whatsapp:+CC.xxx` address.

## Behavior examples

| Send URN | WAC/D3C/TRN payload | TWA form |
|---|---|---|
| `whatsapp:250788123123` | `"to": "250788123123"` | `To=whatsapp:+250788123123` |
| `whatsapp:US.1234` | `"recipient": "US.1234"` | `To=whatsapp:US.1234` |
| `bsuid:US.1234` | `"recipient": "US.1234"` | `To=whatsapp:US.1234` |

## Test plan

- Unit test for `RecipientFields` routing across all three URN forms.
- Outgoing test cases sending to a BSUID-form `whatsapp` URN for all four handlers (WAC, D3C, TRN, and both the plain and template paths for TWA).
- TWA case sending to a `bsuid` scheme URN, locking in the address fix.
- Full suite run locally; CI green.