### PR TITLE
Clear test spool directory when creating test runtime

### DIFF
--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -40,6 +40,9 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.DynamoTablePrefix = "Test"
 	cfg.SpoolDir = absPath("./_test_spool")
 
+	// items spooled by a previous test run would be replayed into this run's reset database
+	require.NoError(t, os.RemoveAll(cfg.SpoolDir))
+
 	rt, err := runtime.NewRuntime(cfg)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Items spooled to disk by one test run could be replayed into the next run's freshly reset database. If a run errored while statuses/msgs/events were in flight (or was interrupted), the files left in `_test_spool/` persisted, and the spool background flusher would replay them on the next run — e.g. appending stale `log_uuids` to seed messages and causing confusing failures in otherwise passing tests.

## Changes

- `testsuite.Runtime()` now removes the spool directory (`os.RemoveAll`) before creating the runtime, matching how the database and valkey are reset between runs. The spool implementations recreate their directories on `Start()` via `MkdirAll`, so nothing else needs to change.

## Test plan

- Seeded a stale spooled status file targeting a seed message and confirmed it is wiped at setup instead of being replayed into the reset database.
- Full test suite passes (`go test -p=1 ./...`).