### PR TITLE
Refresh test schema to match current RapidPro schema

### DIFF
--- a/testsuite/testdata/data.sql
+++ b/testsuite/testdata/data.sql
@@ -10,26 +10,26 @@ INSERT INTO orgs_org("id", "name", "language", "is_anon", "config")
 
 /* Channel with id 10, 11, 12 */
 DELETE FROM channels_channel;
-INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
-                      VALUES('10', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c95d', 'KN', '2500', 1, 'RW', 'SR', '{ "encoding": "smart", "use_national": true, "max_length_int": 320, "max_length_str": "320" }');
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "name", "address", "org_id", "country", "role", "config")
+                      VALUES('10', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c95d', 'KN', 'Kannel 1', '2500', 1, 'RW', 'SR', '{ "encoding": "smart", "use_national": true, "max_length_int": 320, "max_length_str": "320" }');
 
-INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
-                      VALUES('11', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c96a', 'FBA', '4500', 1, 'US', 'SR', '{}');
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "name", "address", "org_id", "country", "role", "config")
+                      VALUES('11', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c96a', 'FBA', 'Facebook 1', '4500', 1, 'US', 'SR', '{}');
 
-INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
-                      VALUES('12', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c97a', 'DM', '4500', 1, 'US', 'SR', '{}');
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "name", "address", "org_id", "country", "role", "config")
+                      VALUES('12', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c97a', 'DM', 'Discord 1', '4500', 1, 'US', 'SR', '{}');
 
-INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
-                      VALUES('13', '{"telegram"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c98a', 'TG', 'courierbot', 1, NULL, 'SR', '{}');
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "name", "address", "org_id", "country", "role", "config")
+                      VALUES('13', '{"telegram"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c98a', 'TG', 'Telegram 1', 'courierbot', 1, NULL, 'SR', '{}');
 
-INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
-                      VALUES('14', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c99a', 'KN', NULL, 1, 'US', 'SR', '{}');
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "name", "address", "org_id", "country", "role", "config")
+                      VALUES('14', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327c99a', 'KN', 'Kannel 2', NULL, 1, 'US', 'SR', '{}');
 
-INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
-                      VALUES('15', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327100a', 'EX', NULL, 1, 'US', 'R', '{}');
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "name", "address", "org_id", "country", "role", "config")
+                      VALUES('15', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327100a', 'EX', 'External 1', NULL, 1, 'US', 'R', '{}');
 
-INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
-                      VALUES('16', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327222a', 'EX', NULL, 1, 'US', '', '{}');
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "name", "address", "org_id", "country", "role", "config")
+                      VALUES('16', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327222a', 'EX', 'External 2', NULL, 1, 'US', '', '{}');
 
 /* Contacts with ids 100, 101 */
 DELETE FROM contacts_contact;

--- a/testsuite/testdata/schema.sql
+++ b/testsuite/testdata/schema.sql
@@ -1,17 +1,17 @@
 DROP TABLE IF EXISTS users_user CASCADE;
 CREATE TABLE users_user (
     id serial primary key,
-    email character varying(254) NOT NULL,
+    email character varying(254) NOT NULL UNIQUE,
     first_name character varying(150) NOT NULL
 );
 
 DROP TABLE IF EXISTS orgs_org CASCADE;
 CREATE TABLE orgs_org (
     id serial primary key,
-    name character varying(255) NOT NULL,
+    name character varying(128) NOT NULL,
     language character varying(64),
-    is_anon boolean NOT NULL,
-    config jsonb NOT NULL
+    config jsonb NOT NULL,
+    is_anon boolean NOT NULL
 );
 
 DROP TABLE IF EXISTS channels_channel CASCADE;
@@ -20,13 +20,13 @@ CREATE TABLE channels_channel (
     is_active boolean NOT NULL,
     created_on timestamp with time zone NOT NULL,
     modified_on timestamp with time zone NOT NULL,
-    uuid character varying(36) NOT NULL,
+    uuid uuid NOT NULL UNIQUE,
     channel_type character varying(3) NOT NULL,
-    name character varying(64),
-    schemes character varying(16)[] NOT NULL,
-    address character varying(64),
+    name character varying(64) NOT NULL,
+    address character varying(255),
     country character varying(2),
     config jsonb NOT NULL,
+    schemes character varying(16)[] NOT NULL,
     role character varying(4) NOT NULL,
     org_id integer references orgs_org(id) on delete cascade
 );
@@ -35,43 +35,43 @@ DROP TABLE IF EXISTS contacts_contact CASCADE;
 CREATE TABLE contacts_contact (
     id serial primary key,
     is_active boolean NOT NULL,
-    status character varying(1) NOT NULL,
-    ticket_count integer NOT NULL,
     created_on timestamp with time zone NOT NULL,
     modified_on timestamp with time zone NOT NULL,
-    uuid character varying(36) NOT NULL,
+    uuid character varying(36) NOT NULL UNIQUE,
     name character varying(128),
     language character varying(3),
-    created_by_id integer references users_user(id) NOT NULL,
-    modified_by_id integer references users_user(id) NOT NULL,
-    org_id integer references orgs_org(id) on delete cascade
+    status character varying(1) NOT NULL,
+    ticket_count integer NOT NULL,
+    created_by_id integer references users_user(id),
+    modified_by_id integer references users_user(id),
+    org_id integer NOT NULL references orgs_org(id) on delete cascade
 );
 
 DROP TABLE IF EXISTS contacts_contacturn CASCADE;
 CREATE TABLE contacts_contacturn (
     id serial primary key,
     identity character varying(255) NOT NULL,
-    path character varying(255) NOT NULL,
     scheme character varying(128) NOT NULL,
-    display character varying(128) NULL,
+    path character varying(255) NOT NULL,
+    display character varying(255) NULL,
     priority integer NOT NULL,
+    auth_tokens jsonb,
     channel_id integer references channels_channel(id) on delete cascade,
     contact_id integer references contacts_contact(id) on delete cascade,
     org_id integer NOT NULL references orgs_org(id) on delete cascade,
-    auth_tokens jsonb,
     UNIQUE (org_id, identity)
 );
 
 DROP TABLE IF EXISTS contacts_contactfire CASCADE;
-CREATE TABLE IF NOT EXISTS contacts_contactfire (
-    id serial primary key,
-    org_id integer NOT NULL,
-    contact_id integer references contacts_contact(id) on delete cascade,
+CREATE TABLE contacts_contactfire (
+    id bigserial primary key,
     fire_type character varying(1) NOT NULL,
-    scope character varying(128) NOT NULL,
+    scope character varying(64) NOT NULL,
     fire_on timestamp with time zone NOT NULL,
     session_uuid uuid,
     sprint_uuid uuid,
+    contact_id integer NOT NULL references contacts_contact(id) on delete cascade,
+    org_id integer NOT NULL references orgs_org(id) on delete cascade,
     UNIQUE (contact_id, fire_type, scope)
 );
 
@@ -79,18 +79,11 @@ DROP TABLE IF EXISTS msgs_msg CASCADE;
 CREATE TABLE msgs_msg (
     id bigserial PRIMARY KEY,
     uuid uuid NOT NULL UNIQUE,
-    org_id integer NOT NULL REFERENCES orgs_org(id) ON DELETE CASCADE,
-    channel_id integer REFERENCES channels_channel(id) ON DELETE CASCADE,
-    contact_id integer NOT NULL REFERENCES contacts_contact(id) ON DELETE CASCADE,
-    contact_urn_id integer REFERENCES contacts_contacturn(id) ON DELETE CASCADE,
-    --broadcast_id integer REFERENCES msgs_broadcast(id) ON DELETE CASCADE,
-    --flow_id integer REFERENCES flows_flow(id) ON DELETE CASCADE,
-    --ticket_uuid uuid,
-    created_by_id integer REFERENCES users_user(id),
     text text NOT NULL,
-    attachments character varying(255)[] NULL,
-    quickreplies JSONB NULL,
+    attachments character varying(2048)[] NULL,
+    quickreplies jsonb NULL,
     locale character varying(6) NULL,
+    templating jsonb NULL,
     created_on timestamp with time zone NOT NULL,
     modified_on timestamp with time zone NOT NULL,
     sent_on timestamp with time zone,
@@ -104,39 +97,47 @@ CREATE TABLE msgs_msg (
     error_count integer NOT NULL,
     next_attempt timestamp with time zone,
     failed_reason character varying(1),
-    external_identifier character varying(255),
-    log_uuids uuid[]
+    log_uuids uuid[],
+    --broadcast_id integer REFERENCES msgs_broadcast(id) ON DELETE CASCADE,
+    channel_id integer REFERENCES channels_channel(id) ON DELETE CASCADE,
+    contact_id integer NOT NULL REFERENCES contacts_contact(id) ON DELETE CASCADE,
+    contact_urn_id integer REFERENCES contacts_contacturn(id) ON DELETE CASCADE,
+    created_by_id integer REFERENCES users_user(id),
+    --flow_id integer REFERENCES flows_flow(id) ON DELETE CASCADE,
+    org_id integer NOT NULL REFERENCES orgs_org(id) ON DELETE CASCADE,
+    --ticket_uuid uuid,
+    external_identifier character varying(255)
 );
 
 DROP TABLE IF EXISTS channels_channelevent CASCADE;
 CREATE TABLE channels_channelevent (
-    id serial primary key,
-    uuid uuid NOT NULL,
+    id bigserial primary key,
+    uuid uuid NOT NULL UNIQUE,
     event_type character varying(16) NOT NULL,
-    status character varying(1) NOT NULL,
+    status character varying(1),
     extra text,
     occurred_on timestamp with time zone NOT NULL,
     created_on timestamp with time zone NOT NULL,
+    log_uuids uuid[],
     channel_id integer NOT NULL references channels_channel(id) on delete cascade,
     contact_id integer NOT NULL references contacts_contact(id) on delete cascade,
-    contact_urn_id integer NOT NULL references contacts_contacturn(id) on delete cascade,
-    org_id integer NOT NULL references orgs_org(id) on delete cascade,
-    log_uuids uuid[]
+    contact_urn_id integer references contacts_contacturn(id) on delete cascade,
+    org_id integer NOT NULL references orgs_org(id) on delete cascade
 );
 
 DROP TABLE IF EXISTS msgs_media CASCADE;
-CREATE TABLE IF NOT EXISTS msgs_media (
-    id serial primary key,
-    uuid uuid NOT NULL,
-    org_id integer NOT NULL,
-    content_type character varying(255) NOT NULL,
+CREATE TABLE msgs_media (
+    id bigserial primary key,
+    uuid uuid NOT NULL UNIQUE,
     url character varying(2048) NOT NULL,
+    content_type character varying(255) NOT NULL,
     path character varying(2048) NOT NULL,
     size integer NOT NULL,
     duration integer NOT NULL,
     width integer NOT NULL,
     height integer NOT NULL,
-    original_id integer
+    org_id integer NOT NULL references orgs_org(id) on delete cascade,
+    original_id bigint references msgs_media(id) on delete cascade
 );
 
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO courier_test;


### PR DESCRIPTION
Refreshes the hand-written test schema (`testsuite/testdata/schema.sql`) against the current RapidPro schema. It remains a subset of columns that courier actually touches, but the columns it does declare now match real types, nullability and ordering:

- `channels_channel`: `uuid` is now a real `uuid NOT NULL UNIQUE` (was varchar(36)), `name` is now NOT NULL, `address` widened 64→255
- `orgs_org`: `name` corrected to varchar(128) NOT NULL
- `users_user`: `email` now UNIQUE
- `contacts_contact`: `created_by_id`/`modified_by_id` now nullable, `org_id` now NOT NULL, `uuid` now UNIQUE
- `contacts_contacturn`: `display` widened 128→255
- `contacts_contactfire`: id now bigserial, `scope` narrowed 128→64, `contact_id` NOT NULL, added org FK
- `msgs_msg`: `attachments` widened to varchar(2048)[], added `templating` column, columns reordered
- `channels_channelevent`: id now bigserial, `status` and `contact_urn_id` now nullable, `uuid` now UNIQUE
- `msgs_media`: id/original_id now bigints, `uuid` now UNIQUE, added FKs

The `optin_id` columns remain excluded per #1093. Channel fixtures in `data.sql` now include a `name` value since that column is NOT NULL.

Note: `TestMsgSuite/TestMsgStatus` is flaky (pre-existing timing issue with the async status committer, reproducible on main) and unrelated to this change.