### PR TITLE
Reuse FilterSupportedQuickReplies for the WhatsApp and Turn quick reply buckets

### DIFF
--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -929,7 +929,7 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"text","text":{"body":"Interactive form msg","preview_url":false}}`,
 		}},
 		ExpectedExtIDs:    []string{"157b5e14568e8"},
-		ExpectedLogErrors: []*clogs.Error{{Message: "form quick reply is missing a form ID and can't be sent"}},
+		ExpectedLogErrors: []*clogs.Error{{Message: "quick reply of type form is missing its extra value and can't be sent"}},
 	},
 	{
 		Label:           "Interactive with URL button",
@@ -993,7 +993,7 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"text","text":{"body":"Interactive URL msg","preview_url":false}}`,
 		}},
 		ExpectedExtIDs:    []string{"157b5e14568e8"},
-		ExpectedLogErrors: []*clogs.Error{{Message: "URL quick reply is missing a URL and can't be sent"}},
+		ExpectedLogErrors: []*clogs.Error{{Message: "quick reply of type url is missing its extra value and can't be sent"}},
 	},
 	{
 		Label:   "Link Sending",

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -51,8 +51,8 @@ const maxCaptionAndBodyLength = 1024
 func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.ChannelLog) ([]SendRequest, error) {
 	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
 	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
-	formQRs := FilterFormQuickReplies(msg.QuickReplies(), clog)
-	urlQRs := FilterURLQuickReplies(msg.QuickReplies(), clog)
+	formQRs := handlers.FilterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeForm, clog)
+	urlQRs := handlers.FilterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeURL, clog)
 	menuButton := handlers.GetText("Menu", msg.Locale())
 
 	// if text could end up as a media caption or an interactive message body, use their lower length limit
@@ -193,34 +193,6 @@ func buildMediaPayload(msg courier.MsgOut, attachmentIdx int, caption string) (S
 		p.Document = &media
 	}
 	return p, nil
-}
-
-// FilterFormQuickReplies returns quick replies of type "form" that have an extra value (the form ID), logging an
-// error for any that don't since they can't be sent.
-func FilterFormQuickReplies(qrs []models.QuickReply, clog *courier.ChannelLog) []models.QuickReply {
-	f := make([]models.QuickReply, 0, len(qrs))
-	for _, qr := range handlers.FilterQuickRepliesByType(qrs, models.QuickReplyTypeForm) {
-		if qr.Extra == "" {
-			clog.Error(&clogs.Error{Message: "form quick reply is missing a form ID and can't be sent"})
-			continue
-		}
-		f = append(f, qr)
-	}
-	return f
-}
-
-// FilterURLQuickReplies returns quick replies of type "url" that have an extra value (the URL), logging an error for
-// any that don't since they can't be sent.
-func FilterURLQuickReplies(qrs []models.QuickReply, clog *courier.ChannelLog) []models.QuickReply {
-	f := make([]models.QuickReply, 0, len(qrs))
-	for _, qr := range handlers.FilterQuickRepliesByType(qrs, models.QuickReplyTypeURL) {
-		if qr.Extra == "" {
-			clog.Error(&clogs.Error{Message: "URL quick reply is missing a URL and can't be sent"})
-			continue
-		}
-		f = append(f, qr)
-	}
-	return f
 }
 
 func buildLocationRequestPayload(msg courier.MsgOut, body string) SendRequest {

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -49,10 +49,11 @@ const maxCaptionAndBodyLength = 1024
 
 // buildContentPayloads constructs payloads for a non-template message with text, attachments, and quick replies.
 func buildContentPayloads(msg courier.MsgOut, maxMsgLength int, clog *courier.ChannelLog) ([]SendRequest, error) {
-	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
-	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
-	formQRs := handlers.FilterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeForm, clog)
-	urlQRs := handlers.FilterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeURL, clog)
+	sqrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeForm, models.QuickReplyTypeURL)
+	qrs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeText)
+	locationQRs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeLocation)
+	formQRs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeForm)
+	urlQRs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeURL)
 	menuButton := handlers.GetText("Menu", msg.Locale())
 
 	// if text could end up as a media caption or an interactive message body, use their lower length limit

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -370,7 +370,7 @@ func TestGetMsgPayloads(t *testing.T) {
 				assert.Equal(t, 1, len(payloads))
 				assert.Equal(t, "text", payloads[0].Type)
 				assert.Len(t, clog.Errors, 1)
-				assert.Equal(t, "form quick reply is missing a form ID and can't be sent", clog.Errors[0].Message)
+				assert.Equal(t, "quick reply of type form is missing its extra value and can't be sent", clog.Errors[0].Message)
 			},
 		},
 		{
@@ -400,7 +400,7 @@ func TestGetMsgPayloads(t *testing.T) {
 				assert.Equal(t, 1, len(payloads))
 				assert.Equal(t, "text", payloads[0].Type)
 				assert.Len(t, clog.Errors, 1)
-				assert.Equal(t, "URL quick reply is missing a URL and can't be sent", clog.Errors[0].Message)
+				assert.Equal(t, "quick reply of type url is missing its extra value and can't be sent", clog.Errors[0].Message)
 			},
 		},
 		{

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -498,7 +498,8 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 
 	parts := handlers.SplitMsgByChannel(msg.Channel(), msg.Text(), maxMsgLength)
 
-	qrs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeText)
+	sqrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeForm, models.QuickReplyTypeURL)
+	qrs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeText)
 	qrsAsList := false
 	for i, qr := range qrs {
 		if i > 2 || qr.Extra != "" {
@@ -506,9 +507,9 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 		}
 	}
 
-	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
-	formQRs := handlers.FilterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeForm, clog)
-	urlQRs := handlers.FilterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeURL, clog)
+	locationQRs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeLocation)
+	formQRs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeForm)
+	urlQRs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeURL)
 
 	isInteractiveMsg := len(qrs) > 0 || len(locationQRs) > 0 || len(formQRs) > 0 || len(urlQRs) > 0
 

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -507,8 +507,8 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 	}
 
 	locationQRs := handlers.FilterQuickRepliesByType(msg.QuickReplies(), models.QuickReplyTypeLocation)
-	formQRs := whatsapp.FilterFormQuickReplies(msg.QuickReplies(), clog)
-	urlQRs := whatsapp.FilterURLQuickReplies(msg.QuickReplies(), clog)
+	formQRs := handlers.FilterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeForm, clog)
+	urlQRs := handlers.FilterQuickRepliesWithExtra(msg.QuickReplies(), models.QuickReplyTypeURL, clog)
 
 	isInteractiveMsg := len(qrs) > 0 || len(locationQRs) > 0 || len(formQRs) > 0 || len(urlQRs) > 0
 

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -1123,7 +1123,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			Body: `{"to":"250788123123","type":"text","text":{"body":"Interactive form msg"}}`,
 		}},
 		ExpectedExtIDs:    []string{"157b5e14568e8"},
-		ExpectedLogErrors: []*clogs.Error{{Message: "form quick reply is missing a form ID and can't be sent"}},
+		ExpectedLogErrors: []*clogs.Error{{Message: "quick reply of type form is missing its extra value and can't be sent"}},
 	},
 	{
 		Label:           "Interactive with URL button",
@@ -1169,7 +1169,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			Body: `{"to":"250788123123","type":"text","text":{"body":"Interactive URL msg"}}`,
 		}},
 		ExpectedExtIDs:    []string{"157b5e14568e8"},
-		ExpectedLogErrors: []*clogs.Error{{Message: "URL quick reply is missing a URL and can't be sent"}},
+		ExpectedLogErrors: []*clogs.Error{{Message: "quick reply of type url is missing its extra value and can't be sent"}},
 	},
 	{
 		Label:   "Error Channel Contact Pair limit hit",

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -76,6 +76,20 @@ func FilterSupportedQuickReplies(qrs []models.QuickReply, clog *courier.ChannelL
 	return t
 }
 
+// FilterQuickRepliesWithExtra returns quick replies of the given type that also have the extra value their type
+// requires to be sendable, logging a channel error for any that don't
+func FilterQuickRepliesWithExtra(qrs []models.QuickReply, qrType string, clog *courier.ChannelLog) []models.QuickReply {
+	f := make([]models.QuickReply, 0, len(qrs))
+	for _, qr := range FilterQuickRepliesByType(qrs, qrType) {
+		if qr.RequiresExtra() && qr.Extra == "" {
+			clog.Error(&clogs.Error{Message: fmt.Sprintf("quick reply of type %s is missing its extra value and can't be sent", qr.Type)})
+		} else {
+			f = append(f, qr)
+		}
+	}
+	return f
+}
+
 // NameFromFirstLastUsername is a utility function to build a contact's name from the passed
 // in values, all of which can be empty
 func NameFromFirstLastUsername(first string, last string, username string) string {

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -76,20 +76,6 @@ func FilterSupportedQuickReplies(qrs []models.QuickReply, clog *courier.ChannelL
 	return t
 }
 
-// FilterQuickRepliesWithExtra returns quick replies of the given type that also have the extra value their type
-// requires to be sendable, logging a channel error for any that don't
-func FilterQuickRepliesWithExtra(qrs []models.QuickReply, qrType string, clog *courier.ChannelLog) []models.QuickReply {
-	f := make([]models.QuickReply, 0, len(qrs))
-	for _, qr := range FilterQuickRepliesByType(qrs, qrType) {
-		if qr.RequiresExtra() && qr.Extra == "" {
-			clog.Error(&clogs.Error{Message: fmt.Sprintf("quick reply of type %s is missing its extra value and can't be sent", qr.Type)})
-		} else {
-			f = append(f, qr)
-		}
-	}
-	return f
-}
-
 // NameFromFirstLastUsername is a utility function to build a contact's name from the passed
 // in values, all of which can be empty
 func NameFromFirstLastUsername(first string, last string, username string) string {


### PR DESCRIPTION
Replaces the two WhatsApp-specific filter functions (`FilterFormQuickReplies` and `FilterURLQuickReplies`, also used by the Turn handler) with a single `handlers.FilterSupportedQuickReplies` pass up front — which already does both the type filtering and the missing-extra drop with the same error wording — followed by cheap `FilterQuickRepliesByType` bucket splits.

No new helper needed, and behavior is unchanged for the four existing quick reply types. If a new type is ever added, these handlers will now log "isn't supported" like other handlers do instead of silently ignoring it.