### PR TITLE
Support Turn WhatsApp media and interactive template components.

### DIFF
--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -452,31 +451,14 @@ type mediaObject struct {
 	Filename string `json:"filename,omitempty"`
 }
 
-type LocalizableParam struct {
-	Default string `json:"default"`
-}
-
-type Param struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
-}
-
-type Component struct {
-	Type       string  `json:"type"`
-	Parameters []Param `json:"parameters,omitempty"`
-}
-
 type templatePayload struct {
 	recipient
 	Type     string `json:"type"`
 	Template struct {
-		Namespace string `json:"namespace"`
-		Name      string `json:"name"`
-		Language  struct {
-			Policy string `json:"policy"`
-			Code   string `json:"code"`
-		} `json:"language"`
-		Components []Component `json:"components,omitempty"`
+		Namespace  string                `json:"namespace"`
+		Name       string                `json:"name"`
+		Language   whatsapp.Language     `json:"language"`
+		Components []*whatsapp.Component `json:"components,omitempty"`
 	} `json:"template"`
 }
 
@@ -509,6 +491,33 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 	var err error
 
 	rcpt := newRecipient(msg)
+
+	// Template messages must be sent as a single template payload. Mailroom/goflow may also
+	// attach preview media and button quick-replies on the same message; those must not be
+	// turned into separate image/interactive sends.
+	if msg.Templating() != nil {
+		langCode := getSupportedLanguage(msg.Locale())
+		namespace := msg.Templating().Namespace
+		if namespace == "" {
+			namespace = msg.Channel().StringConfigForKey(configNamespace, "")
+		}
+		if namespace == "" {
+			return nil, fmt.Errorf("cannot send template message without Facebook namespace for channel: %s", msg.Channel().UUID())
+		}
+
+		waTpl := whatsapp.GetTemplatePayload(msg.Templating())
+
+		payload := templatePayload{
+			recipient: rcpt,
+			Type:      "template",
+		}
+		payload.Template.Namespace = namespace
+		payload.Template.Name = waTpl.Name
+		payload.Template.Language = whatsapp.Language{Policy: "deterministic", Code: langCode}
+		payload.Template.Components = waTpl.Components
+
+		return []any{payload}, nil
+	}
 
 	parts := handlers.SplitMsgByChannel(msg.Channel(), msg.Text(), maxMsgLength)
 
@@ -698,152 +707,104 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *co
 		}
 
 	} else {
-		// do we have a template?
-		if msg.Templating() != nil {
-			langCode := getSupportedLanguage(msg.Locale())
-			namespace := msg.Templating().Namespace
-			if namespace == "" {
-				namespace = msg.Channel().StringConfigForKey(configNamespace, "")
-			}
-			if namespace == "" {
-				return nil, fmt.Errorf("cannot send template message without Facebook namespace for channel: %s", msg.Channel().UUID())
-			}
-
-			payload := templatePayload{
-				recipient: rcpt,
-				Type:      "template",
-			}
-			payload.Template.Namespace = namespace
-			payload.Template.Name = msg.Templating().Template.Name
-			payload.Template.Language.Policy = "deterministic"
-			payload.Template.Language.Code = langCode
-
-			for _, comp := range msg.Templating().Components {
-				// get the variables used by this component in order of their names 1, 2 etc
-				compParams := make([]models.TemplatingVariable, 0, len(comp.Variables))
-
-				for _, varName := range slices.SortedFunc(maps.Keys(comp.Variables), func(a, b string) int {
-					ai, _ := strconv.Atoi(a)
-					bi, _ := strconv.Atoi(b)
-					return cmp.Compare(ai, bi)
-				}) {
-					compParams = append(compParams, msg.Templating().Variables[comp.Variables[varName]])
-				}
-
-				if comp.Type == "body" || strings.HasPrefix(comp.Type, "body/") {
-					component := &Component{Type: "body"}
-					for _, p := range compParams {
-						component.Parameters = append(component.Parameters, Param{Type: p.Type, Text: p.Value})
-					}
-					payload.Template.Components = append(payload.Template.Components, *component)
-
-				}
-
-			}
-
-			payloads = append(payloads, payload)
-
-		} else {
-
-			if isInteractiveMsg {
-				for i, part := range parts {
-					if i < (len(parts) - 1) { //if split into more than one message, the first parts will be text and the last interactive
-						payload := mtTextPayload{
-							recipient: rcpt,
-							Type:      "text",
-						}
-						payload.Text.Body = part
-						payloads = append(payloads, payload)
-
-					} else {
-						payload := mtInteractivePayload{
-							recipient: rcpt,
-							Type:      "interactive",
-						}
-
-						if len(locationQRs) > 0 {
-							payload.Interactive.Type = "location_request_message"
-							payload.Interactive.Body.Text = part
-							payload.Interactive.Action.Name = "send_location"
-							payloads = append(payloads, payload)
-
-						} else if len(formQRs) > 0 {
-							qr := formQRs[0]
-							payload.Interactive.Type = "flow"
-							payload.Interactive.Body.Text = part
-							payload.Interactive.Action.Name = "flow"
-							payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
-								FlowMessageVersion: "3",
-								FlowID:             qr.Extra,
-								FlowCTA:            qr.GetText(),
-							}
-							payloads = append(payloads, payload)
-
-						} else if len(urlQRs) > 0 {
-							qr := urlQRs[0]
-							payload.Interactive.Type = "cta_url"
-							payload.Interactive.Body.Text = part
-							payload.Interactive.Action.Name = "cta_url"
-							payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
-								DisplayText: qr.GetText(),
-								URL:         qr.Extra,
-							}
-							payloads = append(payloads, payload)
-
-						} else if !qrsAsList { // we show buttons
-							payload.Interactive.Type = "button"
-							payload.Interactive.Body.Text = part
-							btns := make([]mtButton, len(qrs))
-							for i, qr := range qrs {
-								btns[i] = mtButton{
-									Type: "reply",
-								}
-								btns[i].Reply.ID = fmt.Sprint(i)
-								btns[i].Reply.Title = qr.Text
-							}
-							payload.Interactive.Action.Buttons = btns
-							payloads = append(payloads, payload)
-						} else {
-							payload.Interactive.Type = "list"
-							payload.Interactive.Body.Text = part
-							payload.Interactive.Action.Button = "Menu"
-							section := mtSection{
-								Rows: make([]mtSectionRow, len(qrs)),
-							}
-							for i, qr := range qrs {
-								section.Rows[i] = mtSectionRow{
-									ID:          fmt.Sprint(i),
-									Title:       qr.Text,
-									Description: qr.Extra,
-								}
-							}
-							payload.Interactive.Action.Sections = []mtSection{
-								section,
-							}
-							payloads = append(payloads, payload)
-						}
-					}
-				}
-			} else {
-				for _, part := range parts {
-
-					// check if you have a link
-					var payload mtTextPayload
-					if strings.Contains(part, "https://") || strings.Contains(part, "http://") {
-						payload = mtTextPayload{
-							recipient:  rcpt,
-							Type:       "text",
-							PreviewURL: true,
-						}
-					} else {
-						payload = mtTextPayload{
-							recipient: rcpt,
-							Type:      "text",
-						}
+		if isInteractiveMsg {
+			for i, part := range parts {
+				if i < (len(parts) - 1) { //if split into more than one message, the first parts will be text and the last interactive
+					payload := mtTextPayload{
+						recipient: rcpt,
+						Type:      "text",
 					}
 					payload.Text.Body = part
 					payloads = append(payloads, payload)
+
+				} else {
+					payload := mtInteractivePayload{
+						recipient: rcpt,
+						Type:      "interactive",
+					}
+
+					if len(locationQRs) > 0 {
+						payload.Interactive.Type = "location_request_message"
+						payload.Interactive.Body.Text = part
+						payload.Interactive.Action.Name = "send_location"
+						payloads = append(payloads, payload)
+
+					} else if len(formQRs) > 0 {
+						qr := formQRs[0]
+						payload.Interactive.Type = "flow"
+						payload.Interactive.Body.Text = part
+						payload.Interactive.Action.Name = "flow"
+						payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
+							FlowMessageVersion: "3",
+							FlowID:             qr.Extra,
+							FlowCTA:            qr.GetText(),
+						}
+						payloads = append(payloads, payload)
+
+					} else if len(urlQRs) > 0 {
+						qr := urlQRs[0]
+						payload.Interactive.Type = "cta_url"
+						payload.Interactive.Body.Text = part
+						payload.Interactive.Action.Name = "cta_url"
+						payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
+							DisplayText: qr.GetText(),
+							URL:         qr.Extra,
+						}
+						payloads = append(payloads, payload)
+
+					} else if !qrsAsList { // we show buttons
+						payload.Interactive.Type = "button"
+						payload.Interactive.Body.Text = part
+						btns := make([]mtButton, len(qrs))
+						for i, qr := range qrs {
+							btns[i] = mtButton{
+								Type: "reply",
+							}
+							btns[i].Reply.ID = fmt.Sprint(i)
+							btns[i].Reply.Title = qr.Text
+						}
+						payload.Interactive.Action.Buttons = btns
+						payloads = append(payloads, payload)
+					} else {
+						payload.Interactive.Type = "list"
+						payload.Interactive.Body.Text = part
+						payload.Interactive.Action.Button = "Menu"
+						section := mtSection{
+							Rows: make([]mtSectionRow, len(qrs)),
+						}
+						for i, qr := range qrs {
+							section.Rows[i] = mtSectionRow{
+								ID:          fmt.Sprint(i),
+								Title:       qr.Text,
+								Description: qr.Extra,
+							}
+						}
+						payload.Interactive.Action.Sections = []mtSection{
+							section,
+						}
+						payloads = append(payloads, payload)
+					}
 				}
+			}
+		} else {
+			for _, part := range parts {
+
+				// check if you have a link
+				var payload mtTextPayload
+				if strings.Contains(part, "https://") || strings.Contains(part, "http://") {
+					payload = mtTextPayload{
+						recipient:  rcpt,
+						Type:       "text",
+						PreviewURL: true,
+					}
+				} else {
+					payload = mtTextPayload{
+						recipient: rcpt,
+						Type:      "text",
+					}
+				}
+				payload.Text.Body = part
+				payloads = append(payloads, payload)
 			}
 		}
 	}

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -1052,6 +1052,183 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
+		Label:     "Template Send with image header",
+		MsgText:   "templated message",
+		MsgURN:    "whatsapp:250788123123",
+		MsgLocale: "eng",
+		MsgTemplating: `{
+			"template": {"uuid": "171f8a4d-f725-46d7-85a6-11aceff0bfe3", "name": "revive_issue"},
+			"components": [
+				{"type": "header/media", "name": "header", "variables": {"1": 0}},
+				{"type": "body/text", "name": "body", "variables": {"1": 1, "2": 2}}
+			],
+			"variables": [
+				{"type": "image", "value": "image/jpeg:https://foo.bar/image.jpg"},
+				{"type": "text", "value": "Chef"},
+				{"type": "text", "value": "tomorrow"}
+			],
+			"language": "en_US"
+		}`,
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Path: "/v1/messages",
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"image","image":{"link":"https://foo.bar/image.jpg"}}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:     "Template Send with video header",
+		MsgText:   "templated message",
+		MsgURN:    "whatsapp:250788123123",
+		MsgLocale: "eng",
+		MsgTemplating: `{
+			"template": {"uuid": "171f8a4d-f725-46d7-85a6-11aceff0bfe3", "name": "revive_issue"},
+			"components": [
+				{"type": "header/media", "name": "header", "variables": {"1": 0}},
+				{"type": "body/text", "name": "body", "variables": {"1": 1, "2": 2}}
+			],
+			"variables": [
+				{"type": "video", "value": "video/mp4:https://foo.bar/video.mp4"},
+				{"type": "text", "value": "Chef"},
+				{"type": "text", "value": "tomorrow"}
+			],
+			"language": "en_US"
+		}`,
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Path: "/v1/messages",
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"video","video":{"link":"https://foo.bar/video.mp4"}}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:     "Template Send with document header",
+		MsgText:   "templated message",
+		MsgURN:    "whatsapp:250788123123",
+		MsgLocale: "eng",
+		MsgTemplating: `{
+			"template": {"uuid": "171f8a4d-f725-46d7-85a6-11aceff0bfe3", "name": "revive_issue"},
+			"components": [
+				{"type": "header/media", "name": "header", "variables": {"1": 0}},
+				{"type": "body/text", "name": "body", "variables": {"1": 1, "2": 2}}
+			],
+			"variables": [
+				{"type": "document", "value": "application/pdf:https://foo.bar/doc.pdf"},
+				{"type": "text", "value": "Chef"},
+				{"type": "text", "value": "tomorrow"}
+			],
+			"language": "en_US"
+		}`,
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Path: "/v1/messages",
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"document","document":{"link":"https://foo.bar/doc.pdf","filename":"doc.pdf"}}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:     "Template Send with text header",
+		MsgText:   "templated message",
+		MsgURN:    "whatsapp:250788123123",
+		MsgLocale: "eng",
+		MsgTemplating: `{
+			"template": {"uuid": "171f8a4d-f725-46d7-85a6-11aceff0bfe3", "name": "revive_issue"},
+			"components": [
+				{"type": "header/text", "name": "header", "variables": {"1": 0}},
+				{"type": "body/text", "name": "body", "variables": {"1": 1, "2": 2}}
+			],
+			"variables": [
+				{"type": "text", "value": "Welcome"},
+				{"type": "text", "value": "Chef"},
+				{"type": "text", "value": "tomorrow"}
+			],
+			"language": "en_US"
+		}`,
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Path: "/v1/messages",
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"text","text":"Welcome"}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:     "Template Send with button params",
+		MsgText:   "templated message",
+		MsgURN:    "whatsapp:250788123123",
+		MsgLocale: "eng",
+		MsgTemplating: `{
+			"template": {"uuid": "171f8a4d-f725-46d7-85a6-11aceff0bfe3", "name": "revive_issue"},
+			"components": [
+				{"name": "header", "type": "header/media", "variables": {"1": 0}},
+				{"name": "body", "type": "body/text", "variables": {"1": 1, "2": 2}},
+				{"name": "button.0", "type": "button/quick_reply", "variables": {"1": 3}},
+				{"name": "button.1", "type": "button/url", "variables": {"1": 4}}
+			],
+			"variables": [
+				{"type": "image", "value": "image/jpeg:https://foo.bar/image.jpg"},
+				{"type": "text", "value": "Ryan Lewis"},
+				{"type": "text", "value": "niño"},
+				{"type": "text", "value": "Sip"},
+				{"type": "text", "value": "id00231"}
+			],
+			"language": "en_US"
+		}`,
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Path: "/v1/messages",
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"image","image":{"link":"https://foo.bar/image.jpg"}}]},{"type":"body","parameters":[{"type":"text","text":"Ryan Lewis"},{"type":"text","text":"niño"}]},{"type":"button","sub_type":"quick_reply","index":"0","parameters":[{"type":"payload","payload":"Sip"}]},{"type":"button","sub_type":"url","index":"1","parameters":[{"type":"text","text":"id00231"}]}]}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Template Send ignores preview attachments and quick replies",
+		MsgText:         "This is a test image template message to check if Rapidpro",
+		MsgURN:          "whatsapp:250788123123",
+		MsgLocale:       "eng",
+		MsgAttachments:  []string{"image:https://foo.bar/image.jpg"},
+		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "Test"}, {Type: "text", Text: "Another test"}},
+		MsgTemplating: `{
+			"template": {"uuid": "171f8a4d-f725-46d7-85a6-11aceff0bfe3", "name": "test_image_rapidpro"},
+			"components": [
+				{"name": "header", "type": "header/media", "variables": {"1": 0}}
+			],
+			"variables": [
+				{"type": "image", "value": "image:https://foo.bar/image.jpg"}
+			],
+			"language": "en"
+		}`,
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Path: "/v1/messages",
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"test_image_rapidpro","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"image","image":{"link":"https://foo.bar/image.jpg"}}]}]}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:           "Interactive Button Message Send",
 		MsgText:         "Interactive Button Msg",
 		MsgURN:          "whatsapp:250788123123",


### PR DESCRIPTION
Fixes #1104

## Summary

The Turn handler only built `body` components when sending templated messages, so header (including media) and button parameters supplied by RapidPro via `MsgTemplating` were dropped. Media-header templates appeared to send successfully but reached contacts without their image/video/document.

- Reuse `whatsapp.GetTemplatePayload` so Turn emits `header` (text and `image`/`video`/`document` with `link`), `body`, and `button` (`quick_reply` payload / `url` text) components, matching the Cloud API handler.
- Replace the local `Param`/`Component` types (which could only encode `{type, text}`) with the shared `whatsapp` types, and drop the unused `LocalizableParam`.
- Build templated messages as a single template payload. Previously a templated message that also carried attachments took the attachment branch and the template was never sent at all — only the media and text. Preview attachments and button quick-replies that mailroom attaches alongside a template no longer produce extra image/interactive sends.

Turn's namespace resolution (`templating.Namespace`, falling back to the channel's `fb_namespace`) and language mapping via `getSupportedLanguage(msg.Locale())` are unchanged, so existing template behavior and tests are preserved.

Turn documents these component shapes under
[media templated messages](https://whatsapp.turn.io/docs/api/messages#media-templated-messages),
interactive templated messages, and authentication templated messages.

## Test plan

- [x] `go test ./handlers/turn/ ./handlers/meta/...`
- [x] Send an approved media-header template from a `TRN` channel and confirm the outbound request carries a `header` component with `image.link`, and that the contact receives the image
- [x] Confirm body-only templates are unchanged on the wire
- [x] Confirm a templated message that also has preview attachments/quick replies results in exactly one `/v1/messages` template request
- [x] Confirm a template whose header has no variables (serialized as `"parameters":null`, consistent with the Cloud API handler) is accepted by Turn