### PR TITLE
Handle Turn webhooks where sender has no phone number

### DIFF
--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -85,10 +85,11 @@ type eventsPayload struct {
 		Profile struct {
 			Name string `json:"name"`
 		} `json:"profile"`
-		WaID string `json:"wa_id"`
+		WaID   string `json:"wa_id"`
+		UserID string `json:"user_id"`
 	} `json:"contacts"`
 	Messages []struct {
-		From      string `json:"from"      validate:"required"`
+		From      string `json:"from"`
 		FromBSUID string `json:"from_bsuid"`
 		ID        string `json:"id"        validate:"required"`
 		GroupID   string `json:"group_id,omitempty"`
@@ -175,9 +176,16 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 
 	seenMsgIDs := make(map[string]bool, 2)
 
+	// contacts are keyed by both identifiers they can carry, as a message from a user with a username may
+	// only reference them by their user_id
 	var contactNames = make(map[string]string)
 	for _, contact := range payload.Contacts {
-		contactNames[contact.WaID] = contact.Profile.Name
+		if contact.WaID != "" {
+			contactNames[contact.WaID] = contact.Profile.Name
+		}
+		if contact.UserID != "" {
+			contactNames[contact.UserID] = contact.Profile.Name
+		}
 	}
 
 	// first deal with any received messages
@@ -198,8 +206,11 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 		}
 		date := time.Unix(ts, 0).UTC()
 
-		// create our URN
-		urn, err := urns.New(urns.WhatsApp, msg.From)
+		// create our URN from the sender's phone number, falling back to their business-scoped user ID as a user
+		// who has adopted a WhatsApp username can have their phone number omitted from the webhook entirely
+		sender := cmp.Or(msg.From, msg.FromBSUID)
+
+		urn, err := urns.New(urns.WhatsApp, sender)
 		if err != nil {
 			return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, errors.New("invalid whatsapp id"))
 		}
@@ -237,7 +248,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel courier.Channel, w 
 		}
 
 		// create our message
-		event := h.Backend().NewIncomingMsg(ctx, channel, urn, text, msg.ID, clog).WithReceivedOn(date).WithContactName(contactNames[msg.From])
+		event := h.Backend().NewIncomingMsg(ctx, channel, urn, text, msg.ID, clog).WithReceivedOn(date).WithContactName(contactNames[sender])
 
 		// we had an error downloading media
 		if err != nil {

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -71,11 +71,45 @@ var helloMsgFromBSUID = `{
     "profile": {
       "name": "Jerry Cooney"
     },
+    "user_id": "US.1234"
+  }],
+  "messages": [{
+    "from_bsuid": "US.1234",
+    "id": "41",
+    "timestamp": "1454119029",
+    "text": {
+      "body": "hello world"
+    },
+    "type": "text"
+   }]
+}`
+
+var helloMsgBSUIDInFrom = `{
+  "contacts":[{
+    "profile": {
+      "name": "Jerry Cooney"
+    },
     "wa_id": "US.1234"
   }],
   "messages": [{
     "from": "US.1234",
     "from_bsuid": "US.1234",
+    "id": "41",
+    "timestamp": "1454119029",
+    "text": {
+      "body": "hello world"
+    },
+    "type": "text"
+   }]
+}`
+
+var helloMsgNoFromOrBSUID = `{
+  "contacts":[{
+    "profile": {
+      "name": "Jerry Cooney"
+    }
+  }],
+  "messages": [{
     "id": "41",
     "timestamp": "1454119029",
     "text": {
@@ -400,6 +434,27 @@ var testCasesTurn = []IncomingTestCase{
 		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
 		NoQueueErrorCheck:     true,
 		NoInvalidChannelCheck: true,
+	},
+	{
+		Label:                 "Receive Message with BSUID in from",
+		URL:                   turnWhatsappReceiveURL,
+		Data:                  helloMsgBSUIDInFrom,
+		ExpectedRespStatus:    200,
+		ExpectedBodyContains:  `"type":"msg"`,
+		ExpectedContactName:   Sp("Jerry Cooney"),
+		ExpectedMsgText:       Sp("hello world"),
+		ExpectedURN:           "whatsapp:US.1234",
+		ExpectedExternalID:    "41",
+		ExpectedDate:          time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
+		NoQueueErrorCheck:     true,
+		NoInvalidChannelCheck: true,
+	},
+	{
+		Label:                "Receive Message with no from or from_bsuid",
+		URL:                  turnWhatsappReceiveURL,
+		Data:                 helloMsgNoFromOrBSUID,
+		ExpectedRespStatus:   400,
+		ExpectedBodyContains: "invalid whatsapp id",
 	},
 	{
 		Label:                 "Receive Message with invalid bsuid, no new URN added",


### PR DESCRIPTION
## Problem

WhatsApp usernames mean that when a user has adopted a username and none of the phone number retention conditions apply, Turn's inbound message webhooks omit the `from` field entirely — the sender is identified only by their business-scoped user ID (BSUID) in `from_bsuid`, and the contact entry carries `user_id` instead of `wa_id`. Turn's [usernames/BSUID announcement](https://learn.turn.io/l/en/article/hcjjytyfjy-coming-soon-whats-app-usernames-and-bsuids-what-you-need-to-know) documents this shape explicitly, including an example message payload with no `from`.

The TRN handler marked `from` as `validate:"required"`, so such webhooks were rejected at payload validation with a 400 and the message permanently lost once Turn stopped retrying — the existing `from_bsuid` secondary-URN handling further down was unreachable for these senders.

This is the Turn equivalent of #1094, which fixed the same bug in the WAC and D3C handlers.

## Changes

- `from` is no longer required; the primary URN is built from `from` falling back to `from_bsuid` (whatsapp scheme, matching the secondary-URN behaviour and the scheme rationale in #1094), and only errors when both are missing.
- Contact names are keyed on `user_id` as well as `wa_id`, and looked up by whichever identifier the message carried, so the name isn't lost when `wa_id` is omitted.
- Corrected the `helloMsgFromBSUID` fixture, which put the BSUID in `from` — a shape Turn doesn't send (`from` is omitted, not repurposed).

## Testing

New incoming cases cover the true BSUID-only shape (message written, URN from `from_bsuid`, contact name picked up via `user_id`), a BSUID arriving in `from` so that path stays covered, and the both-missing case erroring. Reverting just `handler.go` fails the BSUID-only case with `expected a msg to be written`, so it's a genuine regression test. Full suite passes.