### PR TITLE
Treat Turn HTTP 429 as throttled (retry instead of permanent fail)

### DIFF
--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -995,6 +995,12 @@ func (h *handler) makeAPIRequest(payload any, accessToken string, res *courier.S
 	if err != nil || resp.StatusCode/100 == 5 {
 		return courier.ErrConnectionFailed
 	}
+	// Turn returns HTTP 429 with its own rate-limit payload (errors[].code=429) and
+	// Retry-After / X-Ratelimit-* headers. Treat that as throttled so the message is
+	// retried via the errored queue rather than permanently failed.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return courier.ErrConnectionThrottled
+	}
 
 	respPayload := &mtResponsePayload{}
 	err = json.Unmarshal(respBody, respPayload)
@@ -1002,7 +1008,7 @@ func (h *handler) makeAPIRequest(payload any, accessToken string, res *courier.S
 		return courier.ErrResponseUnparseable
 	}
 
-	if slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Error.Code) {
+	if respPayload.Error.Code == 429 || slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Error.Code) {
 		return courier.ErrConnectionThrottled
 	}
 
@@ -1015,7 +1021,7 @@ func (h *handler) makeAPIRequest(payload any, accessToken string, res *courier.S
 	}
 
 	if len(respPayload.Errors) > 0 {
-		if slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Errors[0].Code) {
+		if respPayload.Errors[0].Code == 429 || slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Errors[0].Code) {
 			return courier.ErrConnectionThrottled
 		}
 		if slices.Contains(whatsapp.WACRetryableErrorCodes, respPayload.Errors[0].Code) {

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -1282,6 +1282,24 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrConnectionThrottled,
 	},
 	{
+		Label:   "Error Turn HTTP 429 Rate Limit Bucket",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(429, map[string]string{
+					"Content-Type":          "application/json; charset=utf-8",
+					"Retry-After":           "1",
+					"X-Ratelimit-Bucket":    "text",
+					"X-Ratelimit-Limit":     "20",
+					"X-Ratelimit-Remaining": "0",
+					"X-Ratelimit-Reset":     "1786331727.285",
+				}, []byte(`{"errors":[{"code":429,"title":"Rate limit hit for bucket text","details":"You are being rate limited by Turn. please read the documentation at https://whatsapp.turn.io/docs/"}]}`)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Error Retryable",
 		MsgText: "Error",
 		MsgURN:  "whatsapp:250788123123",


### PR DESCRIPTION
## Summary
- Treat Turn HTTP `429` and body `errors[].code=429` as `ErrConnectionThrottled` in the TRN adapter, matching WhatsApp Legacy behaviour for provider rate limits.
- Add a send test covering Turn's `text` bucket rate-limit response (including `Retry-After` / `X-Ratelimit-*` headers).

Fixes #1102

## Test plan
- [ ] `go test ./handlers/turn/ -count=1`
- [ ] Confirm mocked Turn HTTP 429 payload returns `ErrConnectionThrottled` (not `ErrFailedWithReason`)
- [ ] Confirm existing Meta-style throttle codes (`130429`, `131056`) still return `ErrConnectionThrottled`


Made with [Cursor](https://cursor.com)