### PR TITLE
Support URL quick replies on Telegram as inline keyboard link buttons

### DIFF
--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -185,6 +184,20 @@ func (h *handler) receiveCallbackQuery(ctx context.Context, channel courier.Chan
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
+// filterQuickRepliesWithExtra returns quick replies of the given type that have the extra value the type requires,
+// logging a channel error for any that don't
+func filterQuickRepliesWithExtra(qrs []models.QuickReply, qrType string, clog *courier.ChannelLog) []models.QuickReply {
+	f := make([]models.QuickReply, 0, len(qrs))
+	for _, qr := range handlers.FilterQuickRepliesByType(qrs, qrType) {
+		if qr.Extra == "" {
+			clog.Error(&clogs.Error{Message: fmt.Sprintf("quick reply of type %s is missing its extra value and can't be sent", qrType)})
+		} else {
+			f = append(f, qr)
+		}
+	}
+	return f
+}
+
 type mtResponse struct {
 	Ok          bool   `json:"ok" validate:"required"`
 	ErrorCode   int    `json:"error_code"`
@@ -251,24 +264,26 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		caption = msg.Text()
 	}
 
-	// figure out whether we have a keyboard to send as well - inline keyboards render attached to the message on all
-	// Telegram clients, so use one whenever possible: text replies become callback buttons, url replies link buttons,
-	// and form replies buttons that open the URL in Extra as a Mini App. Location requests only exist as reply
-	// keyboard buttons, and Telegram only allows one keyboard type per message, so a message with a location reply
-	// falls back to a reply keyboard, where url replies can't render and are dropped.
-	hasLocation := slices.ContainsFunc(msg.QuickReplies(), func(q models.QuickReply) bool {
-		return q.Type == models.QuickReplyTypeLocation
-	})
+	// figure out whether we have a keyboard to send as well.. only one type of quick reply is sent per message,
+	// using the same priority as other channels: location > form > url > text. Location requests only exist as
+	// reply keyboard buttons, everything else becomes an inline keyboard which renders attached to the message
+	// on all Telegram clients: form replies as buttons that open the URL in Extra as a Mini App, url replies as
+	// link buttons, and text replies as callback buttons.
+	textQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
+	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
+	formQRs := filterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeForm, clog)
+	urlQRs := filterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeURL, clog)
 
 	var keyboard any
-	if hasLocation {
-		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeForm); len(qrs) > 0 {
-			keyboard = NewKeyboardFromReplies(qrs)
-		}
-	} else {
-		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeURL, models.QuickReplyTypeForm); len(qrs) > 0 {
-			keyboard = NewInlineKeyboardFromReplies(qrs)
-		}
+	switch {
+	case len(locationQRs) > 0:
+		keyboard = NewKeyboardFromReplies(locationQRs)
+	case len(formQRs) > 0:
+		keyboard = NewInlineKeyboardFromReplies(formQRs)
+	case len(urlQRs) > 0:
+		keyboard = NewInlineKeyboardFromReplies(urlQRs)
+	case len(textQRs) > 0:
+		keyboard = NewInlineKeyboardFromReplies(textQRs)
 	}
 
 	// if we have text, send that if we aren't sending it as a caption

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -273,7 +273,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	// send each attachment
 	for i, attachment := range attachments {
 		var attachmentKeyBoard any
-		if i == len(msg.Attachments())-1 {
+		if i == len(attachments)-1 {
 			attachmentKeyBoard = keyboard
 		}
 

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -152,20 +153,6 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
-// filterQuickRepliesWithExtra returns quick replies of the given type that have the extra value the type requires,
-// logging a channel error for any that don't
-func filterQuickRepliesWithExtra(qrs []models.QuickReply, qrType string, clog *courier.ChannelLog) []models.QuickReply {
-	f := make([]models.QuickReply, 0, len(qrs))
-	for _, qr := range handlers.FilterQuickRepliesByType(qrs, qrType) {
-		if qr.Extra == "" {
-			clog.Error(&clogs.Error{Message: fmt.Sprintf("quick reply of type %s is missing its extra value and can't be sent", qrType)})
-		} else {
-			f = append(f, qr)
-		}
-	}
-	return f
-}
-
 type mtResponse struct {
 	Ok          bool   `json:"ok" validate:"required"`
 	ErrorCode   int    `json:"error_code"`
@@ -232,25 +219,23 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		caption = msg.Text()
 	}
 
-	// figure out whether we have a keyboard to send as well.. only one type of quick reply is sent per message,
-	// using the same priority as other channels: location > form > url > text. URL replies become an inline
-	// keyboard of link buttons which renders attached to the message; the other types become a reply keyboard,
-	// with form replies as buttons that open the URL in Extra as a Mini App.
-	textQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
-	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
-	formQRs := filterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeForm, clog)
-	urlQRs := filterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeURL, clog)
+	// figure out whether we have a keyboard to send as well - text, location and form replies can all appear on the
+	// same reply keyboard, with form replies as buttons that open the URL in Extra as a Mini App. URL replies can
+	// only be rendered as inline keyboard link buttons, and Telegram only allows one keyboard type per message, so
+	// they're only supported when they're the only type on the message, and dropped with a logged error otherwise.
+	urlsOnly := !slices.ContainsFunc(msg.QuickReplies(), func(q models.QuickReply) bool {
+		return q.Type != models.QuickReplyTypeURL
+	})
 
 	var keyboard any
-	switch {
-	case len(locationQRs) > 0:
-		keyboard = NewKeyboardFromReplies(locationQRs)
-	case len(formQRs) > 0:
-		keyboard = NewKeyboardFromReplies(formQRs)
-	case len(urlQRs) > 0:
-		keyboard = NewInlineKeyboardFromReplies(urlQRs)
-	case len(textQRs) > 0:
-		keyboard = NewKeyboardFromReplies(textQRs)
+	if urlsOnly {
+		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeURL); len(qrs) > 0 {
+			keyboard = NewInlineKeyboardFromReplies(qrs)
+		}
+	} else {
+		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeForm); len(qrs) > 0 {
+			keyboard = NewKeyboardFromReplies(qrs)
+		}
 	}
 
 	// if we have text, send that if we aren't sending it as a caption

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"slices"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
@@ -153,6 +155,26 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
+// isValidButtonURL approximates Telegram's validation of inline keyboard button URLs, which accepts HTTP(S) and
+// tg:// URLs, rejects whitespace, and requires HTTP(S) hostnames to have a TLD (or be an IP address)
+func isValidButtonURL(s string) bool {
+	if strings.ContainsFunc(s, unicode.IsSpace) {
+		return false
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	if u.Scheme == "tg" {
+		return true
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	return strings.Contains(u.Hostname(), ".") || net.ParseIP(u.Hostname()) != nil
+}
+
 type mtResponse struct {
 	Ok          bool   `json:"ok" validate:"required"`
 	ErrorCode   int    `json:"error_code"`
@@ -231,10 +253,10 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	if urlsOnly {
 		qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeURL)
 
-		// Telegram rejects the entire message if a button URL isn't a valid absolute HTTP(S) URL, so drop invalid
-		// ones with a logged error instead of failing the send
+		// Telegram rejects the entire message if a button URL isn't valid, so drop invalid ones with a logged error
+		// instead of failing the send
 		qrs = slices.DeleteFunc(qrs, func(q models.QuickReply) bool {
-			if u, err := url.Parse(q.Extra); err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			if !isValidButtonURL(q.Extra) {
 				clog.Error(&clogs.Error{Message: fmt.Sprintf("quick reply of type url has an invalid URL and can't be sent: %s", q.Extra)})
 				return true
 			}

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -52,6 +53,11 @@ func (h *handler) Initialize(s *courier.Server) error {
 
 // receiveMessage is our HTTP handler function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request, payload *moPayload, clog *courier.ChannelLog) ([]courier.Event, error) {
+	// a user tapped a callback button on an inline keyboard
+	if payload.CallbackQuery != nil {
+		return h.receiveCallbackQuery(ctx, channel, w, r, payload, clog)
+	}
+
 	// no message? ignore this
 	if payload.Message.MessageID == 0 {
 		return nil, handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, "Ignoring request, no message")
@@ -152,6 +158,33 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
+// receiveCallbackQuery handles a user tapping a callback button on an inline keyboard, turning the button's data
+// into an incoming message
+func (h *handler) receiveCallbackQuery(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request, payload *moPayload, clog *courier.ChannelLog) ([]courier.Event, error) {
+	cq := payload.CallbackQuery
+
+	urn, err := urns.NewFromParts(urns.Telegram.Prefix, strconv.FormatInt(cq.From.ContactID, 10), nil, strings.ToLower(cq.From.Username))
+	if err != nil {
+		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
+	}
+
+	name := handlers.NameFromFirstLastUsername(cq.From.FirstName, cq.From.LastName, cq.From.Username)
+
+	// answer the callback query so the client stops showing the button as loading.. best effort, an answer failing
+	// or expiring doesn't stop us accepting the message
+	authToken := channel.StringConfigForKey(models.ConfigAuthToken, "")
+	form := url.Values{"callback_query_id": []string{cq.ID}}
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/bot%s/answerCallbackQuery", apiURL, authToken), strings.NewReader(form.Encode()))
+	if err == nil {
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		h.RequestHTTP(req, clog)
+	}
+
+	msg := h.Backend().NewIncomingMsg(ctx, channel, urn, cq.Data, cq.ID, clog).WithContactName(name)
+
+	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
+}
+
 type mtResponse struct {
 	Ok          bool   `json:"ok" validate:"required"`
 	ErrorCode   int    `json:"error_code"`
@@ -161,7 +194,7 @@ type mtResponse struct {
 	} `json:"result"`
 }
 
-func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.Values, keyboard *ReplyKeyboardMarkup, clog *courier.ChannelLog) (string, error) {
+func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.Values, keyboard any, clog *courier.ChannelLog) (string, error) {
 	// either include or remove our keyboard
 	form.Add("parse_mode", "Markdown")
 	if keyboard == nil {
@@ -218,16 +251,29 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		caption = msg.Text()
 	}
 
-	// figure out whether we have a keyboard to send as well - form replies open the URL in Extra as a Mini App
-	qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeForm)
-	var keyboard *ReplyKeyboardMarkup
-	if len(qrs) > 0 {
-		keyboard = NewKeyboardFromReplies(qrs)
+	// figure out whether we have a keyboard to send as well - inline keyboards render attached to the message on all
+	// Telegram clients, so use one whenever possible: text replies become callback buttons, url replies link buttons,
+	// and form replies buttons that open the URL in Extra as a Mini App. Location requests only exist as reply
+	// keyboard buttons, and Telegram only allows one keyboard type per message, so a message with a location reply
+	// falls back to a reply keyboard, where url replies can't render and are dropped.
+	hasLocation := slices.ContainsFunc(msg.QuickReplies(), func(q models.QuickReply) bool {
+		return q.Type == models.QuickReplyTypeLocation
+	})
+
+	var keyboard any
+	if hasLocation {
+		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeForm); len(qrs) > 0 {
+			keyboard = NewKeyboardFromReplies(qrs)
+		}
+	} else {
+		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeURL, models.QuickReplyTypeForm); len(qrs) > 0 {
+			keyboard = NewInlineKeyboardFromReplies(qrs)
+		}
 	}
 
 	// if we have text, send that if we aren't sending it as a caption
 	if msg.Text() != "" && caption == "" {
-		var msgKeyBoard *ReplyKeyboardMarkup
+		var msgKeyBoard any
 		if len(attachments) == 0 {
 			msgKeyBoard = keyboard
 		}
@@ -244,7 +290,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	// send each attachment
 	for i, attachment := range attachments {
-		var attachmentKeyBoard *ReplyKeyboardMarkup
+		var attachmentKeyBoard any
 		if i == len(msg.Attachments())-1 {
 			attachmentKeyBoard = keyboard
 		}
@@ -472,4 +518,14 @@ type moPayload struct {
 			ButtonText string `json:"button_text"`
 		} `json:"web_app_data"`
 	} `json:"message"`
+	CallbackQuery *struct {
+		ID   string `json:"id"`
+		From struct {
+			ContactID int64  `json:"id"`
+			FirstName string `json:"first_name"`
+			LastName  string `json:"last_name"`
+			Username  string `json:"username"`
+		} `json:"from"`
+		Data string `json:"data"`
+	} `json:"callback_query"`
 }

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -152,28 +152,6 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
-// clearReplyKeyboard sends and immediately deletes a blank message whose only purpose is to remove any reply
-// keyboard left showing by a previous message.. best effort, a failure here shouldn't fail the actual send
-func (h *handler) clearReplyKeyboard(msg courier.MsgOut, token string, clog *courier.ChannelLog) {
-	form := url.Values{
-		"chat_id":              []string{msg.URN().Path()},
-		"text":                 []string{"⠀"}, // braille blank, as Telegram doesn't accept empty or whitespace-only text
-		"disable_notification": []string{"true"},
-	}
-	externalID, err := h.sendMsgPart(msg, token, "sendMessage", form, nil, clog)
-	if err != nil {
-		return
-	}
-
-	form = url.Values{"chat_id": []string{msg.URN().Path()}, "message_id": []string{externalID}}
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/bot%s/deleteMessage", apiURL, token), strings.NewReader(form.Encode()))
-	if err != nil {
-		return
-	}
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	h.RequestHTTP(req, clog)
-}
-
 // filterQuickRepliesWithExtra returns quick replies of the given type that have the extra value the type requires,
 // logging a channel error for any that don't
 func filterQuickRepliesWithExtra(qrs []models.QuickReply, qrType string, clog *courier.ChannelLog) []models.QuickReply {
@@ -255,10 +233,9 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 
 	// figure out whether we have a keyboard to send as well.. only one type of quick reply is sent per message,
-	// using the same priority as other channels: location > form > url > text. Location and text replies become a
-	// reply keyboard, where a tap sends the reply as a normal message. Form and url replies become an inline
-	// keyboard which renders attached to the message on all Telegram clients: form replies as buttons that open
-	// the URL in Extra as a Mini App, and url replies as link buttons.
+	// using the same priority as other channels: location > form > url > text. URL replies become an inline
+	// keyboard of link buttons which renders attached to the message; the other types become a reply keyboard,
+	// with form replies as buttons that open the URL in Extra as a Mini App.
 	textQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
 	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
 	formQRs := filterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeForm, clog)
@@ -269,25 +246,11 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	case len(locationQRs) > 0:
 		keyboard = NewKeyboardFromReplies(locationQRs)
 	case len(formQRs) > 0:
-		keyboard = NewInlineKeyboardFromReplies(formQRs)
+		keyboard = NewKeyboardFromReplies(formQRs)
 	case len(urlQRs) > 0:
 		keyboard = NewInlineKeyboardFromReplies(urlQRs)
 	case len(textQRs) > 0:
 		keyboard = NewKeyboardFromReplies(textQRs)
-	}
-
-	// a message can only have one kind of reply_markup, so a message carrying an inline keyboard can't itself remove
-	// a reply keyboard left showing by a previous message. When this message has multiple parts the earlier parts do
-	// that clearing, but when its only part will carry the inline keyboard, start by sending and deleting a blank
-	// placeholder message whose only purpose is to clear any previous reply keyboard.
-	if _, isInline := keyboard.(*InlineKeyboardMarkup); isInline {
-		numParts := len(attachments)
-		if msg.Text() != "" && caption == "" {
-			numParts++
-		}
-		if numParts == 1 {
-			h.clearReplyKeyboard(msg, authToken, clog)
-		}
 	}
 
 	// if we have text, send that if we aren't sending it as a caption

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -52,11 +52,6 @@ func (h *handler) Initialize(s *courier.Server) error {
 
 // receiveMessage is our HTTP handler function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request, payload *moPayload, clog *courier.ChannelLog) ([]courier.Event, error) {
-	// a user tapped a callback button on an inline keyboard
-	if payload.CallbackQuery != nil {
-		return h.receiveCallbackQuery(ctx, channel, w, r, payload, clog)
-	}
-
 	// no message? ignore this
 	if payload.Message.MessageID == 0 {
 		return nil, handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, "Ignoring request, no message")
@@ -157,33 +152,6 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
-// receiveCallbackQuery handles a user tapping a callback button on an inline keyboard, turning the button's data
-// into an incoming message
-func (h *handler) receiveCallbackQuery(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request, payload *moPayload, clog *courier.ChannelLog) ([]courier.Event, error) {
-	cq := payload.CallbackQuery
-
-	urn, err := urns.NewFromParts(urns.Telegram.Prefix, strconv.FormatInt(cq.From.ContactID, 10), nil, strings.ToLower(cq.From.Username))
-	if err != nil {
-		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
-	}
-
-	name := handlers.NameFromFirstLastUsername(cq.From.FirstName, cq.From.LastName, cq.From.Username)
-
-	// answer the callback query so the client stops showing the button as loading.. best effort, an answer failing
-	// or expiring doesn't stop us accepting the message
-	authToken := channel.StringConfigForKey(models.ConfigAuthToken, "")
-	form := url.Values{"callback_query_id": []string{cq.ID}}
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/bot%s/answerCallbackQuery", apiURL, authToken), strings.NewReader(form.Encode()))
-	if err == nil {
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-		h.RequestHTTP(req, clog)
-	}
-
-	msg := h.Backend().NewIncomingMsg(ctx, channel, urn, cq.Data, cq.ID, clog).WithContactName(name)
-
-	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
-}
-
 // filterQuickRepliesWithExtra returns quick replies of the given type that have the extra value the type requires,
 // logging a channel error for any that don't
 func filterQuickRepliesWithExtra(qrs []models.QuickReply, qrType string, clog *courier.ChannelLog) []models.QuickReply {
@@ -265,10 +233,10 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 
 	// figure out whether we have a keyboard to send as well.. only one type of quick reply is sent per message,
-	// using the same priority as other channels: location > form > url > text. Location requests only exist as
-	// reply keyboard buttons, everything else becomes an inline keyboard which renders attached to the message
-	// on all Telegram clients: form replies as buttons that open the URL in Extra as a Mini App, url replies as
-	// link buttons, and text replies as callback buttons.
+	// using the same priority as other channels: location > form > url > text. Location and text replies become a
+	// reply keyboard, where a tap sends the reply as a normal message. Form and url replies become an inline
+	// keyboard which renders attached to the message on all Telegram clients: form replies as buttons that open
+	// the URL in Extra as a Mini App, and url replies as link buttons.
 	textQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
 	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
 	formQRs := filterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeForm, clog)
@@ -283,7 +251,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	case len(urlQRs) > 0:
 		keyboard = NewInlineKeyboardFromReplies(urlQRs)
 	case len(textQRs) > 0:
-		keyboard = NewInlineKeyboardFromReplies(textQRs)
+		keyboard = NewKeyboardFromReplies(textQRs)
 	}
 
 	// if we have text, send that if we aren't sending it as a caption
@@ -533,14 +501,4 @@ type moPayload struct {
 			ButtonText string `json:"button_text"`
 		} `json:"web_app_data"`
 	} `json:"message"`
-	CallbackQuery *struct {
-		ID   string `json:"id"`
-		From struct {
-			ContactID int64  `json:"id"`
-			FirstName string `json:"first_name"`
-			LastName  string `json:"last_name"`
-			Username  string `json:"username"`
-		} `json:"from"`
-		Data string `json:"data"`
-	} `json:"callback_query"`
 }

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -162,7 +162,7 @@ type mtResponse struct {
 	} `json:"result"`
 }
 
-func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.Values, keyboard any, clog *courier.ChannelLog) (string, error) {
+func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.Values, keyboard Markup, clog *courier.ChannelLog) (string, error) {
 	// either include or remove our keyboard
 	form.Add("parse_mode", "Markdown")
 	if keyboard == nil {
@@ -227,7 +227,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		return q.Type != models.QuickReplyTypeURL
 	})
 
-	var keyboard any
+	var keyboard Markup
 	if urlsOnly {
 		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeURL); len(qrs) > 0 {
 			keyboard = NewInlineKeyboardFromReplies(qrs)
@@ -240,7 +240,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	// if we have text, send that if we aren't sending it as a caption
 	if msg.Text() != "" && caption == "" {
-		var msgKeyBoard any
+		var msgKeyBoard Markup
 		if len(attachments) == 0 {
 			msgKeyBoard = keyboard
 		}
@@ -257,7 +257,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	// send each attachment
 	for i, attachment := range attachments {
-		var attachmentKeyBoard any
+		var attachmentKeyBoard Markup
 		if i == len(attachments)-1 {
 			attachmentKeyBoard = keyboard
 		}

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -152,6 +152,28 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
+// clearReplyKeyboard sends and immediately deletes a blank message whose only purpose is to remove any reply
+// keyboard left showing by a previous message.. best effort, a failure here shouldn't fail the actual send
+func (h *handler) clearReplyKeyboard(msg courier.MsgOut, token string, clog *courier.ChannelLog) {
+	form := url.Values{
+		"chat_id":              []string{msg.URN().Path()},
+		"text":                 []string{"⠀"}, // braille blank, as Telegram doesn't accept empty or whitespace-only text
+		"disable_notification": []string{"true"},
+	}
+	externalID, err := h.sendMsgPart(msg, token, "sendMessage", form, nil, clog)
+	if err != nil {
+		return
+	}
+
+	form = url.Values{"chat_id": []string{msg.URN().Path()}, "message_id": []string{externalID}}
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/bot%s/deleteMessage", apiURL, token), strings.NewReader(form.Encode()))
+	if err != nil {
+		return
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	h.RequestHTTP(req, clog)
+}
+
 // filterQuickRepliesWithExtra returns quick replies of the given type that have the extra value the type requires,
 // logging a channel error for any that don't
 func filterQuickRepliesWithExtra(qrs []models.QuickReply, qrType string, clog *courier.ChannelLog) []models.QuickReply {
@@ -252,6 +274,20 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		keyboard = NewInlineKeyboardFromReplies(urlQRs)
 	case len(textQRs) > 0:
 		keyboard = NewKeyboardFromReplies(textQRs)
+	}
+
+	// a message can only have one kind of reply_markup, so a message carrying an inline keyboard can't itself remove
+	// a reply keyboard left showing by a previous message. When this message has multiple parts the earlier parts do
+	// that clearing, but when its only part will carry the inline keyboard, start by sending and deleting a blank
+	// placeholder message whose only purpose is to clear any previous reply keyboard.
+	if _, isInline := keyboard.(*InlineKeyboardMarkup); isInline {
+		numParts := len(attachments)
+		if msg.Text() != "" && caption == "" {
+			numParts++
+		}
+		if numParts == 1 {
+			h.clearReplyKeyboard(msg, authToken, clog)
+		}
 	}
 
 	// if we have text, send that if we aren't sending it as a caption

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -229,7 +229,19 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	var keyboard any
 	if urlsOnly {
-		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeURL); len(qrs) > 0 {
+		qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeURL)
+
+		// Telegram rejects the entire message if a button URL isn't a valid absolute HTTP(S) URL, so drop invalid
+		// ones with a logged error instead of failing the send
+		qrs = slices.DeleteFunc(qrs, func(q models.QuickReply) bool {
+			if u, err := url.Parse(q.Extra); err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+				clog.Error(&clogs.Error{Message: fmt.Sprintf("quick reply of type url has an invalid URL and can't be sent: %s", q.Extra)})
+				return true
+			}
+			return false
+		})
+
+		if len(qrs) > 0 {
 			keyboard = NewInlineKeyboardFromReplies(qrs)
 		}
 	} else {

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -573,30 +573,6 @@ var webAppDataNonJSONMsg = `
     }
 }`
 
-var callbackQueryMsg = `
-{
-    "update_id": 900946539,
-    "callback_query": {
-        "id": "4382bfdwdsb323b2d9",
-        "from": {
-            "id": 3527065,
-            "first_name": "Nic",
-            "last_name": "Pottier",
-            "username": "Nicpottier"
-        },
-        "message": {
-            "message_id": 99,
-            "chat": {
-                "id": 3527065,
-                "type": "private"
-            },
-            "date": 1493845755,
-            "text": "Are you happy?"
-        },
-        "data": "Yes"
-    }
-}`
-
 var testCases = []IncomingTestCase{
 	{
 
@@ -767,17 +743,6 @@ var testCases = []IncomingTestCase{
 		ExpectedErrors:       []*clogs.Error{{Message: "web_app_data data is not a valid JSON object"}},
 	},
 	{
-		Label:                "Receive Callback Query",
-		URL:                  "/c/tg/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive/",
-		Data:                 callbackQueryMsg,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedContactName:  Sp("Nic Pottier"),
-		ExpectedMsgText:      Sp("Yes"),
-		ExpectedURN:          "telegram:3527065#nicpottier",
-		ExpectedExternalID:   "4382bfdwdsb323b2d9",
-	},
-	{
 		Label:                "Receive Empty",
 		URL:                  "/c/tg/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive/",
 		Data:                 emptyMsg,
@@ -833,14 +798,8 @@ var testCases = []IncomingTestCase{
 
 func buildMockTelegramService(testCases []IncomingTestCase) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
-
-		if strings.HasSuffix(r.URL.Path, "/answerCallbackQuery") {
-			w.Write([]byte(`{ "ok": true, "result": true }`))
-			return
-		}
-
 		fileID := r.FormValue("file_id")
+		defer r.Body.Close()
 
 		filePath := ""
 
@@ -930,7 +889,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Yes","callback_data":"Yes"},{"text":"No","callback_data":"No"}]]}`}}},
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Yes"},{"text":"No"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -975,7 +934,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Skip","callback_data":"Skip"}]]}`}}},
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
 		},
 		ExpectedLogErrors: []*clogs.Error{
 			{Message: "quick reply of type form is missing its extra value and can't be sent"},
@@ -1048,7 +1007,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": []string{"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
 			{Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/doc1.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
-			{Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/document.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Yes","callback_data":"Yes"},{"text":"No","callback_data":"No"}]]}`}}},
+			{Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/document.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Yes"},{"text":"No"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
 		},
 		ExpectedExtIDs: []string{"133", "133", "133"},
 	},

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -915,17 +915,11 @@ var outgoingCases = []OutgoingTestCase{
 		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Register", Extra: "https://example.com/form"}, {Type: "text", Text: "Skip"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 132 } }`)),
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
-			},
-			"*/botauth_token/deleteMessage": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": true }`)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Path: "/botauth_token/sendMessage", Form: url.Values{"text": {"⠀"}, "chat_id": {"12345"}, "disable_notification": {"true"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
-			{Path: "/botauth_token/deleteMessage", Form: url.Values{"chat_id": {"12345"}, "message_id": {"132"}}},
-			{Path: "/botauth_token/sendMessage", Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}}]]}`}}},
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -954,41 +948,13 @@ var outgoingCases = []OutgoingTestCase{
 		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "url", Extra: "http://example.com"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 132 } }`)),
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
-			},
-			"*/botauth_token/deleteMessage": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": true }`)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Path: "/botauth_token/sendMessage", Form: url.Values{"text": {"⠀"}, "chat_id": {"12345"}, "disable_notification": {"true"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
-			{Path: "/botauth_token/deleteMessage", Form: url.Values{"chat_id": {"12345"}, "message_id": {"132"}}},
-			{Path: "/botauth_token/sendMessage", Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Open Link","url":"http://example.com"}]]}`}}},
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Open Link","url":"http://example.com"}]]}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
-	},
-	{
-		Label:           "Quick Reply, inline keyboard on multi-part message doesn't need a placeholder to clear",
-		MsgText:         "Please register",
-		MsgURN:          "telegram:12345",
-		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Register", Extra: "https://example.com/form"}},
-		MsgAttachments:  []string{"application/pdf:https://foo.bar/doc1.pdf", "application/pdf:https://foo.bar/document.pdf"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"*/botauth_token/sendMessage": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
-			},
-			"*/botauth_token/sendDocument": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
-				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{Path: "/botauth_token/sendMessage", Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
-			{Path: "/botauth_token/sendDocument", Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/doc1.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
-			{Path: "/botauth_token/sendDocument", Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/document.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}}]]}`}}},
-		},
-		ExpectedExtIDs: []string{"133", "133", "133"},
 	},
 	{
 		Label:           "Quick Reply, url type without a URL is dropped",

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -915,11 +915,17 @@ var outgoingCases = []OutgoingTestCase{
 		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Register", Extra: "https://example.com/form"}, {Type: "text", Text: "Skip"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 132 } }`)),
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+			"*/botauth_token/deleteMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": true }`)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}}]]}`}}},
+			{Path: "/botauth_token/sendMessage", Form: url.Values{"text": {"⠀"}, "chat_id": {"12345"}, "disable_notification": {"true"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+			{Path: "/botauth_token/deleteMessage", Form: url.Values{"chat_id": {"12345"}, "message_id": {"132"}}},
+			{Path: "/botauth_token/sendMessage", Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}}]]}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -948,13 +954,41 @@ var outgoingCases = []OutgoingTestCase{
 		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "url", Extra: "http://example.com"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 132 } }`)),
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+			"*/botauth_token/deleteMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": true }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Path: "/botauth_token/sendMessage", Form: url.Values{"text": {"⠀"}, "chat_id": {"12345"}, "disable_notification": {"true"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+			{Path: "/botauth_token/deleteMessage", Form: url.Values{"chat_id": {"12345"}, "message_id": {"132"}}},
+			{Path: "/botauth_token/sendMessage", Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Open Link","url":"http://example.com"}]]}`}}},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
+		Label:           "Quick Reply, inline keyboard on multi-part message doesn't need a placeholder to clear",
+		MsgText:         "Please register",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Register", Extra: "https://example.com/form"}},
+		MsgAttachments:  []string{"application/pdf:https://foo.bar/doc1.pdf", "application/pdf:https://foo.bar/document.pdf"},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+			"*/botauth_token/sendDocument": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Open Link","url":"http://example.com"}]]}`}}},
+			{Path: "/botauth_token/sendMessage", Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+			{Path: "/botauth_token/sendDocument", Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/doc1.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+			{Path: "/botauth_token/sendDocument", Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/document.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}}]]}`}}},
 		},
-		ExpectedExtIDs: []string{"133"},
+		ExpectedExtIDs: []string{"133", "133", "133"},
 	},
 	{
 		Label:           "Quick Reply, url type without a URL is dropped",

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -904,7 +904,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Where Are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Where Are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true},{"text":"Ignore"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -919,7 +919,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -942,32 +942,35 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, url type takes priority over text",
+		Label:           "Quick Reply, url types as inline keyboard link buttons",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",
-		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "url", Extra: "http://example.com"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit Us", Extra: "http://example.com"}, {Type: "url", Extra: "http://example.com/more"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Open Link","url":"http://example.com"}]]}`}}},
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Visit Us","url":"http://example.com"},{"text":"Open Link","url":"http://example.com/more"}]]}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, form type takes priority over url",
+		Label:           "Quick Reply, url type mixed with reply keyboard types is dropped",
 		MsgText:         "Please register",
 		MsgURN:          "telegram:12345",
-		MsgQuickReplies: []models.QuickReply{{Type: "url", Extra: "http://example.com"}, {Type: "form", Text: "Register", Extra: "https://example.com/form"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Extra: "http://example.com"}, {Type: "form", Text: "Register", Extra: "https://example.com/form"}, {Type: "text", Text: "Skip"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -988,7 +991,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, unknown type ignored",
+		Label:           "Quick Reply, unknown type dropped",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",
 		MsgQuickReplies: []models.QuickReply{{Type: "video", Text: "Play"}},
@@ -999,6 +1002,9 @@ var outgoingCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type video isn't supported by this channel and can't be sent"},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -1021,7 +1027,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, location type takes priority over url",
+		Label:           "Quick Reply, url type mixed with location is dropped",
 		MsgText:         "Where are you?",
 		MsgURN:          "telegram:12345",
 		MsgQuickReplies: []models.QuickReply{{Type: "location"}, {Type: "url", Extra: "http://example.com"}},
@@ -1033,7 +1039,32 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"text": {"Where are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
 		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
+		},
 		ExpectedExtIDs: []string{"133"},
+	},
+	{
+		Label:           "Quick Reply, url type with multiple attachments",
+		MsgText:         "Check this out",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit", Extra: "http://example.com"}},
+		MsgAttachments:  []string{"application/pdf:https://foo.bar/doc1.pdf", "application/pdf:https://foo.bar/document.pdf"},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+			"*/botauth_token/sendDocument": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Check this out"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+			{Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/doc1.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+			{Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/document.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Visit","url":"http://example.com"}]]}`}}},
+		},
+		ExpectedExtIDs: []string{"133", "133", "133"},
 	},
 	{
 		Label:           "Quick Reply with multiple attachments",

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -1009,6 +1009,24 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
+		Label:           "Quick Reply, url type with an invalid URL is dropped",
+		MsgText:         "Are you happy?",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit Us", Extra: "example.com/visit"}, {Type: "url", Text: "Read More", Extra: "https://example.com/more"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Read More","url":"https://example.com/more"}]]}`}}},
+		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type url has an invalid URL and can't be sent: example.com/visit"},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
 		Label:           "Quick Reply, url type without a URL is dropped",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -573,6 +573,30 @@ var webAppDataNonJSONMsg = `
     }
 }`
 
+var callbackQueryMsg = `
+{
+    "update_id": 900946539,
+    "callback_query": {
+        "id": "4382bfdwdsb323b2d9",
+        "from": {
+            "id": 3527065,
+            "first_name": "Nic",
+            "last_name": "Pottier",
+            "username": "Nicpottier"
+        },
+        "message": {
+            "message_id": 99,
+            "chat": {
+                "id": 3527065,
+                "type": "private"
+            },
+            "date": 1493845755,
+            "text": "Are you happy?"
+        },
+        "data": "Yes"
+    }
+}`
+
 var testCases = []IncomingTestCase{
 	{
 
@@ -743,6 +767,17 @@ var testCases = []IncomingTestCase{
 		ExpectedErrors:       []*clogs.Error{{Message: "web_app_data data is not a valid JSON object"}},
 	},
 	{
+		Label:                "Receive Callback Query",
+		URL:                  "/c/tg/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive/",
+		Data:                 callbackQueryMsg,
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: "Accepted",
+		ExpectedContactName:  Sp("Nic Pottier"),
+		ExpectedMsgText:      Sp("Yes"),
+		ExpectedURN:          "telegram:3527065#nicpottier",
+		ExpectedExternalID:   "4382bfdwdsb323b2d9",
+	},
+	{
 		Label:                "Receive Empty",
 		URL:                  "/c/tg/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive/",
 		Data:                 emptyMsg,
@@ -798,8 +833,14 @@ var testCases = []IncomingTestCase{
 
 func buildMockTelegramService(testCases []IncomingTestCase) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fileID := r.FormValue("file_id")
 		defer r.Body.Close()
+
+		if strings.HasSuffix(r.URL.Path, "/answerCallbackQuery") {
+			w.Write([]byte(`{ "ok": true, "result": true }`))
+			return
+		}
+
+		fileID := r.FormValue("file_id")
 
 		filePath := ""
 
@@ -889,7 +930,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Yes"},{"text":"No"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Yes","callback_data":"Yes"},{"text":"No","callback_data":"No"}]]}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -919,7 +960,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip","callback_data":"Skip"}]]}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -934,7 +975,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Skip","callback_data":"Skip"}]]}`}}},
 		},
 		ExpectedLogErrors: []*clogs.Error{
 			{Message: "quick reply of type form is missing its extra value and can't be sent"},
@@ -942,7 +983,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, unsupported types ignored",
+		Label:           "Quick Reply, mixed text and url types on one inline keyboard",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",
 		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "url", Extra: "http://example.com"}},
@@ -952,18 +993,15 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Yes"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
-		},
-		ExpectedLogErrors: []*clogs.Error{
-			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Yes","callback_data":"Yes"},{"text":"Open Link","url":"http://example.com"}]]}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, only unsupported types means no keyboard",
+		Label:           "Quick Reply, url type without a URL is dropped",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",
-		MsgQuickReplies: []models.QuickReply{{Type: "url", Extra: "http://example.com"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit Us"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
@@ -971,6 +1009,24 @@ var outgoingCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type url is missing its extra value and can't be sent"},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
+		Label:           "Quick Reply, url type dropped when location forces a reply keyboard",
+		MsgText:         "Where are you?",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "location"}, {Type: "url", Extra: "http://example.com"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Where are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
 		},
 		ExpectedLogErrors: []*clogs.Error{
 			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
@@ -995,7 +1051,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": []string{"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
 			{Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/doc1.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
-			{Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/document.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Yes"},{"text":"No"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"caption": []string{""}, "chat_id": {"12345"}, "document": {"https://foo.bar/document.pdf"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Yes","callback_data":"Yes"},{"text":"No","callback_data":"No"}]]}`}}},
 		},
 		ExpectedExtIDs: []string{"133", "133", "133"},
 	},

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -1009,10 +1009,10 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, url type with an invalid URL is dropped",
+		Label:           "Quick Reply, url types with invalid URLs are dropped",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",
-		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit Us", Extra: "example.com/visit"}, {Type: "url", Text: "Read More", Extra: "https://example.com/more"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit Us", Extra: "example.com/visit"}, {Type: "url", Text: "Local", Extra: "http://localhost/visit"}, {Type: "url", Text: "Spaced", Extra: "https://example.com/a page"}, {Type: "url", Text: "Read More", Extra: "https://example.com/more"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
@@ -1023,6 +1023,8 @@ var outgoingCases = []OutgoingTestCase{
 		},
 		ExpectedLogErrors: []*clogs.Error{
 			{Message: "quick reply of type url has an invalid URL and can't be sent: example.com/visit"},
+			{Message: "quick reply of type url has an invalid URL and can't be sent: http://localhost/visit"},
+			{Message: "quick reply of type url has an invalid URL and can't be sent: https://example.com/a page"},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -1279,4 +1281,35 @@ func TestSendEvent(t *testing.T) {
 	// an event type the handler doesn't declare support for can't be sent
 	err = h.SendEvent(context.Background(), ch, events.NewTypingStopped(events.DirectionOutgoing, nil, "telegram:12345", ""), clog)
 	assert.ErrorContains(t, err, "unsupported event type: typing_stopped")
+}
+
+func TestIsValidButtonURL(t *testing.T) {
+	valid := []string{
+		"http://example.com",
+		"https://example.com/path?x=1#y",
+		"https://example.com:8080/path",
+		"http://127.0.0.1/dev",
+		"http://[::1]/dev",
+		"https://exämple.com/ü",
+		"tg://user?id=123456",
+		"tg://resolve?domain=example",
+	}
+	for _, s := range valid {
+		assert.True(t, isValidButtonURL(s), "expected %s to be valid", s)
+	}
+
+	invalid := []string{
+		"",
+		"example.com",
+		"www.example.com/path",
+		"mailto:bob@example.com",
+		"ftp://example.com/file",
+		"http://",
+		"http://localhost/dev",
+		"https://example.com/a page",
+		"https://example .com",
+	}
+	for _, s := range invalid {
+		assert.False(t, isValidButtonURL(s), "expected %s to be invalid", s)
+	}
 }

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -945,7 +945,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Where Are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true},{"text":"Ignore"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Where Are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -960,7 +960,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip","callback_data":"Skip"}]]}`}}},
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}}]]}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -983,7 +983,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, mixed text and url types on one inline keyboard",
+		Label:           "Quick Reply, url type takes priority over text",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",
 		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "url", Extra: "http://example.com"}},
@@ -993,7 +993,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Yes","callback_data":"Yes"},{"text":"Open Link","url":"http://example.com"}]]}`}}},
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Open Link","url":"http://example.com"}]]}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -1016,7 +1016,7 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, url type dropped when location forces a reply keyboard",
+		Label:           "Quick Reply, location type takes priority over url",
 		MsgText:         "Where are you?",
 		MsgURN:          "telegram:12345",
 		MsgQuickReplies: []models.QuickReply{{Type: "location"}, {Type: "url", Extra: "http://example.com"}},
@@ -1027,9 +1027,6 @@ var outgoingCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{
 			{Form: url.Values{"text": {"Where are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
-		},
-		ExpectedLogErrors: []*clogs.Error{
-			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -957,6 +957,52 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
+		Label:           "Quick Reply, form type takes priority over url",
+		MsgText:         "Please register",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Extra: "http://example.com"}, {Type: "form", Text: "Register", Extra: "https://example.com/form"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
+		Label:           "Quick Reply, url type with attachment",
+		MsgText:         "Check this out",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit", Extra: "http://example.com"}},
+		MsgAttachments:  []string{"image/jpeg:https://foo.bar/image.jpg"},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendPhoto": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"caption": {"Check this out"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "photo": {"https://foo.bar/image.jpg"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Visit","url":"http://example.com"}]]}`}}},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
+		Label:           "Quick Reply, unknown type ignored",
+		MsgText:         "Are you happy?",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "video", Text: "Play"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
 		Label:           "Quick Reply, url type without a URL is dropped",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",

--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -4,6 +4,14 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 )
 
+// Markup is a keyboard that can be sent as a message's reply_markup
+type Markup interface {
+	isMarkup()
+}
+
+func (*ReplyKeyboardMarkup) isMarkup()  {}
+func (*InlineKeyboardMarkup) isMarkup() {}
+
 // WebAppInfo describes a Mini App to be launched, see https://core.telegram.org/bots/api/#webappinfo
 type WebAppInfo struct {
 	URL string `json:"url"`

--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -50,9 +50,8 @@ func NewKeyboardFromReplies(replies []models.QuickReply) *ReplyKeyboardMarkup {
 
 // InlineKeyboardButton is a button on an inline keyboard, see https://core.telegram.org/bots/api/#inlinekeyboardbutton
 type InlineKeyboardButton struct {
-	Text   string      `json:"text"`
-	URL    string      `json:"url,omitempty"`
-	WebApp *WebAppInfo `json:"web_app,omitempty"`
+	Text string `json:"text"`
+	URL  string `json:"url,omitempty"`
 }
 
 // InlineKeyboardMarkup models an inline keyboard, see https://core.telegram.org/bots/api/#inlinekeyboardmarkup
@@ -60,8 +59,7 @@ type InlineKeyboardMarkup struct {
 	InlineKeyboard [][]InlineKeyboardButton `json:"inline_keyboard"`
 }
 
-// NewInlineKeyboardFromReplies creates an inline keyboard from the given quick replies - url replies become link
-// buttons and form replies buttons that open the URL in Extra as a Mini App
+// NewInlineKeyboardFromReplies creates an inline keyboard of link buttons from the given URL quick replies
 func NewInlineKeyboardFromReplies(replies []models.QuickReply) *InlineKeyboardMarkup {
 	rows := models.QuickRepliesToRows(replies, 5, 30, 2)
 	keyboard := make([][]InlineKeyboardButton, len(rows))
@@ -70,13 +68,7 @@ func NewInlineKeyboardFromReplies(replies []models.QuickReply) *InlineKeyboardMa
 		keyboard[i] = make([]InlineKeyboardButton, len(rows[i]))
 		for j := range rows[i] {
 			keyboard[i][j].Text = rows[i][j].GetText()
-
-			switch rows[i][j].Type {
-			case models.QuickReplyTypeURL:
-				keyboard[i][j].URL = rows[i][j].Extra
-			case models.QuickReplyTypeForm:
-				keyboard[i][j].WebApp = &WebAppInfo{URL: rows[i][j].Extra}
-			}
+			keyboard[i][j].URL = rows[i][j].Extra
 		}
 	}
 

--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -1,8 +1,6 @@
 package telegram
 
 import (
-	"unicode/utf8"
-
 	"github.com/nyaruka/courier/v26/core/models"
 )
 
@@ -52,10 +50,9 @@ func NewKeyboardFromReplies(replies []models.QuickReply) *ReplyKeyboardMarkup {
 
 // InlineKeyboardButton is a button on an inline keyboard, see https://core.telegram.org/bots/api/#inlinekeyboardbutton
 type InlineKeyboardButton struct {
-	Text         string      `json:"text"`
-	CallbackData string      `json:"callback_data,omitempty"`
-	URL          string      `json:"url,omitempty"`
-	WebApp       *WebAppInfo `json:"web_app,omitempty"`
+	Text   string      `json:"text"`
+	URL    string      `json:"url,omitempty"`
+	WebApp *WebAppInfo `json:"web_app,omitempty"`
 }
 
 // InlineKeyboardMarkup models an inline keyboard, see https://core.telegram.org/bots/api/#inlinekeyboardmarkup
@@ -63,8 +60,8 @@ type InlineKeyboardMarkup struct {
 	InlineKeyboard [][]InlineKeyboardButton `json:"inline_keyboard"`
 }
 
-// NewInlineKeyboardFromReplies creates an inline keyboard from the given quick replies - text replies become callback
-// buttons, url replies link buttons, and form replies buttons that open the URL in Extra as a Mini App
+// NewInlineKeyboardFromReplies creates an inline keyboard from the given quick replies - url replies become link
+// buttons and form replies buttons that open the URL in Extra as a Mini App
 func NewInlineKeyboardFromReplies(replies []models.QuickReply) *InlineKeyboardMarkup {
 	rows := models.QuickRepliesToRows(replies, 5, 30, 2)
 	keyboard := make([][]InlineKeyboardButton, len(rows))
@@ -79,21 +76,9 @@ func NewInlineKeyboardFromReplies(replies []models.QuickReply) *InlineKeyboardMa
 				keyboard[i][j].URL = rows[i][j].Extra
 			case models.QuickReplyTypeForm:
 				keyboard[i][j].WebApp = &WebAppInfo{URL: rows[i][j].Extra}
-			default:
-				// the tapped button's data comes back to us as the reply, and Telegram caps it at 64 bytes
-				keyboard[i][j].CallbackData = truncateBytes(rows[i][j].Text, 64)
 			}
 		}
 	}
 
 	return &InlineKeyboardMarkup{InlineKeyboard: keyboard}
-}
-
-// truncates a string to at most n bytes without splitting a multi-byte character
-func truncateBytes(s string, n int) string {
-	for len(s) > n {
-		_, size := utf8.DecodeLastRuneInString(s)
-		s = s[:len(s)-size]
-	}
-	return s
 }

--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -1,6 +1,8 @@
 package telegram
 
 import (
+	"unicode/utf8"
+
 	"github.com/nyaruka/courier/v26/core/models"
 )
 
@@ -46,4 +48,52 @@ func NewKeyboardFromReplies(replies []models.QuickReply) *ReplyKeyboardMarkup {
 	}
 
 	return &ReplyKeyboardMarkup{Keyboard: keyboard, ResizeKeyboard: true, OneTimeKeyboard: true}
+}
+
+// InlineKeyboardButton is a button on an inline keyboard, see https://core.telegram.org/bots/api/#inlinekeyboardbutton
+type InlineKeyboardButton struct {
+	Text         string      `json:"text"`
+	CallbackData string      `json:"callback_data,omitempty"`
+	URL          string      `json:"url,omitempty"`
+	WebApp       *WebAppInfo `json:"web_app,omitempty"`
+}
+
+// InlineKeyboardMarkup models an inline keyboard, see https://core.telegram.org/bots/api/#inlinekeyboardmarkup
+type InlineKeyboardMarkup struct {
+	InlineKeyboard [][]InlineKeyboardButton `json:"inline_keyboard"`
+}
+
+// NewInlineKeyboardFromReplies creates an inline keyboard from the given quick replies - text replies become callback
+// buttons, url replies link buttons, and form replies buttons that open the URL in Extra as a Mini App
+func NewInlineKeyboardFromReplies(replies []models.QuickReply) *InlineKeyboardMarkup {
+	rows := models.QuickRepliesToRows(replies, 5, 30, 2)
+	keyboard := make([][]InlineKeyboardButton, len(rows))
+
+	for i := range rows {
+		keyboard[i] = make([]InlineKeyboardButton, len(rows[i]))
+		for j := range rows[i] {
+			keyboard[i][j].Text = rows[i][j].GetText()
+
+			switch rows[i][j].Type {
+			case models.QuickReplyTypeURL:
+				keyboard[i][j].URL = rows[i][j].Extra
+			case models.QuickReplyTypeForm:
+				keyboard[i][j].WebApp = &WebAppInfo{URL: rows[i][j].Extra}
+			default:
+				// the tapped button's data comes back to us as the reply, and Telegram caps it at 64 bytes
+				keyboard[i][j].CallbackData = truncateBytes(rows[i][j].Text, 64)
+			}
+		}
+	}
+
+	return &InlineKeyboardMarkup{InlineKeyboard: keyboard}
+}
+
+// truncates a string to at most n bytes without splitting a multi-byte character
+func truncateBytes(s string, n int) string {
+	for len(s) > n {
+		_, size := utf8.DecodeLastRuneInString(s)
+		s = s[:len(s)-size]
+	}
+	return s
 }

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -107,11 +107,17 @@ func TestInlineKeyboardFromReplies(t *testing.T) {
 			},
 		},
 		{
-			[]models.QuickReply{{Type: "text", Text: "Skip"}, {Type: "url", Extra: "https://example.com"}, {Type: "form", Text: "Register", Extra: "https://example.com/form"}},
+			[]models.QuickReply{{Type: "url", Extra: "https://example.com"}, {Type: "url", Text: "Read More", Extra: "https://example.com/more"}},
 			&telegram.InlineKeyboardMarkup{
 				InlineKeyboard: [][]telegram.InlineKeyboardButton{
-					{{Text: "Skip", CallbackData: "Skip"}},
-					{{Text: "Open Link", URL: "https://example.com"}},
+					{{Text: "Open Link", URL: "https://example.com"}, {Text: "Read More", URL: "https://example.com/more"}},
+				},
+			},
+		},
+		{
+			[]models.QuickReply{{Type: "form", Text: "Register", Extra: "https://example.com/form"}},
+			&telegram.InlineKeyboardMarkup{
+				InlineKeyboard: [][]telegram.InlineKeyboardButton{
 					{{Text: "Register", WebApp: &telegram.WebAppInfo{URL: "https://example.com/form"}}},
 				},
 			},

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -1,7 +1,6 @@
 package telegram_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/nyaruka/courier/v26/core/models"
@@ -99,14 +98,6 @@ func TestInlineKeyboardFromReplies(t *testing.T) {
 		expected *telegram.InlineKeyboardMarkup
 	}{
 		{
-			[]models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "text", Text: "No"}},
-			&telegram.InlineKeyboardMarkup{
-				InlineKeyboard: [][]telegram.InlineKeyboardButton{
-					{{Text: "Yes", CallbackData: "Yes"}, {Text: "No", CallbackData: "No"}},
-				},
-			},
-		},
-		{
 			[]models.QuickReply{{Type: "url", Extra: "https://example.com"}, {Type: "url", Text: "Read More", Extra: "https://example.com/more"}},
 			&telegram.InlineKeyboardMarkup{
 				InlineKeyboard: [][]telegram.InlineKeyboardButton{
@@ -119,15 +110,6 @@ func TestInlineKeyboardFromReplies(t *testing.T) {
 			&telegram.InlineKeyboardMarkup{
 				InlineKeyboard: [][]telegram.InlineKeyboardButton{
 					{{Text: "Register", WebApp: &telegram.WebAppInfo{URL: "https://example.com/form"}}},
-				},
-			},
-		},
-		{
-			// callback data is truncated to 64 bytes without splitting characters
-			[]models.QuickReply{{Type: "text", Text: strings.Repeat("é", 40)}},
-			&telegram.InlineKeyboardMarkup{
-				InlineKeyboard: [][]telegram.InlineKeyboardButton{
-					{{Text: strings.Repeat("é", 40), CallbackData: strings.Repeat("é", 32)}},
 				},
 			},
 		},

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -106,10 +106,10 @@ func TestInlineKeyboardFromReplies(t *testing.T) {
 			},
 		},
 		{
-			[]models.QuickReply{{Type: "form", Text: "Register", Extra: "https://example.com/form"}},
+			[]models.QuickReply{{Type: "url", Text: "Visit Us", Extra: "https://example.com/visit"}},
 			&telegram.InlineKeyboardMarkup{
 				InlineKeyboard: [][]telegram.InlineKeyboardButton{
-					{{Text: "Register", WebApp: &telegram.WebAppInfo{URL: "https://example.com/form"}}},
+					{{Text: "Visit Us", URL: "https://example.com/visit"}},
 				},
 			},
 		},

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -1,6 +1,7 @@
 package telegram_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nyaruka/courier/v26/core/models"
@@ -88,6 +89,46 @@ func TestKeyboardFromReplies(t *testing.T) {
 
 	for _, tc := range tcs {
 		kb := telegram.NewKeyboardFromReplies(tc.replies)
+		assert.Equal(t, tc.expected, kb, "keyboard mismatch for replies %v", tc.replies)
+	}
+}
+
+func TestInlineKeyboardFromReplies(t *testing.T) {
+	tcs := []struct {
+		replies  []models.QuickReply
+		expected *telegram.InlineKeyboardMarkup
+	}{
+		{
+			[]models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "text", Text: "No"}},
+			&telegram.InlineKeyboardMarkup{
+				InlineKeyboard: [][]telegram.InlineKeyboardButton{
+					{{Text: "Yes", CallbackData: "Yes"}, {Text: "No", CallbackData: "No"}},
+				},
+			},
+		},
+		{
+			[]models.QuickReply{{Type: "text", Text: "Skip"}, {Type: "url", Extra: "https://example.com"}, {Type: "form", Text: "Register", Extra: "https://example.com/form"}},
+			&telegram.InlineKeyboardMarkup{
+				InlineKeyboard: [][]telegram.InlineKeyboardButton{
+					{{Text: "Skip", CallbackData: "Skip"}},
+					{{Text: "Open Link", URL: "https://example.com"}},
+					{{Text: "Register", WebApp: &telegram.WebAppInfo{URL: "https://example.com/form"}}},
+				},
+			},
+		},
+		{
+			// callback data is truncated to 64 bytes without splitting characters
+			[]models.QuickReply{{Type: "text", Text: strings.Repeat("é", 40)}},
+			&telegram.InlineKeyboardMarkup{
+				InlineKeyboard: [][]telegram.InlineKeyboardButton{
+					{{Text: strings.Repeat("é", 40), CallbackData: strings.Repeat("é", 32)}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		kb := telegram.NewInlineKeyboardFromReplies(tc.replies)
 		assert.Equal(t, tc.expected, kb, "keyboard mismatch for replies %v", tc.replies)
 	}
 }

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -113,6 +113,15 @@ func TestInlineKeyboardFromReplies(t *testing.T) {
 				},
 			},
 		},
+		{
+			[]models.QuickReply{{Type: "url", Text: "Visit our website", Extra: "https://example.com"}, {Type: "url", Text: "Read the latest news", Extra: "https://example.com/news"}},
+			&telegram.InlineKeyboardMarkup{
+				InlineKeyboard: [][]telegram.InlineKeyboardButton{
+					{{Text: "Visit our website", URL: "https://example.com"}},
+					{{Text: "Read the latest news", URL: "https://example.com/news"}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
Telegram reply keyboards can mix text, location and form buttons, so those quick reply types continue to be sent together on one reply keyboard as before — form replies as `web_app` buttons that open the URL in `extra` as a Mini App.

URL replies, previously dropped entirely for Telegram, become an `InlineKeyboardMarkup` of link buttons, which renders attached to the message on all Telegram clients and needs no new webhook handling. Since a message can only have one kind of `reply_markup` and url buttons only exist on inline keyboards, url replies are sent when they're the only type on the message, and dropped with a logged channel error when mixed with types that need the reply keyboard. Unknown quick reply types are also dropped with a logged error rather than silently.

Also fixes the keyboard being attached to the last attachment based on the count of the message's raw attachments rather than the resolved ones, which silently dropped the keyboard when any attachment failed to resolve.