### PR TITLE
Use a marker interface for Telegram keyboard markup instead of any

### DIFF
--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -162,7 +162,7 @@ type mtResponse struct {
 	} `json:"result"`
 }
 
-func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.Values, keyboard any, clog *courier.ChannelLog) (string, error) {
+func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.Values, keyboard Markup, clog *courier.ChannelLog) (string, error) {
 	// either include or remove our keyboard
 	form.Add("parse_mode", "Markdown")
 	if keyboard == nil {
@@ -227,7 +227,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		return q.Type != models.QuickReplyTypeURL
 	})
 
-	var keyboard any
+	var keyboard Markup
 	if urlsOnly {
 		if qrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeURL); len(qrs) > 0 {
 			keyboard = NewInlineKeyboardFromReplies(qrs)
@@ -240,7 +240,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	// if we have text, send that if we aren't sending it as a caption
 	if msg.Text() != "" && caption == "" {
-		var msgKeyBoard any
+		var msgKeyBoard Markup
 		if len(attachments) == 0 {
 			msgKeyBoard = keyboard
 		}
@@ -257,7 +257,7 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 
 	// send each attachment
 	for i, attachment := range attachments {
-		var attachmentKeyBoard any
+		var attachmentKeyBoard Markup
 		if i == len(attachments)-1 {
 			attachmentKeyBoard = keyboard
 		}

--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -4,6 +4,14 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 )
 
+// Markup is a keyboard that can be sent as a message's reply_markup
+type Markup interface {
+	isMarkup()
+}
+
+func (*ReplyKeyboardMarkup) isMarkup()  {}
+func (*InlineKeyboardMarkup) isMarkup() {}
+
 // WebAppInfo describes a Mini App to be launched, see https://core.telegram.org/bots/api/#webappinfo
 type WebAppInfo struct {
 	URL string `json:"url"`


### PR DESCRIPTION
`sendMsgPart` taking `any` for the markup argument gives up compile-time checking, and `any` + `== nil` is the shape that eventually grows a typed-nil bug — a `*ReplyKeyboardMarkup`-typed nil assigned into the interface would skip the `remove_keyboard` branch and send `reply_markup=null`. A one-method `Markup` interface implemented by both keyboard types keeps the nil check honest at no runtime cost.

Stacked on #1087.