### PR TITLE
Drop Telegram url quick replies with invalid URLs instead of failing the send

### DIFF
--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"slices"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
@@ -153,6 +155,26 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.MsgIn{msg}, w, r, clog)
 }
 
+// isValidButtonURL approximates Telegram's validation of inline keyboard button URLs, which accepts HTTP(S) and
+// tg:// URLs, rejects whitespace, and requires HTTP(S) hostnames to have a TLD (or be an IP address)
+func isValidButtonURL(s string) bool {
+	if strings.ContainsFunc(s, unicode.IsSpace) {
+		return false
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	if u.Scheme == "tg" {
+		return true
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	return strings.Contains(u.Hostname(), ".") || net.ParseIP(u.Hostname()) != nil
+}
+
 type mtResponse struct {
 	Ok          bool   `json:"ok" validate:"required"`
 	ErrorCode   int    `json:"error_code"`
@@ -231,10 +253,10 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	if urlsOnly {
 		qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeURL)
 
-		// Telegram rejects the entire message if a button URL isn't a valid absolute HTTP(S) URL, so drop invalid
-		// ones with a logged error instead of failing the send
+		// Telegram rejects the entire message if a button URL isn't valid, so drop invalid ones with a logged error
+		// instead of failing the send
 		qrs = slices.DeleteFunc(qrs, func(q models.QuickReply) bool {
-			if u, err := url.Parse(q.Extra); err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			if !isValidButtonURL(q.Extra) {
 				clog.Error(&clogs.Error{Message: fmt.Sprintf("quick reply of type url has an invalid URL and can't be sent: %s", q.Extra)})
 				return true
 			}

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -229,7 +229,19 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	var keyboard any
 	if urlsOnly {
-		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeURL); len(qrs) > 0 {
+		qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeURL)
+
+		// Telegram rejects the entire message if a button URL isn't a valid absolute HTTP(S) URL, so drop invalid
+		// ones with a logged error instead of failing the send
+		qrs = slices.DeleteFunc(qrs, func(q models.QuickReply) bool {
+			if u, err := url.Parse(q.Extra); err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+				clog.Error(&clogs.Error{Message: fmt.Sprintf("quick reply of type url has an invalid URL and can't be sent: %s", q.Extra)})
+				return true
+			}
+			return false
+		})
+
+		if len(qrs) > 0 {
 			keyboard = NewInlineKeyboardFromReplies(qrs)
 		}
 	} else {

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -1009,6 +1009,24 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
+		Label:           "Quick Reply, url type with an invalid URL is dropped",
+		MsgText:         "Are you happy?",
+		MsgURN:          "telegram:12345",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit Us", Extra: "example.com/visit"}, {Type: "url", Text: "Read More", Extra: "https://example.com/more"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Are you happy?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"inline_keyboard":[[{"text":"Read More","url":"https://example.com/more"}]]}`}}},
+		},
+		ExpectedLogErrors: []*clogs.Error{
+			{Message: "quick reply of type url has an invalid URL and can't be sent: example.com/visit"},
+		},
+		ExpectedExtIDs: []string{"133"},
+	},
+	{
 		Label:           "Quick Reply, url type without a URL is dropped",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -1009,10 +1009,10 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"133"},
 	},
 	{
-		Label:           "Quick Reply, url type with an invalid URL is dropped",
+		Label:           "Quick Reply, url types with invalid URLs are dropped",
 		MsgText:         "Are you happy?",
 		MsgURN:          "telegram:12345",
-		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit Us", Extra: "example.com/visit"}, {Type: "url", Text: "Read More", Extra: "https://example.com/more"}},
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit Us", Extra: "example.com/visit"}, {Type: "url", Text: "Local", Extra: "http://localhost/visit"}, {Type: "url", Text: "Spaced", Extra: "https://example.com/a page"}, {Type: "url", Text: "Read More", Extra: "https://example.com/more"}},
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/botauth_token/sendMessage": {
 				httpx.NewMockResponse(200, nil, []byte(`{ "ok": true, "result": { "message_id": 133 } }`)),
@@ -1023,6 +1023,8 @@ var outgoingCases = []OutgoingTestCase{
 		},
 		ExpectedLogErrors: []*clogs.Error{
 			{Message: "quick reply of type url has an invalid URL and can't be sent: example.com/visit"},
+			{Message: "quick reply of type url has an invalid URL and can't be sent: http://localhost/visit"},
+			{Message: "quick reply of type url has an invalid URL and can't be sent: https://example.com/a page"},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -1279,4 +1281,35 @@ func TestSendEvent(t *testing.T) {
 	// an event type the handler doesn't declare support for can't be sent
 	err = h.SendEvent(context.Background(), ch, events.NewTypingStopped(events.DirectionOutgoing, nil, "telegram:12345", ""), clog)
 	assert.ErrorContains(t, err, "unsupported event type: typing_stopped")
+}
+
+func TestIsValidButtonURL(t *testing.T) {
+	valid := []string{
+		"http://example.com",
+		"https://example.com/path?x=1#y",
+		"https://example.com:8080/path",
+		"http://127.0.0.1/dev",
+		"http://[::1]/dev",
+		"https://exämple.com/ü",
+		"tg://user?id=123456",
+		"tg://resolve?domain=example",
+	}
+	for _, s := range valid {
+		assert.True(t, isValidButtonURL(s), "expected %s to be valid", s)
+	}
+
+	invalid := []string{
+		"",
+		"example.com",
+		"www.example.com/path",
+		"mailto:bob@example.com",
+		"ftp://example.com/file",
+		"http://",
+		"http://localhost/dev",
+		"https://example.com/a page",
+		"https://example .com",
+	}
+	for _, s := range invalid {
+		assert.False(t, isValidButtonURL(s), "expected %s to be invalid", s)
+	}
 }


### PR DESCRIPTION
Telegram rejects an entire message with `400 BUTTON_URL_INVALID` if an inline keyboard button URL isn't valid, so a single malformed url quick reply would fail the whole send. Validate the URL when filtering and drop invalid ones with a logged channel error instead, so the message still goes out.

The validation approximates Telegram's rules for inline button URLs:

* `http://`, `https://` and `tg://` URLs are accepted (`tg://` deep links are valid button URLs per the Bot API)
* URLs containing whitespace are rejected
* HTTP(S) hostnames must contain a dot or be an IP address — Telegram's parser rejects bare hostnames like `localhost`

It's an approximation of an undocumented parser, so a genuinely exotic URL can still fail the send — this catches what can be caught cheaply.

Stacked on #1087.