### PR TITLE
Don't make Telegram keyboards single use when they contain form or location buttons

### DIFF
--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -919,7 +919,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"is_persistent":true,"resize_keyboard":true,"one_time_keyboard":false}`}}},
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":false}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -904,7 +904,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Where Are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true},{"text":"Ignore"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Where Are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true},{"text":"Ignore"}]],"resize_keyboard":true,"one_time_keyboard":false}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -919,7 +919,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"is_persistent":true,"resize_keyboard":true,"one_time_keyboard":false}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},

--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -20,7 +20,6 @@ type KeyboardButton struct {
 // ReplyKeyboardMarkup models a keyboard, see https://core.telegram.org/bots/api/#replykeyboardmarkup
 type ReplyKeyboardMarkup struct {
 	Keyboard        [][]KeyboardButton `json:"keyboard"`
-	IsPersistent    bool               `json:"is_persistent,omitempty"`
 	ResizeKeyboard  bool               `json:"resize_keyboard"`
 	OneTimeKeyboard bool               `json:"one_time_keyboard"`
 }
@@ -51,10 +50,9 @@ func NewKeyboardFromReplies(replies []models.QuickReply) *ReplyKeyboardMarkup {
 
 	// tapping a text button is itself the reply so those keyboards can be single use, but form and location buttons
 	// launch a separate interaction that the user might not complete, and one-time state syncs across their devices -
-	// so keep those keyboards available (and pinned open, for forms) until the next message clears them
+	// so keep those keyboards available until the next message clears them
 	return &ReplyKeyboardMarkup{
 		Keyboard:        keyboard,
-		IsPersistent:    hasForm,
 		ResizeKeyboard:  true,
 		OneTimeKeyboard: !hasForm && !hasLocation,
 	}

--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -20,6 +20,7 @@ type KeyboardButton struct {
 // ReplyKeyboardMarkup models a keyboard, see https://core.telegram.org/bots/api/#replykeyboardmarkup
 type ReplyKeyboardMarkup struct {
 	Keyboard        [][]KeyboardButton `json:"keyboard"`
+	IsPersistent    bool               `json:"is_persistent,omitempty"`
 	ResizeKeyboard  bool               `json:"resize_keyboard"`
 	OneTimeKeyboard bool               `json:"one_time_keyboard"`
 }
@@ -28,6 +29,7 @@ type ReplyKeyboardMarkup struct {
 func NewKeyboardFromReplies(replies []models.QuickReply) *ReplyKeyboardMarkup {
 	rows := models.QuickRepliesToRows(replies, 5, 30, 2)
 	keyboard := make([][]KeyboardButton, len(rows))
+	hasForm, hasLocation := false, false
 
 	for i := range rows {
 		keyboard[i] = make([]KeyboardButton, len(rows[i]))
@@ -39,11 +41,21 @@ func NewKeyboardFromReplies(replies []models.QuickReply) *ReplyKeyboardMarkup {
 			switch rows[i][j].Type {
 			case models.QuickReplyTypeLocation:
 				keyboard[i][j].RequestLocation = true
+				hasLocation = true
 			case models.QuickReplyTypeForm:
 				keyboard[i][j].WebApp = &WebAppInfo{URL: rows[i][j].Extra}
+				hasForm = true
 			}
 		}
 	}
 
-	return &ReplyKeyboardMarkup{Keyboard: keyboard, ResizeKeyboard: true, OneTimeKeyboard: true}
+	// tapping a text button is itself the reply so those keyboards can be single use, but form and location buttons
+	// launch a separate interaction that the user might not complete, and one-time state syncs across their devices -
+	// so keep those keyboards available (and pinned open, for forms) until the next message clears them
+	return &ReplyKeyboardMarkup{
+		Keyboard:        keyboard,
+		IsPersistent:    hasForm,
+		ResizeKeyboard:  true,
+		OneTimeKeyboard: !hasForm && !hasLocation,
+	}
 }

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -17,71 +17,79 @@ func TestKeyboardFromReplies(t *testing.T) {
 
 			[]models.QuickReply{{Type: "text", Text: "OK"}},
 			&telegram.ReplyKeyboardMarkup{
-				[][]telegram.KeyboardButton{
+				Keyboard: [][]telegram.KeyboardButton{
 					{{Text: "OK"}},
 				},
-				true, true,
+				ResizeKeyboard:  true,
+				OneTimeKeyboard: true,
 			},
 		},
 		{
 			[]models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "text", Text: "No"}, {Type: "text", Text: "Maybe"}},
 			&telegram.ReplyKeyboardMarkup{
-				[][]telegram.KeyboardButton{
+				Keyboard: [][]telegram.KeyboardButton{
 					{{Text: "Yes"}, {Text: "No"}, {Text: "Maybe"}},
 				},
-				true, true,
+				ResizeKeyboard:  true,
+				OneTimeKeyboard: true,
 			},
 		},
 		{
 			[]models.QuickReply{{Type: "text", Text: "Vanilla"}, {Type: "text", Text: "Chocolate"}, {Type: "text", Text: "Mint"}, {Type: "text", Text: "Lemon Sorbet"}, {Type: "text", Text: "Papaya"}, {Type: "text", Text: "Strawberry"}},
 			&telegram.ReplyKeyboardMarkup{
-				[][]telegram.KeyboardButton{
+				Keyboard: [][]telegram.KeyboardButton{
 					{{Text: "Vanilla"}, {Text: "Chocolate"}},
 					{{Text: "Mint"}, {Text: "Lemon Sorbet"}},
 					{{Text: "Papaya"}, {Text: "Strawberry"}},
 				},
-				true, true,
+				ResizeKeyboard:  true,
+				OneTimeKeyboard: true,
 			},
 		},
 		{
 			[]models.QuickReply{{Type: "text", Text: "A"}, {Type: "text", Text: "B"}, {Type: "text", Text: "C"}, {Type: "text", Text: "D"}, {Type: "text", Text: "Chicken"}, {Type: "text", Text: "Fish"}, {Type: "text", Text: "Peanut Butter Pickle"}},
 			&telegram.ReplyKeyboardMarkup{
-				[][]telegram.KeyboardButton{
+				Keyboard: [][]telegram.KeyboardButton{
 					{{Text: "A"}, {Text: "B"}, {Text: "C"}, {Text: "D"}},
 					{{Text: "Chicken"}, {Text: "Fish"}},
 					{{Text: "Peanut Butter Pickle"}},
 				},
-				true, true,
+				ResizeKeyboard:  true,
+				OneTimeKeyboard: true,
 			},
 		},
 		{
 
 			[]models.QuickReply{{Type: "location"}},
 			&telegram.ReplyKeyboardMarkup{
-				[][]telegram.KeyboardButton{
+				Keyboard: [][]telegram.KeyboardButton{
 					{{Text: "Send Location", RequestLocation: true}},
 				},
-				true, true,
+				ResizeKeyboard:  true,
+				OneTimeKeyboard: false,
 			},
 		},
 		{
 
 			[]models.QuickReply{{Type: "location", Text: "Share Location"}},
 			&telegram.ReplyKeyboardMarkup{
-				[][]telegram.KeyboardButton{
+				Keyboard: [][]telegram.KeyboardButton{
 					{{Text: "Share Location", RequestLocation: true}},
 				},
-				true, true,
+				ResizeKeyboard:  true,
+				OneTimeKeyboard: false,
 			},
 		},
 		{
 
 			[]models.QuickReply{{Type: "form", Extra: "https://example.com/form"}, {Type: "text", Text: "Skip"}},
 			&telegram.ReplyKeyboardMarkup{
-				[][]telegram.KeyboardButton{
+				Keyboard: [][]telegram.KeyboardButton{
 					{{Text: "Open Form", WebApp: &telegram.WebAppInfo{URL: "https://example.com/form"}}, {Text: "Skip"}},
 				},
-				true, true,
+				IsPersistent:    true,
+				ResizeKeyboard:  true,
+				OneTimeKeyboard: false,
 			},
 		},
 	}

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -87,7 +87,6 @@ func TestKeyboardFromReplies(t *testing.T) {
 				Keyboard: [][]telegram.KeyboardButton{
 					{{Text: "Open Form", WebApp: &telegram.WebAppInfo{URL: "https://example.com/form"}}, {Text: "Skip"}},
 				},
-				IsPersistent:    true,
 				ResizeKeyboard:  true,
 				OneTimeKeyboard: false,
 			},


### PR DESCRIPTION
Form and location quick reply buttons launch a separate interaction — opening a Mini App or a location picker — that the user might not complete, and Telegram syncs one-time keyboard state across a user's devices, so a single tap on one client hides the keyboard everywhere. That made form keyboards effectively disappear before the user could open the form on another client.

Since keyboards are already explicitly cleared with `remove_keyboard` on the next message, keyboards containing form or location buttons now drop `one_time_keyboard` so they stay available until the conversation moves on.

Text-only keyboards keep the existing single-use behavior, where the tap itself is the reply.