### PR TITLE
Support URL quick replies on Telegram as inline keyboard link buttons

### DIFF
--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -161,7 +162,7 @@ type mtResponse struct {
 	} `json:"result"`
 }
 
-func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.Values, keyboard *ReplyKeyboardMarkup, clog *courier.ChannelLog) (string, error) {
+func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.Values, keyboard any, clog *courier.ChannelLog) (string, error) {
 	// either include or remove our keyboard
 	form.Add("parse_mode", "Markdown")
 	if keyboard == nil {
@@ -218,16 +219,25 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		caption = msg.Text()
 	}
 
-	// figure out whether we have a keyboard to send as well - form replies open the URL in Extra as a Mini App
-	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeForm)
-	var keyboard *ReplyKeyboardMarkup
-	if len(qrs) > 0 {
-		keyboard = NewKeyboardFromReplies(qrs)
+	// figure out whether we have a keyboard to send as well - form replies open the URL in Extra as a Mini App. URL
+	// replies become inline keyboard link buttons, but Telegram only allows one keyboard type per message, so they're
+	// only supported when the message has no other quick reply types needing the reply keyboard.
+	urlsOnly := !slices.ContainsFunc(msg.QuickReplies(), func(q models.QuickReply) bool { return q.Type != models.QuickReplyTypeURL })
+
+	var keyboard any
+	if urlsOnly {
+		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeURL); len(qrs) > 0 {
+			keyboard = NewInlineKeyboardFromReplies(qrs)
+		}
+	} else {
+		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeForm); len(qrs) > 0 {
+			keyboard = NewKeyboardFromReplies(qrs)
+		}
 	}
 
 	// if we have text, send that if we aren't sending it as a caption
 	if msg.Text() != "" && caption == "" {
-		var msgKeyBoard *ReplyKeyboardMarkup
+		var msgKeyBoard any
 		if len(attachments) == 0 {
 			msgKeyBoard = keyboard
 		}
@@ -244,7 +254,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	// send each attachment
 	for i, attachment := range attachments {
-		var attachmentKeyBoard *ReplyKeyboardMarkup
+		var attachmentKeyBoard any
 		if i == len(msg.Attachments())-1 {
 			attachmentKeyBoard = keyboard
 		}

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -942,7 +942,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, unsupported types ignored",
+		Label:           "Quick Reply, url type mixed with reply keyboard types is dropped",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",
 		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "url", Extra: "http://example.com"}},
@@ -960,10 +960,25 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, only unsupported types means no keyboard",
+		Label:           "Quick Reply, url types as inline keyboard link buttons",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",
-		MsgQuickReplies: []models.QuickReply{{Type: "url", Extra: "http://example.com"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit Us", Extra: "http://example.com"}, {Type: "url", Extra: "http://example.com/more"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Visit Us","url":"http://example.com"},{"text":"Open Link","url":"http://example.com/more"}]]}`}}},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
+		Label:           "Quick Reply, url type without a URL is dropped",
+		MsgText:         "Are you happy?",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit Us"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
@@ -973,7 +988,7 @@ var outgoingCases = []OutgoingTestCase{
 			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
 		},
 		ExpectedLogErrors: []*clogs.Error{
-			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
+			{Message: "quick reply of type url is missing its extra value and can't be sent"},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},

--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -47,3 +47,30 @@ func NewKeyboardFromReplies(replies []models.QuickReply) *ReplyKeyboardMarkup {
 
 	return &ReplyKeyboardMarkup{Keyboard: keyboard, ResizeKeyboard: true, OneTimeKeyboard: true}
 }
+
+// InlineKeyboardButton is a button on an inline keyboard, see https://core.telegram.org/bots/api/#inlinekeyboardbutton
+type InlineKeyboardButton struct {
+	Text string `json:"text"`
+	URL  string `json:"url,omitempty"`
+}
+
+// InlineKeyboardMarkup models an inline keyboard, see https://core.telegram.org/bots/api/#inlinekeyboardmarkup
+type InlineKeyboardMarkup struct {
+	InlineKeyboard [][]InlineKeyboardButton `json:"inline_keyboard"`
+}
+
+// NewInlineKeyboardFromReplies creates an inline keyboard of link buttons from the given URL quick replies
+func NewInlineKeyboardFromReplies(replies []models.QuickReply) *InlineKeyboardMarkup {
+	rows := models.QuickRepliesToRows(replies, 5, 30, 2)
+	keyboard := make([][]InlineKeyboardButton, len(rows))
+
+	for i := range rows {
+		keyboard[i] = make([]InlineKeyboardButton, len(rows[i]))
+		for j := range rows[i] {
+			keyboard[i][j].Text = rows[i][j].GetText()
+			keyboard[i][j].URL = rows[i][j].Extra
+		}
+	}
+
+	return &InlineKeyboardMarkup{InlineKeyboard: keyboard}
+}

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -91,3 +91,32 @@ func TestKeyboardFromReplies(t *testing.T) {
 		assert.Equal(t, tc.expected, kb, "keyboard mismatch for replies %v", tc.replies)
 	}
 }
+
+func TestInlineKeyboardFromReplies(t *testing.T) {
+	tcs := []struct {
+		replies  []models.QuickReply
+		expected *telegram.InlineKeyboardMarkup
+	}{
+		{
+			[]models.QuickReply{{Type: "url", Text: "Visit Us", Extra: "https://example.com"}},
+			&telegram.InlineKeyboardMarkup{
+				InlineKeyboard: [][]telegram.InlineKeyboardButton{
+					{{Text: "Visit Us", URL: "https://example.com"}},
+				},
+			},
+		},
+		{
+			[]models.QuickReply{{Type: "url", Extra: "https://example.com"}, {Type: "url", Text: "Read More", Extra: "https://example.com/more"}},
+			&telegram.InlineKeyboardMarkup{
+				InlineKeyboard: [][]telegram.InlineKeyboardButton{
+					{{Text: "Open Link", URL: "https://example.com"}, {Text: "Read More", URL: "https://example.com/more"}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		kb := telegram.NewInlineKeyboardFromReplies(tc.replies)
+		assert.Equal(t, tc.expected, kb, "keyboard mismatch for replies %v", tc.replies)
+	}
+}


### PR DESCRIPTION
URL quick replies were dropped for Telegram because reply keyboard buttons can't open links. Inline keyboard URL buttons can, and render attached to the message on all Telegram clients, so they're used instead:

* when a message's quick replies are all of type `url`, they're sent as an `InlineKeyboardMarkup` of link buttons
* Telegram only allows one keyboard type per message, so URL replies mixed with types that need the reply keyboard (text, location, form) continue to be dropped with a logged channel error
* URL replies missing their URL are dropped with a "missing its extra value" error

No new webhook handling is needed — opening a link is entirely client-side.