### PR TITLE
Save incoming WhatsApp BSUIDs as secondary whatsapp URNs

### DIFF
--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -164,13 +164,15 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					courier.LogRequestError(r, channel, errors.New("nfm_reply response_json is not a valid JSON object"))
 				}
 
-				// if we have a user_id, add it as secondary BSUID URN
+				// if we have a user_id, add it as a secondary whatsapp URN (unless it's already the primary URN)
 				if waMsg.FromUserID != "" {
-					userIDURN, urnErr := urns.New(urns.BSUID, waMsg.FromUserID)
+					userIDURN, urnErr := urns.New(urns.WhatsApp, waMsg.FromUserID)
 					if urnErr == nil {
-						event.WithNewURN(userIDURN, models.NewURNAppend)
+						if userIDURN != urn {
+							event.WithNewURN(userIDURN, models.NewURNAppend)
+						}
 					} else {
-						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for BSUID URN: %w", urnErr))
+						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for whatsapp URN: %w", urnErr))
 					}
 				}
 
@@ -300,12 +302,12 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 
 	// if we got a user_id in the response, set it as a new URN on the send result so the backend
-	// can queue a contact_changed task to append it to the contact
+	// can queue a contact_changed task to append it to the contact (unless it's the URN we sent to)
 	if userID != "" {
-		userIDURN, err := urns.New(urns.BSUID, userID)
+		userIDURN, err := urns.New(urns.WhatsApp, userID)
 		if err != nil {
-			clog.RawError(fmt.Errorf("unable to make BSUID URN from user_id %s: %w", userID, err))
-		} else {
+			clog.RawError(fmt.Errorf("unable to make whatsapp URN from user_id %s: %w", userID, err))
+		} else if userIDURN != msg.URN() {
 			res.SetNewURN(userIDURN)
 		}
 	}

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -65,7 +65,20 @@ var testCasesD3C = []IncomingTestCase{
 		ExpectedURN:           "whatsapp:5678",
 		ExpectedExternalID:    "external_id",
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
-		ExpectedNewURN:        &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend},
+		ExpectedNewURN:        &models.NewURNSpec{Value: "whatsapp:US.1234", Action: models.NewURNAppend},
+	},
+	{
+		Label:                 "Receive Message WAC from BSUID with no phone",
+		URL:                   d3CReceiveURL,
+		Data:                  string(test.ReadFile("../meta/testdata/wac/hello_from_bsuid.json")),
+		ExpectedRespStatus:    200,
+		ExpectedBodyContains:  "Handled",
+		NoQueueErrorCheck:     true,
+		NoInvalidChannelCheck: true,
+		ExpectedMsgText:       Sp("Hello World"),
+		ExpectedURN:           "whatsapp:US.1234",
+		ExpectedExternalID:    "external_id",
+		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
 	},
 	{
 		Label:                 "Receive Duplicate Valid Message",
@@ -411,14 +424,14 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 		ExpectedContactURNs: map[string]bool{
 			"whatsapp:250788123123": true,
-			"bsuid:US.1234":         true,
+			"whatsapp:US.1234":      true,
 		},
 	},
 	{
 		Label:               "Plain Send with user_id already on contact",
 		MsgText:             "Simple Message",
 		MsgURN:              "whatsapp:250788123123",
-		MsgContactOtherURNs: []urns.URN{"bsuid:US.1234"},
+		MsgContactOtherURNs: []urns.URN{"whatsapp:US.1234"},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"https://waba-v2.360dialog.io/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "contacts": [{"input": "250788123123", "user_id": "US.1234"}], "messages": [{"id": "157b5e14568e8"}] }`)),

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -428,6 +428,17 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		},
 	},
 	{
+		Label:   "Send to BSUID with same user_id in response",
+		MsgText: "Simple Message",
+		MsgURN:  "whatsapp:US.1234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://waba-v2.360dialog.io/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "contacts": [{"input": "US.1234", "user_id": "US.1234"}], "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:               "Plain Send with user_id already on contact",
 		MsgText:             "Simple Message",
 		MsgURN:              "whatsapp:250788123123",

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -309,13 +309,15 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel courier.Ch
 					courier.LogRequestError(r, channel, errors.New("nfm_reply response_json is not a valid JSON object"))
 				}
 
-				// if we have a user_id, add it as secondary BSUID URN
+				// if we have a user_id, add it as a secondary whatsapp URN (unless it's already the primary URN)
 				if waMsg.FromUserID != "" {
-					userIDURN, urnErr := urns.New(urns.BSUID, waMsg.FromUserID)
+					userIDURN, urnErr := urns.New(urns.WhatsApp, waMsg.FromUserID)
 					if urnErr == nil {
-						event.WithNewURN(userIDURN, models.NewURNAppend)
+						if userIDURN != urn {
+							event.WithNewURN(userIDURN, models.NewURNAppend)
+						}
 					} else {
-						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for BSUID URN: %w", urnErr))
+						courier.LogRequestError(r, channel, fmt.Errorf("invalid user_id for whatsapp URN: %w", urnErr))
 					}
 				}
 
@@ -732,12 +734,12 @@ func (h *handler) sendWhatsAppMsg(ctx context.Context, msg courier.MsgOut, res *
 	}
 
 	// if we got a user_id in the response, set it as a new URN on the send result so the backend
-	// can queue a contact_changed task to append it to the contact
+	// can queue a contact_changed task to append it to the contact (unless it's the URN we sent to)
 	if userID != "" {
-		userIDURN, err := urns.New(urns.BSUID, userID)
+		userIDURN, err := urns.New(urns.WhatsApp, userID)
 		if err != nil {
-			clog.RawError(fmt.Errorf("unable to make BSUID URN from user_id %s: %w", userID, err))
-		} else {
+			clog.RawError(fmt.Errorf("unable to make whatsapp URN from user_id %s: %w", userID, err))
+		} else if userIDURN != msg.URN() {
 			res.SetNewURN(userIDURN)
 		}
 	}

--- a/handlers/meta/testdata/wac/hello_from_bsuid.json
+++ b/handlers/meta/testdata/wac/hello_from_bsuid.json
@@ -1,0 +1,42 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "8856996819413533",
+      "changes": [
+        {
+          "value": {
+            "messaging_product": "whatsapp",
+            "metadata": {
+              "display_phone_number": "+250 788 123 200",
+              "phone_number_id": "12345"
+            },
+            "contacts": [
+              {
+                "profile": {
+                  "name": "Kerry Fisher",
+                  "username": "@kfisher"
+                },
+                "wa_id": "US.1234",
+                "user_id": "US.1234"
+              }
+            ],
+            "messages": [
+              {
+                "from": "US.1234",
+                "from_user_id": "US.1234",
+                "id": "external_id",
+                "timestamp": "1454119029",
+                "text": {
+                  "body": "Hello World"
+                },
+                "type": "text"
+              }
+            ]
+          },
+          "field": "messages"
+        }
+      ]
+    }
+  ]
+}

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -51,7 +51,21 @@ var whatsappIncomingTests = []IncomingTestCase{
 		ExpectedURN:           "whatsapp:5678",
 		ExpectedExternalID:    "external_id",
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
-		ExpectedNewURN:        &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend},
+		ExpectedNewURN:        &models.NewURNSpec{Value: "whatsapp:US.1234", Action: models.NewURNAppend},
+		PrepRequest:           addValidSignature,
+	},
+	{
+		Label:                 "Receive Message WAC from BSUID with no phone",
+		URL:                   whatappReceiveURL,
+		Data:                  string(test.ReadFile("./testdata/wac/hello_from_bsuid.json")),
+		ExpectedRespStatus:    200,
+		ExpectedBodyContains:  "Handled",
+		NoQueueErrorCheck:     true,
+		NoInvalidChannelCheck: true,
+		ExpectedMsgText:       Sp("Hello World"),
+		ExpectedURN:           "whatsapp:US.1234",
+		ExpectedExternalID:    "external_id",
+		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
 		PrepRequest:           addValidSignature,
 	},
 	{
@@ -403,17 +417,28 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 		ExpectedContactURNs: map[string]bool{
 			"whatsapp:250788123123": true,
-			"bsuid:US.1234":         true,
+			"whatsapp:US.1234":      true,
 		},
 	},
 	{
 		Label:               "Plain Send with user_id already on contact",
 		MsgText:             "Simple Message",
 		MsgURN:              "whatsapp:250788123123",
-		MsgContactOtherURNs: []urns.URN{"bsuid:US.1234"},
+		MsgContactOtherURNs: []urns.URN{"whatsapp:US.1234"},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/12345_ID/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "contacts": [{"input": "250788123123", "user_id": "US.1234"}], "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:   "Send to BSUID with same user_id in response",
+		MsgText: "Simple Message",
+		MsgURN:  "whatsapp:US.1234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "contacts": [{"input": "US.1234", "user_id": "US.1234"}], "messages": [{"id": "157b5e14568e8"}] }`)),
 			},
 		},
 		ExpectedExtIDs: []string{"157b5e14568e8"},

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -248,12 +248,15 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 			event.WithAttachment(mediaURL)
 		}
 
+		// if we have a from_bsuid, add it as a secondary whatsapp URN (unless it's already the primary URN)
 		if msg.FromBSUID != "" {
-			userIDURN, urnErr := urns.New(urns.BSUID, msg.FromBSUID)
+			userIDURN, urnErr := urns.New(urns.WhatsApp, msg.FromBSUID)
 			if urnErr == nil {
-				event.WithNewURN(userIDURN, models.NewURNAppend)
+				if userIDURN != urn {
+					event.WithNewURN(userIDURN, models.NewURNAppend)
+				}
 			} else {
-				courier.LogRequestError(r, channel, fmt.Errorf("invalid from_bsuid for BSUID URN: %w", urnErr))
+				courier.LogRequestError(r, channel, fmt.Errorf("invalid from_bsuid for whatsapp URN: %w", urnErr))
 			}
 		}
 

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -66,6 +66,25 @@ var helloMsgWithValidBSUID = `{
    }]
 }`
 
+var helloMsgFromBSUID = `{
+  "contacts":[{
+    "profile": {
+      "name": "Jerry Cooney"
+    },
+    "wa_id": "US.1234"
+  }],
+  "messages": [{
+    "from": "US.1234",
+    "from_bsuid": "US.1234",
+    "id": "41",
+    "timestamp": "1454119029",
+    "text": {
+      "body": "hello world"
+    },
+    "type": "text"
+   }]
+}`
+
 var helloMsgWithInvalidBSUID = `{
   "contacts":[{
     "profile": {
@@ -364,7 +383,21 @@ var testCasesTurn = []IncomingTestCase{
 		ExpectedURN:           "whatsapp:250788123123",
 		ExpectedExternalID:    "41",
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
-		ExpectedNewURN:        &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend},
+		ExpectedNewURN:        &models.NewURNSpec{Value: "whatsapp:US.1234", Action: models.NewURNAppend},
+		NoQueueErrorCheck:     true,
+		NoInvalidChannelCheck: true,
+	},
+	{
+		Label:                 "Receive Message from BSUID with no phone",
+		URL:                   turnWhatsappReceiveURL,
+		Data:                  helloMsgFromBSUID,
+		ExpectedRespStatus:    200,
+		ExpectedBodyContains:  `"type":"msg"`,
+		ExpectedContactName:   Sp("Jerry Cooney"),
+		ExpectedMsgText:       Sp("hello world"),
+		ExpectedURN:           "whatsapp:US.1234",
+		ExpectedExternalID:    "41",
+		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
 		NoQueueErrorCheck:     true,
 		NoInvalidChannelCheck: true,
 	},

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -159,7 +159,9 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		userIDURN, urnErr := h.parseURN(channel, form.ExternalUserId, i18n.Country(form.FromCountry))
 
 		if urnErr == nil {
-			msg.WithNewURN(userIDURN, models.NewURNAppend)
+			if userIDURN != urn {
+				msg.WithNewURN(userIDURN, models.NewURNAppend)
+			}
 		} else {
 			slog.Warn("ignoring invalid ExternalUserId for message", "ExternalUserId", form.ExternalUserId, "MessageSID", form.MessageSID, "Error", urnErr.Error())
 
@@ -529,8 +531,8 @@ func (h *handler) parseURN(channel courier.Channel, text string, country i18n.Co
 		}
 
 		if dot := strings.Index(fromTel, "."); dot >= 0 && dot < len(fromTel)-1 {
-			// if we have a BSUID, use that as the URN
-			return urns.New(urns.BSUID, fromTel)
+			// a business-scoped user ID becomes a whatsapp URN
+			return urns.New(urns.WhatsApp, fromTel)
 		}
 
 		// trim off left +, official whatsapp IDs dont have that

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -82,6 +82,7 @@ var (
 
 	waReceiveValid         = "ToCountry=US&ToState=District+Of+Columbia&SmsMessageSid=SMe287d7109a5a925f182f0e07fe5b223b&NumMedia=0&ToCity=&FromZip=01022&SmsSid=SMe287d7109a5a925f182f0e07fe5b223b&FromState=MA&SmsStatus=received&FromCity=CHICOPEE&Body=Msg&FromCountry=US&To=whatsapp:%2B12028831111&ToZip=&NumSegments=1&MessageSid=SMe287d7109a5a925f182f0e07fe5b223b&AccountSid=acctid&From=whatsapp:%2B14133881111&ApiVersion=2010-04-01"
 	waReceiveBSUIDValid    = "ToCountry=US&ToState=District+Of+Columbia&SmsMessageSid=SMe287d7109a5a925f182f0e07fe5b223b&NumMedia=0&ToCity=&FromZip=01022&SmsSid=SMe287d7109a5a925f182f0e07fe5b223b&FromState=MA&SmsStatus=received&FromCity=CHICOPEE&Body=Msg&FromCountry=US&To=whatsapp:%2B12028831111&ToZip=&NumSegments=1&MessageSid=SMe287d7109a5a925f182f0e07fe5b223b&AccountSid=acctid&From=whatsapp:%2B14133881111&ExternalUserId=whatsapp:US.1234&ApiVersion=2010-04-01"
+	waReceiveFromBSUID     = "ToCountry=US&ToState=District+Of+Columbia&SmsMessageSid=SMe287d7109a5a925f182f0e07fe5b223b&NumMedia=0&ToCity=&FromZip=01022&SmsSid=SMe287d7109a5a925f182f0e07fe5b223b&FromState=MA&SmsStatus=received&FromCity=CHICOPEE&Body=Msg&FromCountry=US&To=whatsapp:%2B12028831111&ToZip=&NumSegments=1&MessageSid=SMe287d7109a5a925f182f0e07fe5b223b&AccountSid=acctid&From=whatsapp:US.1234&ExternalUserId=whatsapp:US.1234&ApiVersion=2010-04-01"
 	waReceiveButtonValid   = "ToCountry=US&ToState=District+Of+Columbia&SmsMessageSid=SMe287d7109a5a925f182f0e07fe5b223b&NumMedia=0&ToCity=&FromZip=01022&SmsSid=SMe287d7109a5a925f182f0e07fe5b223b&FromState=MA&SmsStatus=received&FromCity=CHICOPEE&Body=Msg&ButtonText=Confirm&FromCountry=US&To=whatsapp:%2B12028831111&ToZip=&NumSegments=1&MessageSid=SMe287d7109a5a925f182f0e07fe5b223b&AccountSid=acctid&From=whatsapp:%2B14133881111&ApiVersion=2010-04-01"
 	waReceivePrefixlessURN = "ToCountry=US&ToState=CA&SmsMessageSid=SM681a1f26d9ec591431ce406e8f399525&NumMedia=0&ToCity=&FromZip=60625&SmsSid=SM681a1f26d9ec591431ce406e8f399525&FromState=IL&SmsStatus=received&FromCity=CHICAGO&Body=Msg&FromCountry=US&To=%2B12028831111&ToZip=&NumSegments=1&MessageSid=SM681a1f26d9ec591431ce406e8f399525&AccountSid=acctid&From=%2B14133881111&ApiVersion=2010-04-01"
 )
@@ -458,7 +459,10 @@ var twaTestCases = []IncomingTestCase{
 		ExpectedMsgText: Sp("Msg"), ExpectedURN: "whatsapp:14133881111", ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",
 		PrepRequest: addValidSignature},
 	{Label: "Receive BSUID Valid", URL: twaReceiveURL, Data: waReceiveBSUIDValid, ExpectedRespStatus: 200, ExpectedBodyContains: "<Response/>",
-		ExpectedMsgText: Sp("Msg"), ExpectedURN: "whatsapp:14133881111", ExpectedNewURN: &models.NewURNSpec{Value: "bsuid:US.1234", Action: models.NewURNAppend}, ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",
+		ExpectedMsgText: Sp("Msg"), ExpectedURN: "whatsapp:14133881111", ExpectedNewURN: &models.NewURNSpec{Value: "whatsapp:US.1234", Action: models.NewURNAppend}, ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",
+		PrepRequest: addValidSignature},
+	{Label: "Receive From BSUID with no phone", URL: twaReceiveURL, Data: waReceiveFromBSUID, ExpectedRespStatus: 200, ExpectedBodyContains: "<Response/>",
+		ExpectedMsgText: Sp("Msg"), ExpectedURN: "whatsapp:US.1234", ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",
 		PrepRequest: addValidSignature},
 	{Label: "Receive Valid", URL: twaReceiveURL, Data: waReceiveButtonValid, ExpectedRespStatus: 200, ExpectedBodyContains: "<Response/>",
 		ExpectedMsgText: Sp("Confirm"), ExpectedURN: "whatsapp:14133881111", ExpectedExternalID: "SMe287d7109a5a925f182f0e07fe5b223b",


### PR DESCRIPTION
## Summary

Incoming WhatsApp business-scoped user IDs are now stored as `whatsapp` scheme URNs instead of the separate `bsuid` scheme, appended behind the phone number which stays the message's primary URN. This builds the phone↔BSUID mapping on every message while phones still appear in webhooks, without changing message attribution, URN priority, or contact resolution by phone. Follows #1083 (sending to BSUID-form whatsapp URNs).

## Changes

- **Receive (WAC, D3C, TRN, TWA):** a `user_id` / `from_bsuid` / `ExternalUserId` is appended as a `whatsapp:CC.xxx` URN (was `bsuid:CC.xxx`). The phone remains the primary URN.
- **Phone-hidden senders:** when the sender identity is itself a BSUID (no phone in the payload), it becomes the primary whatsapp URN, and a matching secondary is no longer redundantly appended.
- **Send responses (WAC, D3C):** a response `user_id` is appended as a `whatsapp` URN, now skipped when it equals the URN the message was sent to — previously that queued a no-op contact task.

## Behavior

| Incoming payload | Primary URN | Appended URN |
|---|---|---|
| phone only | `whatsapp:<digits>` | — |
| phone + BSUID | `whatsapp:<digits>` | `whatsapp:CC.xxx` |
| BSUID only | `whatsapp:CC.xxx` | — |

A payload carrying both identifiers resolves the contact by phone, so an existing contact keeps its history when a BSUID first appears. URN appends never steal a URN owned by another contact.

Contacts holding a legacy `bsuid:` URN will additionally get the whatsapp form on their next message; a later migration collapses the `bsuid:` rows.

## Test plan

- New "from BSUID with no phone" incoming cases for all four handlers, asserting no redundant appended URN.
- New send cases covering the response `user_id` == destination guard for both WAC and D3C.
- Existing incoming/outgoing BSUID expectations updated to the whatsapp scheme.
- Full suite green locally; CI green.