### PR TITLE
Treat HTTP 429 responses as throttling across all channel handlers

### DIFF
--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -151,10 +151,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	// was this request successful?

--- a/handlers/africastalking/handler_test.go
+++ b/handlers/africastalking/handler_test.go
@@ -170,6 +170,20 @@ var outgoingCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.africastalking.com/version1/messaging": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"message": {`Error Message`}, "username": {"Username"}, "to": {"+250788383383"}, "from": {"2020"}}},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 var sharedOutgoingCases = []OutgoingTestCase{

--- a/handlers/arabiacell/handler.go
+++ b/handlers/arabiacell/handler.go
@@ -84,10 +84,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Accept", "application/xml")
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		// parse our response as XML

--- a/handlers/arabiacell/handler_test.go
+++ b/handlers/arabiacell/handler_test.go
@@ -102,6 +102,17 @@ var outgoingCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrConnectionFailed,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://acsdp.arabiacell.net": {
+				httpx.NewMockResponse(429, nil, []byte(`Bad Gateway`)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -229,6 +229,9 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		if err != nil || resp.StatusCode/100 == 5 {
 			return courier.ErrConnectionFailed
 		}
+		if handlers.IsThrottled(resp) {
+			return courier.ErrConnectionThrottled
+		}
 
 		response := &mtResponse{}
 		if err = json.Unmarshal(respBody, response); err != nil {

--- a/handlers/bandwidth/handler_test.go
+++ b/handlers/bandwidth/handler_test.go
@@ -353,6 +353,27 @@ var outgoingCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrFailedWithReason("request-validation", "Your request could not be accepted"),
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+12067791234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://messaging.bandwidth.com/api/v2/users/accound-id/messages": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "type": "request-validation", "description": "Your request could not be accepted" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Headers: map[string]string{
+					"Content-Type":  "application/json",
+					"Accept":        "application/json",
+					"Authorization": "Basic dXNlcjE6cGFzczE=",
+				},
+				Body: `{"applicationId":"application-id","to":["+12067791234"],"from":"2020","text":"Error Message"}`,
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/burstsms/handler.go
+++ b/handlers/burstsms/handler.go
@@ -80,10 +80,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Accept", "application/json")
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		response := &mtResponse{}

--- a/handlers/burstsms/handler_test.go
+++ b/handlers/burstsms/handler_test.go
@@ -137,6 +137,26 @@ var outgoingCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrConnectionFailed,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.transmitsms.com/send-sms.json": {
+				httpx.NewMockResponse(429, nil, []byte(`Bad Gateway`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Form: url.Values{
+					"to":      {"250788383383"},
+					"message": {"Error Message"},
+					"from":    {"2020"},
+				},
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -178,10 +178,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Accept", "application/json")
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		// try to read out our message id, if we can't then this was a failure

--- a/handlers/clickatell/handler_test.go
+++ b/handlers/clickatell/handler_test.go
@@ -214,6 +214,20 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://platform.clickatell.com/messages/http/send*": {
+				httpx.NewMockResponse(429, nil, []byte(`Error`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Params: url.Values{"content": {"Error Message"}, "to": {"250788383383"}, "from": {"2020"}, "apiKey": {"API-KEY"}}},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Error Response",
 		MsgText: "Error Message",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/clickmobile/handler.go
+++ b/handlers/clickmobile/handler.go
@@ -139,10 +139,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Accept", "application/json")
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		responseCode, _ := jsonparser.GetString(respBody, "code")

--- a/handlers/clickmobile/handler_test.go
+++ b/handlers/clickmobile/handler_test.go
@@ -190,6 +190,23 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://example.com/send": {
+				httpx.NewMockResponse(429, nil, []byte(`{"code":"001","desc":"Database SQL Error"}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Headers: map[string]string{"Content-Type": "application/json"},
+				Body:    `{"app_id":"001-app","org_id":"001-org","user_id":"Username","timestamp":"20180411182430","auth_key":"3e1347ddb444d13aa23d11e097602be0","operation":"send","reference":"0191e180-7d60-7000-aded-7d8b151cbd5b","message_type":"1","src_address":"2020","dst_address":"+250788383383","message":"Error Message"}`,
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:          "Send Attachment",
 		MsgText:        "My pic!",
 		MsgURN:         "tel:+250788383383",

--- a/handlers/clicksend/handler.go
+++ b/handlers/clicksend/handler.go
@@ -86,10 +86,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.SetBasicAuth(username, password)
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		s, _ := jsonparser.GetString(respBody, "data", "messages", "[0]", "status")

--- a/handlers/clicksend/handler_test.go
+++ b/handlers/clicksend/handler_test.go
@@ -201,6 +201,23 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Sending",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://rest.clicksend.com/v3/sms/send": {
+				httpx.NewMockResponse(429, nil, []byte(`[{"Response": "101"}]`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Headers: map[string]string{"Authorization": "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="},
+				Body:    `{"messages":[{"to":"+250788383383","from":"2020","body":"Error Sending","source":"courier"}]}`,
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Failure Response",
 		MsgText: "Error Sending",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -183,10 +183,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		responseCode := stringsx.Truncate(string(respBody), 3)

--- a/handlers/dart/handler_test.go
+++ b/handlers/dart/handler_test.go
@@ -150,6 +150,20 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://202.43.169.11/APIhttpU/receive2waysms.php*": {
+				httpx.NewMockResponse(429, nil, []byte(`Error`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Params: url.Values{"message": {"Error Message"}, "sendto": {"250788383383"}, "original": {"2020"}, "userid": {"Username"}, "password": {"Password"}, "dcs": {"0"}, "udhl": {"0"}, "messageid": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}}},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Authentication Error",
 		MsgText: "Simple Message",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -365,6 +365,10 @@ func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event event
 		return courier.ErrConnectionFailed
 	}
 
+	if handlers.IsThrottled(resp) {
+		return courier.ErrConnectionThrottled
+	}
+
 	response := &struct {
 		Success bool `json:"success"`
 	}{}
@@ -391,6 +395,10 @@ func (h *handler) requestD3C(payload whatsapp.SendRequest, accessToken string, r
 	if err != nil || resp.StatusCode/100 == 5 {
 		return "", courier.ErrConnectionFailed
 	}
+	if handlers.IsThrottled(resp) {
+		return "", courier.ErrConnectionThrottled
+	}
+
 	respPayload := &whatsapp.SendResponse{}
 	err = json.Unmarshal(respBody, respPayload)
 	if err != nil {

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -982,6 +982,17 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		ExpectedError: courier.ErrConnectionThrottled,
 	},
 	{
+		Label:   "Error HTTP 429",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://waba-v2.360dialog.io/messages": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": {"message": "Calls to this api have exceeded the rate limit","code": 613 }}`)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Error Retryable",
 		MsgText: "Error",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -134,10 +134,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Authorization", fmt.Sprintf("Token %s", auth))
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		// grab the external id

--- a/handlers/dmark/handler_test.go
+++ b/handlers/dmark/handler_test.go
@@ -150,6 +150,26 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://smsapi1.dmarkmobile.com/sms/": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Authorization": "Token Authy"},
+			Form: url.Values{
+				"text":     {"Error Message"},
+				"receiver": {"250788383383"},
+				"sender":   {"2020"},
+				"dlr_url":  {"https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%s"},
+			},
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/errors.go
+++ b/handlers/errors.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/nyaruka/courier/v26"
+)
+
+// ErrorFromResponse converts the response and error from a send request into the send error that should be
+// returned to the sender, or nil if the response indicates success. Note that HTTP 429 is treated as throttling
+// for every channel type - it's a standard status code and no channel uses it to mean permanent failure.
+func ErrorFromResponse(resp *http.Response, err error) error {
+	if err != nil || resp.StatusCode/100 == 5 {
+		return courier.ErrConnectionFailed
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return courier.ErrConnectionThrottled
+	}
+	if resp.StatusCode/100 != 2 {
+		return courier.ErrResponseStatus
+	}
+	return nil
+}
+
+// IsThrottled returns whether the given response indicates that we're being rate limited. Handlers which need to
+// inspect the response body before deciding how to fail should use this to check the status code first.
+func IsThrottled(resp *http.Response) bool {
+	return resp != nil && resp.StatusCode == http.StatusTooManyRequests
+}

--- a/handlers/errors_test.go
+++ b/handlers/errors_test.go
@@ -1,0 +1,44 @@
+package handlers_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/nyaruka/courier/v26"
+	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorFromResponse(t *testing.T) {
+	tcs := []struct {
+		status      int
+		err         error
+		expectedErr error
+	}{
+		{200, nil, nil},
+		{201, nil, nil},
+		{400, nil, courier.ErrResponseStatus},
+		{401, nil, courier.ErrResponseStatus},
+		{429, nil, courier.ErrConnectionThrottled},
+		{500, nil, courier.ErrConnectionFailed},
+		{503, nil, courier.ErrConnectionFailed},
+		{0, errors.New("timeout"), courier.ErrConnectionFailed},
+	}
+
+	for _, tc := range tcs {
+		var resp *http.Response
+		if tc.err == nil {
+			resp = &http.Response{StatusCode: tc.status}
+		}
+
+		assert.Equal(t, tc.expectedErr, handlers.ErrorFromResponse(resp, tc.err), "mismatch for status %d", tc.status)
+	}
+}
+
+func TestIsThrottled(t *testing.T) {
+	assert.True(t, handlers.IsThrottled(&http.Response{StatusCode: 429}))
+	assert.False(t, handlers.IsThrottled(&http.Response{StatusCode: 200}))
+	assert.False(t, handlers.IsThrottled(&http.Response{StatusCode: 503}))
+	assert.False(t, handlers.IsThrottled(nil))
+}

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -380,10 +380,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 
 		resp, respBody, err := h.RequestHTTPProxied(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		if responseCheck != "" && !strings.Contains(string(respBody), responseCheck) {

--- a/handlers/external/handler_test.go
+++ b/handlers/external/handler_test.go
@@ -442,6 +442,25 @@ var getSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://example.com/send*": {
+				httpx.NewMockResponse(429, nil, []byte(`1: Unknown channel`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+			Params: url.Values{
+				"text": {`Error Message`},
+				"to":   {"+250788383383"},
+				"from": {"2020"},
+			},
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:          "Send Attachment",
 		MsgText:        "My pic!",
 		MsgURN:         "tel:+250788383383",

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -521,10 +521,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Accept", "application/json")
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		externalID, err := jsonparser.GetString(respBody, "message_id")

--- a/handlers/facebook_legacy/handler_test.go
+++ b/handlers/facebook_legacy/handler_test.go
@@ -962,6 +962,23 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error",
+		MsgURN:  "facebook:12345",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://graph.facebook.com/v3.3/me/messages*": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "is_error": true }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Params: url.Values{
+				"access_token": {"access_token"},
+			},
+			Body: `{"messaging_type":"NON_PROMOTIONAL_SUBSCRIPTION","recipient":{"id":"12345"},"message":{"text":"Error"}}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestSending(t *testing.T) {

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -234,10 +234,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		responseName, err := jsonparser.GetString(respBody, "name")

--- a/handlers/firebase/handler_test.go
+++ b/handlers/firebase/handler_test.go
@@ -244,6 +244,22 @@ var sendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrConnectionFailed,
 	},
 	{
+		Label:      "Throttled",
+		MsgText:    "Error",
+		MsgURN:     "fcm:250788123123",
+		MsgURNAuth: "auth1",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://fcm.googleapis.com/v1/projects/foo-project-id/messages:send": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": "error" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Authorization": "Bearer FCMToken"},
+			Body:    `{"message":{"data":{"type":"rapidpro","title":"FCMTitle","message":"Error","message_id":"0191e180-7d60-7000-aded-7d8b151cbd5b","session_status":""},"token":"auth1","android":{"priority":"high"}}}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:      "Response Unexpected",
 		MsgText:    "Simple Message",
 		MsgURN:     "fcm:250788123123",

--- a/handlers/freshchat/handler.go
+++ b/handlers/freshchat/handler.go
@@ -158,10 +158,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	req.Header.Set("Authorization", bearer)
 
 	resp, _, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	return nil

--- a/handlers/freshchat/handler_test.go
+++ b/handlers/freshchat/handler_test.go
@@ -139,6 +139,21 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error",
+		MsgURN:  "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.freshchat.com/v2/conversations": {
+				httpx.NewMockResponse(429, nil, []byte(``)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Content-Type": "application/json", "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ="},
+			Body:    `{"messages":[{"message_parts":[{"text":{"content":"Error"}}],"actor_id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606","actor_type":"agent"}],"channel_id":"0534f78-b6e9-4f79-8853-11cedfc1f35b","users":[{"id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606"}]}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Connection Error",
 		MsgText: "Error",
 		MsgURN:  "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606",

--- a/handlers/globe/handler.go
+++ b/handlers/globe/handler.go
@@ -151,10 +151,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Accept", "application/json")
 
 		resp, _, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/handlers/globe/handler_test.go
+++ b/handlers/globe/handler_test.go
@@ -218,6 +218,20 @@ var sendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Sending",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://devapi.globelabs.com.ph/smsmessaging/v1/outbound/2020/requests": {
+				httpx.NewMockResponse(429, nil, []byte(`[{"Response": "101"}]`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"address":"250788383383","message":"Error Sending","passphrase":"opensesame","app_id":"12345","app_secret":"mysecret"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Connection Error",
 		MsgText: "Error",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -163,10 +163,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 
 		resp, _, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 	}

--- a/handlers/highconnection/handler_test.go
+++ b/handlers/highconnection/handler_test.go
@@ -233,6 +233,17 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Sending",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://highpushfastapi-v2.hcnx.eu/api*": {
+				httpx.NewMockResponse(429, nil, []byte(``)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/hormuud/handler.go
+++ b/handlers/hormuud/handler.go
@@ -113,10 +113,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		// try to get the message id out
@@ -153,10 +151,8 @@ func (h *handler) FetchToken(ctx context.Context, channel courier.Channel, msg c
 	req.Header.Set("Accept", "application/json")
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil {
-		return "", courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return "", courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return "", err
 	}
 
 	token, err = jsonparser.GetString(respBody, "access_token")

--- a/handlers/hormuud/handler_test.go
+++ b/handlers/hormuud/handler_test.go
@@ -160,6 +160,25 @@ var sendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Sending",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://smsapi.hormuud.com/api/SendSMS": {
+				httpx.NewMockResponse(429, nil, []byte(`[{"Response": "101"}]`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{
+				"Content-Type":  "application/json",
+				"Accept":        "application/json",
+				"Authorization": "Bearer ghK_Wt4lshZhN",
+			},
+			Body: `{"mobile":"250788383383","message":"Error Sending","senderid":"2020","mType":-1,"eType":-1,"UDH":""}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Connection Error",
 		MsgText: "Error",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/i2sms/handler.go
+++ b/handlers/i2sms/handler.go
@@ -111,10 +111,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Accept", "application/json")
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		// parse our response as JSON

--- a/handlers/i2sms/handler_test.go
+++ b/handlers/i2sms/handler_test.go
@@ -129,6 +129,27 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrConnectionFailed,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://mx2.i2sms.net/mxapi.php": {
+				httpx.NewMockResponse(429, nil, []byte(`Bad Gateway`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Form: url.Values{
+					"action":  {"send_single"},
+					"mobile":  {"250788383383"},
+					"message": {"Error Message"},
+					"channel": {"hash123"},
+				},
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -379,10 +379,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	groupID, err := jsonparser.GetInt(respBody, "messages", "[0]", "status", "groupId")

--- a/handlers/infobip/handler_test.go
+++ b/handlers/infobip/handler_test.go
@@ -409,6 +409,25 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.infobip.com/sms/3/messages": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{
+				"Content-Type":  "application/json",
+				"Accept":        "application/json",
+				"Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
+			},
+			Body: `{"messages":[{"from":"2020","destinations":[{"to":"250788383383","messageId":"0191e180-7d60-7000-aded-7d8b151cbd5b"}],"content":{"text":"Error Message"},"webhooks":{"delivery":{"url":"https://localhost/c/ib/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered","intermediateReport":true,"contentType":"application/json"}}}]}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Error groupId",
 		MsgText: "Simple Message",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -185,10 +185,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	// try to read our external id out

--- a/handlers/jasmin/handler_test.go
+++ b/handlers/jasmin/handler_test.go
@@ -228,6 +228,32 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:           "Throttled",
+		MsgText:         "Error Message",
+		MsgURN:          "tel:+250788383383",
+		MsgHighPriority: false,
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://example.com/send*": {
+				httpx.NewMockResponse(429, nil, []byte(`Failed Sending`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Params: url.Values{
+				"content":    {"Error Message"},
+				"to":         {"250788383383"},
+				"from":       {"2020"},
+				"coding":     {"0"},
+				"dlr-level":  {"2"},
+				"dlr":        {"yes"},
+				"dlr-method": {http.MethodPost},
+				"username":   {"Username"},
+				"password":   {"Password"},
+				"dlr-url":    {"https://localhost/c/js/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status"},
+			},
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -187,10 +187,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 
 		resp, _, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 	}

--- a/handlers/jiochat/handler_test.go
+++ b/handlers/jiochat/handler_test.go
@@ -416,6 +416,17 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "jiochat:12345",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://channels.jiochat.com/custom/custom_send.action": {
+				httpx.NewMockResponse(429, nil, []byte(``)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func setupBackend(mb *test.MockBackend) {

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -189,10 +189,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	req.Header.Set("Authorization", fmt.Sprintf("%s:%s", apiKey, apiSecret))
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	respStatus, err := jsonparser.GetString(respBody, "status")

--- a/handlers/justcall/handler_test.go
+++ b/handlers/justcall/handler_test.go
@@ -364,6 +364,25 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.justcall.io/v1/texts/new": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "status": "fail" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{
+				"Content-Type":  "application/json",
+				"Accept":        "application/json",
+				"Authorization": "api_key:api_secret",
+			},
+			Body: `{"from":"2020","to":"+250788383383","body":"Error"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Error Connection",
 		MsgText: "Error",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -220,10 +220,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		kwaResp, kwaRespBody, kwaErr = h.RequestHTTP(req, clog)
 	}
 
-	if kwaErr != nil || kwaResp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if kwaResp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(kwaResp, kwaErr); err != nil {
+		return err
 	}
 
 	// record external id from the last sent msg request

--- a/handlers/kaleyra/handler_test.go
+++ b/handlers/kaleyra/handler_test.go
@@ -149,6 +149,21 @@ var sendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:14133881112",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.kaleyra.io/v1/SID/messages": {httpx.NewMockResponse(429, nil, []byte(`{"error":{"to":"invalid number"}}`))},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Headers: map[string]string{"Content-type": "application/x-www-form-urlencoded"},
+				Body:    "api-key=123456&body=Error&callback_url=https%3A%2F%2Flocalhost%2Fc%2Fkwa%2F8eb23e93-5ecb-45ba-b726-3b064e0c568c%2Fstatus&channel=WhatsApp&from=250788383383&to=14133881112&type=text",
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:          "Medias Send",
 		MsgText:        "Medias",
 		MsgAttachments: []string{"image/jpg:https://foo.bar/image.jpg", "image/png:https://foo.bar/video.mp4"},

--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -196,10 +196,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	}
 
 	resp, _, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	return nil

--- a/handlers/kannel/handler_test.go
+++ b/handlers/kannel/handler_test.go
@@ -252,6 +252,29 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:           "Throttled",
+		MsgText:         "Not Routable",
+		MsgURN:          "tel:+250788383383",
+		MsgHighPriority: false,
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://example.com/send*": {
+				httpx.NewMockResponse(429, nil, []byte(`Not routable. Do not try again.`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Params: url.Values{
+				"text":     {"Not Routable"},
+				"to":       {"+250788383383"},
+				"from":     {"2020"},
+				"dlr-mask": {"27"},
+				"dlr-url":  {"https://localhost/c/kn/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%d"},
+				"username": {"Username"},
+				"password": {"Password"},
+			},
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:           "Error Sending",
 		MsgText:         "Error Message",
 		MsgURN:          "tel:+250788383383",

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -324,11 +324,8 @@ func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event event
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
 
 	resp, _, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	}
-	if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	return nil
@@ -434,6 +431,11 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 				continue
 			}
 
+			// LINE rate limits per endpoint per channel with a 429, so retry rather than failing
+			if err == nil && handlers.IsThrottled(resp) {
+				return courier.ErrConnectionThrottled
+			}
+
 			respPayload := &mtResponse{}
 			err = json.Unmarshal(respBody, respPayload)
 			if err != nil {
@@ -448,6 +450,10 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 				}
 
 				resp, respBody, _ := h.RequestHTTP(req, clog)
+
+				if handlers.IsThrottled(resp) {
+					return courier.ErrConnectionThrottled
+				}
 
 				respPayload := &mtResponse{}
 				err = json.Unmarshal(respBody, respPayload)

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -431,8 +431,11 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 				continue
 			}
 
+			if err != nil || resp.StatusCode/100 == 5 {
+				return courier.ErrConnectionFailed
+			}
 			// LINE rate limits per endpoint per channel with a 429, so retry rather than failing
-			if err == nil && handlers.IsThrottled(resp) {
+			if handlers.IsThrottled(resp) {
 				return courier.ErrConnectionThrottled
 			}
 

--- a/handlers/line/handler_test.go
+++ b/handlers/line/handler_test.go
@@ -640,6 +640,20 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrFailedWithReason("403", "Failed to send messages"),
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Sending",
+		MsgURN:  "line:uabcdefghij",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.line.me/v2/bot/message/push": {httpx.NewMockResponse(429, nil, []byte(`{"message": "You have reached your monthly limit."}`))},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Body: `{"to":"uabcdefghij","messages":[{"type":"text","text":"Error Sending"}]}`,
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 // setupMedia takes care of having the media files needed to our test server host

--- a/handlers/line/handler_test.go
+++ b/handlers/line/handler_test.go
@@ -641,6 +641,20 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrFailedWithReason("403", "Failed to send messages"),
 	},
 	{
+		Label:   "Connection Error",
+		MsgText: "Error Sending",
+		MsgURN:  "line:uabcdefghij",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.line.me/v2/bot/message/push": {httpx.NewMockResponse(503, nil, []byte(`{"message": "Service unavailable"}`))},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Body: `{"to":"uabcdefghij","messages":[{"type":"text","text":"Error Sending"}]}`,
+			},
+		},
+		ExpectedError: courier.ErrConnectionFailed,
+	},
+	{
 		Label:   "Throttled",
 		MsgText: "Error Sending",
 		MsgURN:  "line:uabcdefghij",

--- a/handlers/m3tech/handler.go
+++ b/handlers/m3tech/handler.go
@@ -109,10 +109,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 
 		resp, _, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 	}
 

--- a/handlers/m3tech/handler_test.go
+++ b/handlers/m3tech/handler_test.go
@@ -158,6 +158,17 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Sending",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": {
+				httpx.NewMockResponse(429, nil, []byte(`[{"Response": "101"}]`)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/macrokiosk/handler.go
+++ b/handlers/macrokiosk/handler.go
@@ -190,10 +190,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Accept", "application/json")
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		externalID, err := jsonparser.GetString(respBody, "MsgID")

--- a/handlers/macrokiosk/handler_test.go
+++ b/handlers/macrokiosk/handler_test.go
@@ -173,6 +173,20 @@ var outgoingTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://www.etracker.cc/bulksms/send": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"user":"Username","pass":"Password","to":"250788383383","text":"Error Message","from":"macro","servid":"service-id","type":"0"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/mblox/handler.go
+++ b/handlers/mblox/handler.go
@@ -142,10 +142,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", password))
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		externalID, err := jsonparser.GetString(respBody, "id")

--- a/handlers/mblox/handler_test.go
+++ b/handlers/mblox/handler_test.go
@@ -221,6 +221,20 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.mblox.com/xms/v1/Username/batches": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"from":"2020","to":["250788383383"],"body":"Error Message","delivery_report":"per_recipient"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -243,10 +243,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	req.Header.Set("Authorization", bearer)
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	externalID, err := jsonparser.GetString(respBody, "id")

--- a/handlers/messagebird/handler_test.go
+++ b/handlers/messagebird/handler_test.go
@@ -319,6 +319,21 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Simple Message ☺",
+		MsgURN:  "tel:188885551515",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://rest.messagebird.com/messages": {
+				httpx.NewMockResponse(429, nil, []byte(validResponse)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Content-Type": "application/json", "Authorization": "AccessKey authtoken"},
+			Body:    `{"recipients":["188885551515"],"reference":"0191e180-7d60-7000-aded-7d8b151cbd5b","originator":"18005551212","body":"Simple Message ☺"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/messangi/handler.go
+++ b/handlers/messangi/handler.go
@@ -84,10 +84,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		// parse our response as XML

--- a/handlers/messangi/handler_test.go
+++ b/handlers/messangi/handler_test.go
@@ -101,6 +101,20 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Invalid Parameters",
+		MsgURN:  "tel:+18765422035",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://flow.messangi.me/mmc/rest/api/sendMT/*": {
+				httpx.NewMockResponse(429, nil, []byte(``)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Path: "/mmc/rest/api/sendMT/7/2020/2/18765422035/SW52YWxpZCBQYXJhbWV0ZXJz/my-public-key/f3d2ea825cf61226925dee2db3c14b7fc00f3183f11809d2183d1e2dbd230df6",
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Error Response",
 		MsgText: "Error Response",
 		MsgURN:  "tel:+18765422035",

--- a/handlers/meta/facebook_test.go
+++ b/handlers/meta/facebook_test.go
@@ -556,6 +556,17 @@ var facebookOutgoingTests = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error",
+		MsgURN:  "facebook:12345",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://graph.facebook.com/v25.0/me/messages*": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "is_error": true }`)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Response is invalid JSON",
 		MsgText: "Error",
 		MsgURN:  "facebook:12345",

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -669,10 +669,8 @@ func (h *handler) sendFacebookInstagramMsg(ctx context.Context, msg courier.MsgO
 		req.Header.Set("Accept", "application/json")
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		respPayload := &messenger.SendResponse{}
@@ -801,6 +799,10 @@ func (h *handler) sendFacebookInstagramEvent(ctx context.Context, ch courier.Cha
 		return courier.ErrConnectionFailed
 	}
 
+	if handlers.IsThrottled(resp) {
+		return courier.ErrConnectionThrottled
+	}
+
 	respPayload := &messenger.SendResponse{}
 	if err := json.Unmarshal(respBody, respPayload); err != nil || resp.StatusCode/100 != 2 || respPayload.Error.Code != 0 {
 		return courier.ErrResponseStatus
@@ -840,6 +842,10 @@ func (h *handler) sendWhatsAppEvent(ctx context.Context, ch courier.Channel, eve
 		return courier.ErrConnectionFailed
 	}
 
+	if handlers.IsThrottled(resp) {
+		return courier.ErrConnectionThrottled
+	}
+
 	response := &struct {
 		Success bool `json:"success"`
 	}{}
@@ -865,6 +871,10 @@ func (h *handler) requestWAC(payload whatsapp.SendRequest, accessToken string, r
 	resp, respBody, err := h.RequestHTTP(req, clog)
 	if err != nil || resp.StatusCode/100 == 5 {
 		return "", courier.ErrConnectionFailed
+	}
+	// Graph API rate limiting is reported as a 429, sometimes with an error code we don't know about
+	if handlers.IsThrottled(resp) {
+		return "", courier.ErrConnectionThrottled
 	}
 
 	respPayload := &whatsapp.SendResponse{}

--- a/handlers/meta/instagram_test.go
+++ b/handlers/meta/instagram_test.go
@@ -367,6 +367,17 @@ var instagramOutgoingTests = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error",
+		MsgURN:  "instagram:12345",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://graph.facebook.com/v25.0/me/messages*": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "is_error": true }`)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Response is invalid JSON",
 		MsgText: "Error",
 		MsgURN:  "instagram:12345",

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -1110,6 +1110,17 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedError: courier.ErrConnectionThrottled,
 	},
 	{
+		Label:   "Error HTTP 429",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": {"message": "Calls to this api have exceeded the rate limit","code": 613 }}`)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Error Retryable",
 		MsgText: "Error",
 		MsgURN:  "whatsapp:250788123123",

--- a/handlers/mtarget/handler.go
+++ b/handlers/mtarget/handler.go
@@ -175,10 +175,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		// parse our response for our status code and ticket (external id)

--- a/handlers/mtarget/handler_test.go
+++ b/handlers/mtarget/handler_test.go
@@ -174,6 +174,17 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Sending",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api-public.mtarget.fr/api-sms.json*": {
+				httpx.NewMockResponse(429, nil, []byte(`{"results":[{"code": "3", "reason": "FAILED", "ticket": "null"}]}`)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Error Response",
 		MsgText: "Error Sending",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/mtn/handler.go
+++ b/handlers/mtn/handler.go
@@ -153,10 +153,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	externalID, err := jsonparser.GetString(respBody, "transactionId")

--- a/handlers/mtn/handler_test.go
+++ b/handlers/mtn/handler_test.go
@@ -230,6 +230,20 @@ var outgoingCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.mtn.com/v2/messages/sms/outbound": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"senderAddress":"2020","receiverAddress":["250788383383"],"message":"Error Message","clientCorrelator":"0191e180-7d60-7000-aded-7d8b151cbd5b"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 var cpAddressOutgoingCases = []OutgoingTestCase{

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -222,10 +222,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 			}
 		}
 
-		if requestErr != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, requestErr); err != nil {
+			return err
 		}
 
 		nexmoStatus, err := jsonparser.GetString(respBody, "messages", "[0]", "status")

--- a/handlers/nexmo/handler_test.go
+++ b/handlers/nexmo/handler_test.go
@@ -212,6 +212,20 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://rest.nexmo.com/sms/json": {
+				httpx.NewMockResponse(429, nil, []byte(`Error`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Form: url.Values{"text": {"Error Message"}, "to": {"250788383383"}, "from": {"2020"}, "api_key": {"nexmo-api-key"}, "api_secret": {"nexmo-api-secret"}, "status-report-req": {"1"}, "type": {"text"}, "callback": {"https://localhost/c/nx/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status"}},
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Invalid Token",
 		MsgText: "Simple Message",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/novo/handler.go
+++ b/handlers/novo/handler.go
@@ -106,10 +106,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		}
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		responseMsgStatus, err := jsonparser.GetString(respBody, "status")

--- a/handlers/novo/handler_test.go
+++ b/handlers/novo/handler_test.go
@@ -132,6 +132,20 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Response",
+		MsgURN:  "tel:+18686846481",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": {
+				httpx.NewMockResponse(429, nil, []byte(`{"error": "Incorrect Query String Authentication ","expectedQueryString": "8868;18686846480;test;"}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Params: url.Values{"from": {"2020"}, "to": {"18686846481"}, "msg": {"Error Response"}, "signature": {"9fe49f073109de29f8c6d5108fd5719ee0b70c22cedb23fffdbabc8a99b9a0a9"}},
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/playmobile/handler.go
+++ b/handlers/playmobile/handler.go
@@ -181,10 +181,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Accept", "application/json")
 
 		resp, _, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/handlers/playmobile/handler_test.go
+++ b/handlers/playmobile/handler_test.go
@@ -182,6 +182,17 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Sending",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://example.com/broker-api/send": {
+				httpx.NewMockResponse(429, nil, []byte(`not json`)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -171,10 +171,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.SetBasicAuth(authID, authToken)
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		externalID, err := jsonparser.GetString(respBody, "message_uuid", "[0]")

--- a/handlers/plivo/handler_test.go
+++ b/handlers/plivo/handler_test.go
@@ -163,6 +163,19 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{Label: "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.plivo.com/v1/Account/AuthID/Message/": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"src":"2020","dst":"250788383383","text":"Error Message","url":"https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status","method":"POST"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func TestOutgoing(t *testing.T) {

--- a/handlers/rocketchat/handler.go
+++ b/handlers/rocketchat/handler.go
@@ -133,10 +133,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	req.Header.Set("Authorization", fmt.Sprintf("Token %s", secret))
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	msgID, err := jsonparser.GetString(respBody, "id")

--- a/handlers/rocketchat/handler_test.go
+++ b/handlers/rocketchat/handler_test.go
@@ -161,6 +161,20 @@ var sendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Simple Message",
+		MsgURN:  "rocketchat:direct:john.doe#john.doe",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": {
+				httpx.NewMockResponse(429, nil, []byte(`Error`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"user":"direct:john.doe","bot":"rocket.cat","text":"Simple Message"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Connection Error",
 		MsgText: "Simple Message",
 		MsgURN:  "rocketchat:direct:john.doe#john.doe",

--- a/handlers/slack/handler.go
+++ b/handlers/slack/handler.go
@@ -198,10 +198,8 @@ func (h *handler) sendTextMsgPart(msg courier.MsgOut, token string, clog *courie
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 != 2 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	ok, err := jsonparser.GetBoolean(respBody, "ok")
@@ -273,10 +271,8 @@ func (h *handler) sendFilePart(msg courier.MsgOut, token string, fileParams *Fil
 	req.Header.Add("Content-Type", writer.FormDataContentType())
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 != 2 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	var fr FileResponse

--- a/handlers/slack/handler_test.go
+++ b/handlers/slack/handler_test.go
@@ -217,6 +217,20 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedLogErrors: []*clogs.Error{&clogs.Error{Message: "invalid_auth"}},
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Hello",
+		MsgURN:  "slack:U0123ABCDEF",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/chat.postMessage": {
+				httpx.NewMockResponse(429, nil, []byte(`{"ok":false,"error":"ratelimited"}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"channel":"U0123ABCDEF","text":"Hello"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Response Unexpected",
 		MsgText: "Simple Message",
 		MsgURN:  "slack:U0123ABCDEF",

--- a/handlers/smscentral/handler.go
+++ b/handlers/smscentral/handler.go
@@ -85,10 +85,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, _, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	return nil

--- a/handlers/smscentral/handler_test.go
+++ b/handlers/smscentral/handler_test.go
@@ -114,6 +114,18 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{Label: "Throttled",
+		MsgText: "Error Message", MsgURN: "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://smail.smscentral.com.np/bp/ApiSms.php": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Form: url.Values{"content": {`Error Message`}, "mobile": {"250788383383"}, "pass": {"Password"}, "user": {"Username"}},
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 	{Label: "Connection Error",
 		MsgText: "Error Message", MsgURN: "tel:+250788383383",
 		MockResponses: map[string][]*httpx.MockResponse{

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -162,10 +162,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.SetBasicAuth(username, password)
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		response := &mtResponse{}

--- a/handlers/start/handler_test.go
+++ b/handlers/start/handler_test.go
@@ -257,6 +257,24 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://bulk.startmobile.ua/clients.php": {
+				httpx.NewMockResponse(429, nil, []byte(`Error`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{
+				"Content-Type":  "application/xml; charset=utf8",
+				"Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
+			},
+			Body: `<message><service id="single" source="2020" validity="+12 hours"></service><to>+250788383383</to><body content-type="plain/text" encoding="plain">Error Message</body></message>`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Response Unexpected",
 		MsgText: "Simple Message ☺",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -204,6 +204,10 @@ func (h *handler) sendMsgPart(msg courier.MsgOut, token, path string, form url.V
 	if err != nil || resp.StatusCode/100 == 5 {
 		return "", courier.ErrConnectionFailed
 	}
+	// Telegram rate limits with a 429 and a retry_after parameter, so retry rather than failing
+	if handlers.IsThrottled(resp) {
+		return "", courier.ErrConnectionThrottled
+	}
 
 	response := &mtResponse{}
 	err = json.Unmarshal(respBody, response)
@@ -378,6 +382,9 @@ func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event event
 	resp, respBody, err := h.RequestHTTP(req, clog)
 	if err != nil || resp.StatusCode/100 == 5 {
 		return courier.ErrConnectionFailed
+	}
+	if handlers.IsThrottled(resp) {
+		return courier.ErrConnectionThrottled
 	}
 
 	response := &struct {

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -1123,6 +1123,20 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrFailedWithReason("400", "Bot domain invalid."),
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error",
+		MsgURN:  "telegram:12345",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/botauth_token/sendMessage": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "ok": false, "error_code":429, "description":"Too Many Requests: retry after 30", "parameters": {"retry_after": 30} }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{Form: url.Values{"text": {"Error"}, "chat_id": {"12345"}, "parse_mode": []string{"Markdown"}, "reply_markup": {`{"remove_keyboard":true}`}}},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Stopped Contact Code",
 		MsgText: "Stopped Contact",
 		MsgURN:  "telegram:12345",

--- a/handlers/telesom/handler.go
+++ b/handlers/telesom/handler.go
@@ -102,10 +102,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		if !strings.Contains(string(respBody), "Success") {

--- a/handlers/telesom/handler_test.go
+++ b/handlers/telesom/handler_test.go
@@ -126,6 +126,21 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+252788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://telesom.com/sendsms_other*": {
+				httpx.NewMockResponse(429, nil, []byte(`<return>error</return>`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Form:    url.Values{"msg": {`Error Message`}, "to": {"0788383383"}, "from": {"2020"}, "key": {"3F1E492B2186551570F24C2F07D5D7E2"}},
+			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:          "Send Attachment",
 		MsgText:        "My pic!",
 		MsgURN:         "tel:+252788383383",

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -164,10 +164,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.SetBasicAuth(tokenUser, token)
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		// try to get our external id
@@ -198,10 +196,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 			req.SetBasicAuth(tokenUser, token)
 
 			resp, respBody, err := h.RequestHTTP(req, clog)
-			if err != nil || resp.StatusCode/100 == 5 {
-				return courier.ErrConnectionFailed
-			} else if resp.StatusCode/100 != 2 {
-				return courier.ErrResponseStatus
+			if err := handlers.ErrorFromResponse(resp, err); err != nil {
+				return err
 			}
 
 			// get our external id

--- a/handlers/thinq/handler_test.go
+++ b/handlers/thinq/handler_test.go
@@ -174,6 +174,20 @@ var sendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+12067791234",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.thinq.com/account/1234/product/origination/sms/send": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"from_did":"2065551212","to_did":"2067791234","message":"Error Message"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Connection Error",
 		MsgText: "Error Message",
 		MsgURN:  "tel:+12067791234",

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -998,7 +998,7 @@ func (h *handler) makeAPIRequest(payload any, accessToken string, res *courier.S
 	// Turn returns HTTP 429 with its own rate-limit payload (errors[].code=429) and
 	// Retry-After / X-Ratelimit-* headers. Treat that as throttled so the message is
 	// retried via the errored queue rather than permanently failed.
-	if resp.StatusCode == http.StatusTooManyRequests {
+	if handlers.IsThrottled(resp) {
 		return courier.ErrConnectionThrottled
 	}
 

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -313,6 +313,10 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		if err != nil || resp.StatusCode/100 == 5 {
 			return courier.ErrConnectionFailed
 		}
+		// Twilio rate limits with a 429 (error 20429) and those requests aren't processed, so retry
+		if handlers.IsThrottled(resp) {
+			return courier.ErrConnectionThrottled
+		}
 
 		// see if we can parse the error if we have one
 		if resp.StatusCode/100 != 2 && len(respBody) > 0 {
@@ -402,6 +406,10 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 			if err != nil || resp.StatusCode/100 == 5 {
 				return courier.ErrConnectionFailed
 			}
+			// Twilio rate limits with a 429 (error 20429) and those requests aren't processed, so retry
+			if handlers.IsThrottled(resp) {
+				return courier.ErrConnectionThrottled
+			}
 
 			// see if we can parse the error if we have one
 			if resp.StatusCode/100 != 2 && len(respBody) > 0 {
@@ -480,6 +488,10 @@ func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event event
 	resp, respBody, err := h.RequestHTTP(req, clog)
 	if err != nil || resp.StatusCode/100 == 5 {
 		return courier.ErrConnectionFailed
+	}
+
+	if handlers.IsThrottled(resp) {
+		return courier.ErrConnectionThrottled
 	}
 
 	response := &struct {

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -625,6 +625,20 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.twilio.com/2010-04-01/Accounts/accountSID/Messages.json": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "code": 20429, "message": "Too Many Requests" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Form: url.Values{"Body": {"Error Message"}, "To": {"+250788383383"}, "From": {"2020"}, "StatusCallback": {"https://localhost/c/t/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&action=callback"}},
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Error Code",
 		MsgText: "Error Code",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -436,10 +436,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		req.Header.Set("Accept", "application/json")
 
 		resp, respBody, err := h.RequestHTTP(req, clog)
-		if err != nil || resp.StatusCode/100 == 5 {
-			return courier.ErrConnectionFailed
-		} else if resp.StatusCode/100 != 2 {
-			return courier.ErrResponseStatus
+		if err := handlers.ErrorFromResponse(resp, err); err != nil {
+			return err
 		}
 
 		respPayload := &mtResponse{}

--- a/handlers/viber/handler_test.go
+++ b/handlers/viber/handler_test.go
@@ -351,6 +351,21 @@ var defaultSendTestCases = []OutgoingTestCase{
 		}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "viber:xy5/5y6O81+/kbWHpLhBoA==",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://chatapi.viber.com/pa/send_message": {
+				httpx.NewMockResponse(429, nil, []byte(`{"status":"5"}`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Headers: map[string]string{"Content-Type": "application/json", "Accept": "application/json"},
+			Body:    `{"auth_token":"Token","receiver":"xy5/5y6O81+/kbWHpLhBoA==","text":"Error Message","type":"text","tracking_data":"0191e180-7d60-7000-aded-7d8b151cbd5b"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 var invalidTokenSendTestCases = []OutgoingTestCase{

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -411,11 +411,8 @@ func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event event
 	req.URL.RawQuery = params.Encode()
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	}
-	if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	// VK reports errors in a 200 response, success is {"response": 1}
@@ -450,10 +447,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	req.URL.RawQuery = params.Encode()
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	externalMsgId, err := jsonparser.GetInt(respBody, responseOutgoingMessageKey)

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -608,6 +608,22 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrConnectionFailed,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Simple message",
+		MsgURN:  "vk:123456789",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.vk.com/method/messages.send.json?*": {
+				httpx.NewMockResponse(429, nil, []byte(`Bad Gateway`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{
+			{
+				Params: url.Values{"access_token": {"token123xyz"}, "attachment": {""}, "message": {"Simple message"}, "random_id": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}, "user_id": {"123456789"}, "v": {"5.103"}},
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Response unexpected",
 		MsgText: "Simple message",
 		MsgURN:  "vk:123456789",

--- a/handlers/wavy/handler.go
+++ b/handlers/wavy/handler.go
@@ -145,10 +145,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	req.Header.Set("authenticationtoken", token)
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	externalID, _ := jsonparser.GetString(respBody, "id")

--- a/handlers/wavy/handler_test.go
+++ b/handlers/wavy/handler_test.go
@@ -198,6 +198,20 @@ var outgoingCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Response",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api-messaging.movile.com/v1/send-sms": {
+				httpx.NewMockResponse(429, nil, []byte(`Error`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"destination":"250788383383","messageText":"Error Response"}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Error Sending",
 		MsgText: "Error Message",
 		MsgURN:  "tel:+250788383383",

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -397,7 +397,7 @@ func (h *handler) fetchAccessToken(channel courier.Channel, clog *courier.Channe
 	req.Header.Set("Accept", "application/json")
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 != 2 {
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
 		return "", 0, err
 	}
 

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -212,6 +212,9 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 		if err != nil || resp.StatusCode/100 == 5 {
 			return courier.ErrConnectionFailed
 		}
+		if handlers.IsThrottled(resp) {
+			return courier.ErrConnectionThrottled
+		}
 	}
 
 	return nil
@@ -270,11 +273,8 @@ func (h *handler) SendEvent(ctx context.Context, ch courier.Channel, event event
 	req.Header.Set("Accept", "application/json")
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	}
-	if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	// WeChat reports errors in a 200 response, success is errcode 0

--- a/handlers/wechat/handler_test.go
+++ b/handlers/wechat/handler_test.go
@@ -289,6 +289,32 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	assert.Len(t, clog.HttpLogs, 1)
 }
 
+func TestFetchAccessTokenThrottled(t *testing.T) {
+	mb := test.NewMockBackend()
+
+	// reset send URL
+	sendURL = "https://api.weixin.qq.com/cgi-bin"
+
+	// ensure that we start with no cached token
+	rc := mb.RedisPool().Get()
+	defer rc.Close()
+	rc.Do("DEL", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab")
+
+	s := newServer(mb)
+	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"https://api.weixin.qq.com/cgi-bin/token?appid=app-id&grant_type=client_credential&secret=app-secret123": {
+			httpx.NewMockResponse(429, nil, []byte(`{"errcode": 45009, "errmsg": "reach max api daily quota limit"}`)),
+		},
+	})
+	handler := newHandler().(*handler)
+	handler.Initialize(s)
+	clog := courier.NewChannelLog(courier.ChannelLogTypeUnknown, testChannels[0], handler.RedactValues(testChannels[0]))
+
+	// a rate limited token fetch is throttling rather than an empty token
+	_, _, err := handler.fetchAccessToken(testChannels[0], clog)
+	assert.Equal(t, courier.ErrConnectionThrottled, err)
+}
+
 var defaultSendTestCases = []OutgoingTestCase{
 	{
 		Label:   "Plain Send",

--- a/handlers/wechat/handler_test.go
+++ b/handlers/wechat/handler_test.go
@@ -373,6 +373,17 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedError: courier.ErrConnectionFailed,
 	},
+	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "wechat:12345",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.weixin.qq.com/cgi-bin/message/custom/send*": {
+				httpx.NewMockResponse(429, nil, []byte(`Error`)),
+			},
+		},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 }
 
 func setupBackend(mb *test.MockBackend) {

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -125,10 +125,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 			resp, respBody, err := h.RequestHTTP(req, clog)
-			if err != nil || resp.StatusCode/100 == 5 {
-				return courier.ErrConnectionFailed
-			} else if resp.StatusCode/100 != 2 {
-				return courier.ErrResponseStatus
+			if err := handlers.ErrorFromResponse(resp, err); err != nil {
+				return err
 			}
 
 			responseQS, _ := url.ParseQuery(string(respBody))

--- a/handlers/yo/handler_test.go
+++ b/handlers/yo/handler_test.go
@@ -120,6 +120,21 @@ var getSendTestCases = []OutgoingTestCase{
 		}}},
 		ExpectedError: courier.ErrResponseStatus,
 	},
+	{Label: "Throttled",
+		MsgText: "Error Message", MsgURN: "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"http://smgw1.yo.co.ug:9100/sendsms*": {
+				httpx.NewMockResponse(429, nil, []byte(`Error`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{Params: url.Values{"sms_content": {"Error Message"},
+			"destinations": {"250788383383"},
+			"ybsacctno":    {"yo-username"},
+			"password":     {"yo-password"},
+			"origin":       {"2020"},
+		}}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
 	{Label: "Connection error",
 		MsgText: "Error Message", MsgURN: "tel:+250788383383",
 		MockResponses: map[string][]*httpx.MockResponse{

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -235,10 +235,8 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	req.Header.Set("X-API-TOKEN", token)
 
 	resp, respBody, err := h.RequestHTTP(req, clog)
-	if err != nil || resp.StatusCode/100 == 5 {
-		return courier.ErrConnectionFailed
-	} else if resp.StatusCode/100 != 2 {
-		return courier.ErrResponseStatus
+	if err := handlers.ErrorFromResponse(resp, err); err != nil {
+		return err
 	}
 
 	externalID, err := jsonparser.GetString(respBody, "id")

--- a/handlers/zenvia/handlers_test.go
+++ b/handlers/zenvia/handlers_test.go
@@ -332,6 +332,20 @@ var defaultWhatsappSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrResponseStatus,
 	},
 	{
+		Label:   "Throttled",
+		MsgText: "Error Message",
+		MsgURN:  "tel:+250788383383",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"https://api.zenvia.com/v2/channels/whatsapp/messages": {
+				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"from":"2020","to":"250788383383","contents":[{"type":"text","text":"Error Message"}]}`,
+		}},
+		ExpectedError: courier.ErrConnectionThrottled,
+	},
+	{
 		Label:   "Connection Error",
 		MsgText: "Error Message",
 		MsgURN:  "tel:+250788383383",


### PR DESCRIPTION
Follow-up to #1103, which fixed HTTP 429 handling for one channel type. Auditing the rest of the handlers showed that channel was the only one checking for it.

## Problem

Nearly every handler used this shape in its send path:

```go
resp, respBody, err := h.RequestHTTP(req, clog)
if err != nil || resp.StatusCode/100 == 5 {
    return courier.ErrConnectionFailed   // retryable
} else if resp.StatusCode/100 != 2 {
    return courier.ErrResponseStatus     // NOT retryable
}
```

`ErrResponseStatus` is `retryable: false`, so a 429 from a channel permanently failed the message on the first attempt rather than going onto the errored queue to be retried. That affected around 50 send paths.

Three handlers did detect throttling, but only from response body error codes, never from the status line - so a 429 carrying an unrecognised or empty body still failed permanently. The Twilio-compatible handler looked like a fourth, but its rate-limit error code is only handled on the inbound status callback; on the send path a 429 became a non-retryable `ErrFailedWithReason`.

## Change

Adds `handlers.ErrorFromResponse(resp, err)`, which converts a send response and request error into the appropriate send error and treats 429 as throttled. Handlers that decided purely from the status line now call it, replacing the repeated block above.

Handlers that parse the response body before deciding - so they can report stopped contacts and channel specific error codes - can't use the full mapping without shadowing those cases, so they check `handlers.IsThrottled(resp)` after the 5xx check and before parsing. That's the pattern #1103 introduced; that handler now calls the helper rather than open-coding the comparison.

429 is a standard status code and no channel uses it to mean permanent failure, so retrying is safe everywhere. Retries stay bounded by the errored queue.

## Transient failures fixed beyond the mechanical sweep

Four paths turned a transient failure into a permanent one and weren't reachable by the status-line replacement:

- **LINE batched send** - the main send path is separate from the one the sweep covered. A 429 became `ErrFailedWithReason("429", ...)`; a connection error fell through to `json.Unmarshal` on an empty body and became `ErrResponseUnparseable`; a 5xx became `ErrFailedWithReason`. All three are non-retryable, so a LINE outage dropped messages. Now guarded with `ErrConnectionFailed` and the throttle check, matching `SendEvent` alongside it. The invalid-reply-token retry branch below it got the same throttle check.
- **Hormuud token fetch** - a 429 failed the message permanently before the send was attempted. Now routes through the helper. This also makes a 5xx there retryable, where it previously returned `ErrResponseStatus`.
- **WeChat token fetch** - returned a nil error on any non-2xx, so the caller reported a misleading `"error updating cached access token"` instead of the rate limit. Now routes through the helper.

## Reviewer notes

One behaviour change beyond transient failures: the Slack handler had a dead `else if resp.StatusCode/100 != 2` branch - unreachable, because the preceding condition already caught it - which meant every 4xx returned the retryable `ErrConnectionFailed`. Routing through the helper makes 4xx non-retryable as that dead branch clearly intended. No test covered it either way.

The only handler left without 429 handling is the legacy WhatsApp one, whose `Send` is disabled and returns unconditionally. The remaining `StatusCode/100 != 2` sites in kaleyra/mtn/viber/jiochat/facebook_legacy are auxiliary paths - media download, contact and token lookups - not channel send paths.

## Test plan

- Table test for `ErrorFromResponse` / `IsThrottled`, covering 2xx, 4xx, 429, 5xx, transport error and a nil response.
- A `Throttled` outgoing case in 52 handler test files asserting `ErrConnectionThrottled` on a 429. The four highest-traffic ones use realistic payloads rather than generic ones.
- The two WhatsApp Cloud API handlers get an explicit HTTP-429 case carrying a Graph rate-limit code absent from the known throttling code list, covering what the body-only check misses.
- LINE gains a 503 case for the batched path; WeChat gains a token-fetch throttling test.

Full suite green locally and in CI.