### PR TITLE
Fix flaky TestMsgStatus by flushing status writer instead of sleeping

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -474,7 +474,7 @@ func (ts *BackendTestSuite) TestMsgStatus() {
 	time.Sleep(2 * time.Millisecond)
 
 	// update to WIRED using external id
-	clog6 := updateStatusByExtID("ext1", models.MsgStatusWired)
+	updateStatusByExtID("ext1", models.MsgStatusWired)
 
 	m = testsuite.ReadDBMsg(ts.T(), ts.b.rt, "0199df0f-9f82-7689-b02d-f34105991321")
 	ts.Equal(models.MsgStatusWired, m.Status)
@@ -510,19 +510,12 @@ func (ts *BackendTestSuite) TestMsgStatus() {
 	ts.NotNil(m.SentOn)
 
 	// reset our status to sent
-	status := ts.b.NewStatusUpdateByExternalID(channel, "ext1", models.MsgStatusSent, clog6)
-	err := ts.b.WriteStatusUpdate(ctx, status)
-	ts.NoError(err)
-	time.Sleep(time.Second)
+	updateStatusByExtID("ext1", models.MsgStatusSent)
 
 	// error our msg
 	now = time.Now().In(time.UTC)
 	time.Sleep(2 * time.Millisecond)
-	status = ts.b.NewStatusUpdateByExternalID(channel, "ext1", models.MsgStatusErrored, clog6)
-	err = ts.b.WriteStatusUpdate(ctx, status)
-	ts.NoError(err)
-
-	time.Sleep(time.Second) // give committer time to write this
+	updateStatusByExtID("ext1", models.MsgStatusErrored)
 
 	m = testsuite.ReadDBMsg(ts.T(), ts.b.rt, "0199df0f-9f82-7689-b02d-f34105991321")
 	ts.Equal(m.Status, models.MsgStatusErrored)
@@ -533,11 +526,7 @@ func (ts *BackendTestSuite) TestMsgStatus() {
 	ts.Equal(m.ExternalIdentifier, null.String("ext1"))
 
 	// second go
-	status = ts.b.NewStatusUpdateByExternalID(channel, "ext1", models.MsgStatusErrored, clog6)
-	err = ts.b.WriteStatusUpdate(ctx, status)
-	ts.NoError(err)
-
-	time.Sleep(time.Second) // give committer time to write this
+	updateStatusByExtID("ext1", models.MsgStatusErrored)
 
 	m = testsuite.ReadDBMsg(ts.T(), ts.b.rt, "0199df0f-9f82-7689-b02d-f34105991321")
 	ts.Equal(m.Status, models.MsgStatusErrored)
@@ -545,12 +534,8 @@ func (ts *BackendTestSuite) TestMsgStatus() {
 	ts.Equal(null.NullString, m.FailedReason)
 
 	// third go
-	status = ts.b.NewStatusUpdateByExternalID(channel, "ext1", models.MsgStatusErrored, clog6)
-	err = ts.b.WriteStatusUpdate(ctx, status)
+	updateStatusByExtID("ext1", models.MsgStatusErrored)
 
-	time.Sleep(time.Second) // give committer time to write this
-
-	ts.NoError(err)
 	m = testsuite.ReadDBMsg(ts.T(), ts.b.rt, "0199df0f-9f82-7689-b02d-f34105991321")
 	ts.Equal(m.Status, models.MsgStatusFailed)
 	ts.Equal(m.ErrorCount, 3)


### PR DESCRIPTION
`TestMsgSuite/TestMsgStatus` was flaky when run in isolation — it failed roughly half the time. The final section of the test wrote status updates directly via `WriteStatusUpdate` and then used fixed `time.Sleep(time.Second)` waits to give the async status writer time to flush, which sometimes wasn't enough.

The test file already has helpers (`updateStatusByUUID` / `updateStatusByExtID`) that call `statusWriter.Flush()`, which is fully synchronous — it blocks until the batcher has drained its buffer and completed the DB write. This change switches the sleep-based section to use the existing helper, making the test deterministic (and ~4 seconds faster).

Verified with 10 consecutive isolated runs plus 20 more via `-count=10`, all passing.