### PR TITLE
Don't make Telegram keyboards single use when they contain form or location buttons

### DIFF
--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -904,7 +904,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Where Are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true},{"text":"Ignore"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Where Are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true},{"text":"Ignore"}]],"resize_keyboard":true,"one_time_keyboard":false}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -919,7 +919,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":false}`}}},
 		},
 		ExpectedExtIDs: []string{"133"},
 	},
@@ -967,7 +967,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Please register"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Register","web_app":{"url":"https://example.com/form"}},{"text":"Skip"}]],"resize_keyboard":true,"one_time_keyboard":false}`}}},
 		},
 		ExpectedLogErrors: []*clogs.Error{
 			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},
@@ -1057,7 +1057,7 @@ var outgoingCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Form: url.Values{"text": {"Where are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true}]],"resize_keyboard":true,"one_time_keyboard":true}`}}},
+			{Form: url.Values{"text": {"Where are you?"}, "chat_id": {"12345"}, "parse_mode": {"Markdown"}, "reply_markup": {`{"keyboard":[[{"text":"Send Location","request_location":true}]],"resize_keyboard":true,"one_time_keyboard":false}`}}},
 		},
 		ExpectedLogErrors: []*clogs.Error{
 			{Message: "quick reply of type url isn't supported by this channel and can't be sent"},

--- a/handlers/telegram/keyboard.go
+++ b/handlers/telegram/keyboard.go
@@ -36,6 +36,7 @@ type ReplyKeyboardMarkup struct {
 func NewKeyboardFromReplies(replies []models.QuickReply) *ReplyKeyboardMarkup {
 	rows := models.QuickRepliesToRows(replies, 5, 30, 2)
 	keyboard := make([][]KeyboardButton, len(rows))
+	hasForm, hasLocation := false, false
 
 	for i := range rows {
 		keyboard[i] = make([]KeyboardButton, len(rows[i]))
@@ -47,13 +48,22 @@ func NewKeyboardFromReplies(replies []models.QuickReply) *ReplyKeyboardMarkup {
 			switch rows[i][j].Type {
 			case models.QuickReplyTypeLocation:
 				keyboard[i][j].RequestLocation = true
+				hasLocation = true
 			case models.QuickReplyTypeForm:
 				keyboard[i][j].WebApp = &WebAppInfo{URL: rows[i][j].Extra}
+				hasForm = true
 			}
 		}
 	}
 
-	return &ReplyKeyboardMarkup{Keyboard: keyboard, ResizeKeyboard: true, OneTimeKeyboard: true}
+	// tapping a text button is itself the reply so those keyboards can be single use, but form and location buttons
+	// launch a separate interaction that the user might not complete, and one-time state syncs across their devices -
+	// so keep those keyboards available until the next message clears them
+	return &ReplyKeyboardMarkup{
+		Keyboard:        keyboard,
+		ResizeKeyboard:  true,
+		OneTimeKeyboard: !hasForm && !hasLocation,
+	}
 }
 
 // InlineKeyboardButton is a button on an inline keyboard, see https://core.telegram.org/bots/api/#inlinekeyboardbutton

--- a/handlers/telegram/keyboard_test.go
+++ b/handlers/telegram/keyboard_test.go
@@ -61,7 +61,7 @@ func TestKeyboardFromReplies(t *testing.T) {
 				[][]telegram.KeyboardButton{
 					{{Text: "Send Location", RequestLocation: true}},
 				},
-				true, true,
+				true, false,
 			},
 		},
 		{
@@ -71,7 +71,7 @@ func TestKeyboardFromReplies(t *testing.T) {
 				[][]telegram.KeyboardButton{
 					{{Text: "Share Location", RequestLocation: true}},
 				},
-				true, true,
+				true, false,
 			},
 		},
 		{
@@ -81,7 +81,7 @@ func TestKeyboardFromReplies(t *testing.T) {
 				[][]telegram.KeyboardButton{
 					{{Text: "Open Form", WebApp: &telegram.WebAppInfo{URL: "https://example.com/form"}}, {Text: "Skip"}},
 				},
-				true, true,
+				true, false,
 			},
 		},
 	}


### PR DESCRIPTION
Form and location quick reply buttons launch a separate interaction — opening a Mini App or a location picker — that the user might not complete, and Telegram syncs one-time keyboard state across a user's devices, so a single tap on one client hides the keyboard everywhere. That can make a form's Mini App button disappear before the user gets a chance to open it.

Since keyboards are already explicitly cleared with `remove_keyboard` on the next message, keyboards containing form or location buttons now drop `one_time_keyboard` so they stay available until the conversation moves on.

Text-only keyboards keep the existing single-use behavior, where the tap itself is the reply.

Re-applies the change from #1085 on top of the reworked keyboard handling that landed in #1087.