### PR TITLE
Match incoming WhatsApp messages to contacts by BSUID when phone is new

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -931,6 +931,59 @@ func (ts *BackendTestSuite) TestWriteChanneLog() {
 	dyntest.AssertCount(ts.T(), ts.b.rt.Dynamo, ts.b.rt.Writers.Main.Table(), 2)
 }
 
+func (ts *BackendTestSuite) TestContactForMsg() {
+	ctx := context.Background()
+	waChannel := ts.getChannel("WAC", "dbc126ed-66bc-4e28-b67b-81dc33277a17")
+	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, waChannel, nil)
+
+	newPhoneMsg := func(phone, bsuid urns.URN) *MsgIn {
+		m := ts.b.NewIncomingMsg(ctx, waChannel, phone, "hi", "", clog).(*MsgIn)
+		if bsuid != urns.NilURN {
+			m.WithNewURN(bsuid, models.NewURNAppend)
+		}
+		return m
+	}
+	lookup := func(urn urns.URN) *models.Contact {
+		c, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, urn, nil, "", false, clog)
+		ts.NoError(err)
+		return c
+	}
+
+	// no existing contact: a message with a phone number and BSUID creates one keyed on the phone number
+	c1, err := contactForMsg(ctx, ts.b, newPhoneMsg("whatsapp:12065551234", "whatsapp:US.1234"), clog)
+	ts.NoError(err)
+	ts.True(c1.IsNew_)
+	ts.Equal(c1.ID_, lookup("whatsapp:12065551234").ID_)
+	ts.Nil(lookup("whatsapp:US.1234")) // BSUID is appended by mailroom, not here
+
+	// existing contact known only by a BSUID: a message with a new phone number and that BSUID is matched to it
+	// (not duplicated) and the phone number is added to it
+	existingByBSUID, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, "whatsapp:US.5555", nil, "", true, clog)
+	ts.NoError(err)
+
+	matched, err := contactForMsg(ctx, ts.b, newPhoneMsg("whatsapp:12065555555", "whatsapp:US.5555"), clog)
+	ts.NoError(err)
+	ts.False(matched.IsNew_)
+	ts.Equal(existingByBSUID.ID_, matched.ID_)
+	ts.Equal(existingByBSUID.ID_, lookup("whatsapp:12065555555").ID_) // phone number now resolves to the same contact
+	ts.NotEqual(existingByBSUID.URNID_, matched.URNID_)               // and the message is attributed to the phone URN
+
+	// existing contact known by the phone number: matched directly, even if another contact owns the BSUID
+	other, err := contactForURN(ctx, ts.b, waChannel.OrgID_, waChannel, "whatsapp:US.9999", nil, "", true, clog)
+	ts.NoError(err)
+
+	matchedByPhone, err := contactForMsg(ctx, ts.b, newPhoneMsg("whatsapp:12065555555", "whatsapp:US.9999"), clog)
+	ts.NoError(err)
+	ts.False(matchedByPhone.IsNew_)
+	ts.Equal(existingByBSUID.ID_, matchedByPhone.ID_)
+	ts.Equal(other.ID_, lookup("whatsapp:US.9999").ID_) // BSUID left with its owner, conflict is mailroom's to resolve
+
+	// no BSUID attached: existing single-URN resolution, a new phone number creates a new contact
+	c2, err := contactForMsg(ctx, ts.b, newPhoneMsg("whatsapp:12065550000", urns.NilURN), clog)
+	ts.NoError(err)
+	ts.True(c2.IsNew_)
+}
+
 func (ts *BackendTestSuite) TestSaveAttachment() {
 	testJPG := test.ReadFile("../../test/testdata/test.jpg")
 	ctx := context.Background()

--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -982,6 +982,13 @@ func (ts *BackendTestSuite) TestContactForMsg() {
 	c2, err := contactForMsg(ctx, ts.b, newPhoneMsg("whatsapp:12065550000", urns.NilURN), clog)
 	ts.NoError(err)
 	ts.True(c2.IsNew_)
+
+	// adding a URN which belongs to another contact - as can happen if it's created after our lookups - doesn't
+	// steal it, and tells the caller to start over
+	added, err := addContactURN(ctx, ts.b, waChannel, existingByBSUID, "whatsapp:12065550000", nil)
+	ts.NoError(err)
+	ts.False(added)
+	ts.Equal(c2.ID_, lookup("whatsapp:12065550000").ID_)
 }
 
 func (ts *BackendTestSuite) TestSaveAttachment() {

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -215,8 +215,8 @@ func altLookupURN(m *MsgIn) urns.URN {
 }
 
 // addContactURN adds the given URN to the contact (if not already present) and points the contact's URNID at it, so
-// an incoming message is attributed to this URN. Returns false without adding if the URN belongs to another contact,
-// rather than stealing it.
+// an incoming message is attributed to this URN. Returns false without adding if the URN belongs to another contact
+// or was concurrently inserted by another writer, rather than stealing it - the caller should restart its lookup.
 func addContactURN(ctx context.Context, b *backend, channel *models.Channel, contact *models.Contact, urn urns.URN, authTokens map[string]string) (bool, error) {
 	tx, err := b.rt.DB.BeginTxx(ctx, nil)
 	if err != nil {
@@ -226,6 +226,11 @@ func addContactURN(ctx context.Context, b *backend, channel *models.Channel, con
 	contactURN, err := models.GetOrCreateContactURN(ctx, tx, channel, contact.ID_, urn, authTokens)
 	if err != nil {
 		tx.Rollback()
+
+		// the URN was inserted by someone else after we tried to look it up
+		if dbutil.IsUniqueViolation(err) {
+			return false, nil
+		}
 		return false, fmt.Errorf("error adding URN to contact: %w", err)
 	}
 

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -159,3 +159,86 @@ func contactForURN(ctx context.Context, b *backend, org models.OrgID, channel *m
 
 	return contact, nil
 }
+
+// contactForMsg resolves the contact for an incoming message. Normally that's a lookup by (or creation from) the
+// message's primary URN. But when a WhatsApp message arrives with a phone number as its primary URN and a
+// business-scoped user ID attached as its new URN, and the phone number doesn't match an existing contact, we also
+// look for one by the BSUID - so a contact created from messages received while the user's phone number was omitted
+// (see https://developers.facebook.com/documentation/business-messaging/whatsapp/business-scoped-user-ids/) is
+// reused rather than duplicated. In that case the phone number is added to the matched contact so the message is
+// still attributed to it as the primary URN.
+func contactForMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLog) (*models.Contact, error) {
+	altURN := altLookupURN(m)
+
+	// simple case: no alternative URN to consider, look up or create by the primary URN
+	if altURN == urns.NilURN {
+		return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+	}
+
+	// try the primary URN first, without creating a contact
+	contact, err := contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, false, clog)
+	if err != nil || contact != nil {
+		return contact, err
+	}
+
+	// the primary URN didn't match an existing contact, try the alternative
+	contact, err = contactForURN(ctx, b, m.OrgID_, m.channel, altURN, nil, "", false, clog)
+	if err != nil {
+		return nil, err
+	}
+	if contact != nil {
+		// matched an existing contact by the BSUID - add the primary URN to it so the message stays attributed to
+		// the primary URN
+		added, err := addContactURN(ctx, b, m.channel, contact, m.URN_, m.URNAuthTokens_)
+		if err != nil {
+			return nil, err
+		}
+		if !added {
+			// the primary URN was created for another contact while we were looking, start over with a lookup
+			return contactForMsg(ctx, b, m, clog)
+		}
+		return contact, nil
+	}
+
+	// no existing contact matched either URN, create one from the primary URN
+	return contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+}
+
+// altLookupURN returns an alternative URN to look up an existing contact by when the message's primary URN doesn't
+// match one: for a message from a WhatsApp phone number with a business-scoped user ID attached as its new URN,
+// that's the BSUID.
+func altLookupURN(m *MsgIn) urns.URN {
+	if m.NewURN_ != nil && m.URN_.Scheme() == urns.WhatsApp.Prefix && urns.IsWhatsAppBSUID(m.NewURN_.Value) {
+		return m.NewURN_.Value
+	}
+	return urns.NilURN
+}
+
+// addContactURN adds the given URN to the contact (if not already present) and points the contact's URNID at it, so
+// an incoming message is attributed to this URN. Returns false without adding if the URN belongs to another contact,
+// rather than stealing it.
+func addContactURN(ctx context.Context, b *backend, channel *models.Channel, contact *models.Contact, urn urns.URN, authTokens map[string]string) (bool, error) {
+	tx, err := b.rt.DB.BeginTxx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("error beginning transaction: %w", err)
+	}
+
+	contactURN, err := models.GetOrCreateContactURN(ctx, tx, channel, contact.ID_, urn, authTokens)
+	if err != nil {
+		tx.Rollback()
+		return false, fmt.Errorf("error adding URN to contact: %w", err)
+	}
+
+	// the URN was created for another contact while we were looking, roll back rather than steal it
+	if contactURN.PrevContactID != models.NilContactID {
+		tx.Rollback()
+		return false, nil
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("error committing transaction: %w", err)
+	}
+
+	contact.URNID_ = contactURN.ID
+	return true, nil
+}

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -121,7 +121,7 @@ func writeMsg(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLo
 }
 
 func writeMsgToDB(ctx context.Context, b *backend, m *MsgIn, clog *courier.ChannelLog) (*models.Contact, error) {
-	contact, err := contactForURN(ctx, b, m.OrgID_, m.channel, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+	contact, err := contactForMsg(ctx, b, m, clog)
 
 	if err != nil {
 		// our db is down, write to the spool, we will write/queue this later

--- a/testsuite/testdata/data.sql
+++ b/testsuite/testdata/data.sql
@@ -31,6 +31,9 @@ INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modifi
 INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
                       VALUES('16', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327222a', 'EX', NULL, 1, 'US', '', '{}');
 
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
+                      VALUES('17', '{"whatsapp"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc33277a17', 'WAC', '12345', 1, NULL, 'SR', '{}');
+
 /* Contacts with ids 100, 101 */
 DELETE FROM contacts_contact;
 INSERT INTO contacts_contact("id", "is_active", "status", "created_on", "modified_on", "uuid", "language", "ticket_count", "created_by_id", "modified_by_id", "org_id")

--- a/testsuite/testdata/data.sql
+++ b/testsuite/testdata/data.sql
@@ -31,8 +31,8 @@ INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modifi
 INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "name", "address", "org_id", "country", "role", "config")
                       VALUES('16', '{"tel"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc3327222a', 'EX', 'External 2', NULL, 1, 'US', '', '{}');
 
-INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "address", "org_id", "country", "role", "config")
-                      VALUES('17', '{"whatsapp"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc33277a17', 'WAC', '12345', 1, NULL, 'SR', '{}');
+INSERT INTO channels_channel("id", "schemes", "is_active", "created_on", "modified_on", "uuid", "channel_type", "name", "address", "org_id", "country", "role", "config")
+                      VALUES('17', '{"whatsapp"}', 'Y', NOW(), NOW(), 'dbc126ed-66bc-4e28-b67b-81dc33277a17', 'WAC', 'WhatsApp Cloud 1', '12345', 1, NULL, 'SR', '{}');
 
 /* Contacts with ids 100, 101 */
 DELETE FROM contacts_contact;


### PR DESCRIPTION
## Summary

Follow-up to #1094. A user whose phone number is omitted from webhooks (because they adopted a WhatsApp username) gets a contact created from their business-scoped user ID. If their phone number later appears in a webhook — a retention condition now applies — contact resolution ran on the phone URN alone, found nothing, and created a **second** contact. Mailroom's shell-claim handling then reassigned the BSUID URN to the new contact, leaving the original — with the user's name, message history and flow runs — stranded without any URN. Identity converged onto the wrong contact.

## Changes

Incoming message contact resolution (`writeMsgToDB`) now goes through a new `contactForMsg`:

- When a WhatsApp message has a phone number as its primary URN and a BSUID attached as its new URN, and the phone URN doesn't match an existing contact, it also looks one up by the BSUID.
- On a match, the phone URN is added to that contact and the message is attributed to it as the primary URN — the original contact is reused and gains the phone number, and mailroom's subsequent BSUID append becomes a no-op.
- Two race guards make the add-URN step restart resolution with a fresh lookup instead of misbehaving: if the phone URN turns out to belong to another contact it is not stolen, and if it was concurrently inserted by another writer the unique violation is treated the same way rather than erroring out and sending the message on a detour through the spool.

## Deliberately unchanged

- A phone URN that matches an existing contact is used directly, even if a *different* contact owns the BSUID — that's a genuine conflict, left to mailroom's no-steal append handling and logging.
- Messages without an attached BSUID, and non-WhatsApp messages, keep the existing single-URN resolution.
- Channel events don't carry a new-URN spec and are untouched.

## Notes for review

- The alternative-lookup shape intentionally mirrors the earlier prototype for the flipped world (BSUID primary, phone attached), so when priorities flip later the same mechanism applies with the roles swapped.
- Includes a merge of main to track the refreshed test schema (#1095), with the new test fixture channel updated for the now-required channel name column.

## Test plan

- New `TestContactForMsg` covers: create-new (phone + BSUID, no existing contact), match-by-BSUID (phone attached, message attributed to the phone URN), match-by-phone with the BSUID owned by another contact (left with its owner), no-BSUID resolution unchanged, and the no-steal/restart path of the add-URN step.
- The concurrent-insert branch only fires in a true race, matching how the equivalent branch in `contactForURN` is covered.
- Full test suite passes.