### PR TITLE
Remove optin_id columns and msgs_optin table from test schema

### DIFF
--- a/testsuite/database.go
+++ b/testsuite/database.go
@@ -56,7 +56,6 @@ type DBMsg struct {
 	ErrorCount         int                  `db:"error_count"`
 	FailedReason       null.String          `db:"failed_reason"`
 	NextAttempt        *time.Time           `db:"next_attempt"`
-	OptInID            null.Int             `db:"optin_id"`
 	LogUUIDs           pq.StringArray       `db:"log_uuids"`
 }
 
@@ -76,7 +75,6 @@ type ChannelEvent struct {
 	ContactURNID models.ContactURNID     `db:"contact_urn_id"`
 	URN          urns.URN                `db:"urn"`
 	EventType    models.ChannelEventType `db:"event_type"`
-	OptInID      null.Int                `db:"optin_id"`
 	Extra        null.Map[string]        `db:"extra"`
 	Status       string                  `db:"status"`
 	OccurredOn   time.Time               `db:"occurred_on"`

--- a/testsuite/testdata/data.sql
+++ b/testsuite/testdata/data.sql
@@ -41,12 +41,6 @@ DELETE FROM contacts_contacturn;
 INSERT INTO contacts_contacturn("id", "identity", "path", "scheme", "priority", "channel_id", "contact_id", "org_id")
                          VALUES(1000, 'tel:+12067799192', '+12067799192', 'tel', 50, 10, 100, 1);
 
-/* Msg optins with ids 1, 2 */
-DELETE FROM msgs_optin;
-INSERT INTO msgs_optin(id, uuid, org_id, name) VALUES
-                      (1, 'fc1cef6e-b5b1-452d-9528-a4b24db28eb0', 1, 'Polls'),
-                      (2, '2b1eba23-4a97-46ac-9022-11304412b32f', 1, 'Jokes');
-
 /** Msg with id 10000 */
 DELETE FROM msgs_msg;
 INSERT INTO msgs_msg("id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "direction", "status", "visibility", "msg_type", "is_android",

--- a/testsuite/testdata/schema.sql
+++ b/testsuite/testdata/schema.sql
@@ -75,14 +75,6 @@ CREATE TABLE IF NOT EXISTS contacts_contactfire (
     UNIQUE (contact_id, fire_type, scope)
 );
 
-DROP TABLE IF EXISTS msgs_optin CASCADE;
-CREATE TABLE msgs_optin (
-    id serial primary key,
-    uuid uuid NOT NULL,
-    org_id integer NOT NULL references orgs_org(id) on delete cascade,
-    name character varying(64)
-);
-
 DROP TABLE IF EXISTS msgs_msg CASCADE;
 CREATE TABLE msgs_msg (
     id bigserial PRIMARY KEY,
@@ -98,7 +90,6 @@ CREATE TABLE msgs_msg (
     text text NOT NULL,
     attachments character varying(255)[] NULL,
     quickreplies JSONB NULL,
-    optin_id integer REFERENCES msgs_optin(id) ON DELETE CASCADE,
     locale character varying(6) NULL,
     created_on timestamp with time zone NOT NULL,
     modified_on timestamp with time zone NOT NULL,
@@ -129,7 +120,6 @@ CREATE TABLE channels_channelevent (
     channel_id integer NOT NULL references channels_channel(id) on delete cascade,
     contact_id integer NOT NULL references contacts_contact(id) on delete cascade,
     contact_urn_id integer NOT NULL references contacts_contacturn(id) on delete cascade,
-    optin_id integer references msgs_optin(id) on delete cascade,
     org_id integer NOT NULL references orgs_org(id) on delete cascade,
     log_uuids uuid[]
 );


### PR DESCRIPTION
## Summary

Removes all traces of optins from the test database schema, ahead of the columns being dropped for real. Since optin/optout channel events and optin request messages were removed, nothing in courier reads or writes these columns — taking them out of the test schema proves that, so the real drop can't surprise us.

## Changes

- `testsuite/testdata/schema.sql` — drops `msgs_msg.optin_id`, `channels_channelevent.optin_id`, and the `msgs_optin` table
- `testsuite/testdata/data.sql` — drops the two `msgs_optin` fixture rows
- `testsuite/database.go` — drops the now-orphaned `DBMsg.OptInID` and `ChannelEvent.OptInID` fields

Test-only: no production code or migrations are touched.

## Test plan

`DBMsg` and `ChannelEvent` are read with `SELECT *`, and sqlx fails a scan on any result column the struct can't map. That makes the suite a real check on this change rather than a formality: if anything still wrote `optin_id`, or if either struct field had been left behind, the read would error.

Full suite passes against a schema rebuilt from these files.

## Notes for reviewers

`testsuite.Runtime` only loads `schema.sql` when `orgs_org` is missing, and the rapidpro suite reloads it in `TearDownSuite`. On a pre-existing local test database, the first run after any schema edit therefore tests the *previous* schema until the first in-test `ResetDB` fires — and `TestChannelEvent` sorts ahead of that. It shows up as a spurious `missing destination name optin_id` on run one, then passes on run two. CI starts from an empty database and isn't affected.

Unrelated: `utils/queue.TestLua` is flaky. It's a `time.Sleep`-based rate-limit test that touches valkey only, so nothing here can reach it, but it can fail a CI run.