### PR TITLE
Fail Turn sends when media can't be uploaded instead of falling back to a link

### DIFF
--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -444,9 +444,9 @@ type mtButton struct {
 	} `json:"reply" validate:"required"`
 }
 
+// media messages reference media by the id returned from /v1/media - they can't carry a link
 type mediaObject struct {
 	ID       string `json:"id,omitempty"`
-	Link     string `json:"link,omitempty"`
 	Caption  string `json:"caption,omitempty"`
 	Filename string `json:"filename,omitempty"`
 }
@@ -546,11 +546,14 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *mo
 			if err != nil {
 				slog.Error("error while uploading media to whatsapp", "error", err, "channel_uuid", msg.Channel().UUID())
 			}
-			fileURL := mediaURL
-			if err == nil && mediaID != "" {
-				mediaURL = ""
+
+			// media messages must reference media uploaded to /v1/media by id - unlike template headers and
+			// interactive headers, they can't carry a link, so without an id there's no request worth making
+			if mediaID == "" {
+				return nil, courier.ErrRetryableWithReason("media_upload_failed", "unable to upload media to WhatsApp")
 			}
-			mediaPayload := &mediaObject{ID: mediaID, Link: mediaURL}
+
+			mediaPayload := &mediaObject{ID: mediaID}
 			if strings.HasPrefix(mimeType, "audio") {
 				payload := mtAudioPayload{
 					recipient: rcpt,
@@ -567,7 +570,7 @@ func buildPayloads(ctx context.Context, msg courier.MsgOut, h *handler, clog *mo
 					mediaPayload.Caption = msg.Text()
 					textAsCaption = true
 				}
-				mediaPayload.Filename, err = utils.BasePathForURL(fileURL)
+				mediaPayload.Filename, err = utils.BasePathForURL(mediaURL)
 
 				// Logging error
 				if err != nil {
@@ -903,8 +906,6 @@ func (h *handler) Send(ctx context.Context, msg courier.MsgOut, res *courier.Sen
 	sendURL, _ := url.Parse("/v1/messages")
 
 	requestPayloads, err := buildPayloads(ctx, msg, h, clog)
-
-	//requestPayloads, err := whatsapp.GetMsgPayloads(ctx, msg, maxMsgLength, clog)
 	if err != nil {
 		return err
 	}

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -1330,15 +1330,23 @@ var defaultSendTestCases = []OutgoingTestCase{
 		MsgText:         "Interactive Button Msg",
 		MsgURN:          "whatsapp:250788123123",
 		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "BUTTON1"}},
-		MsgAttachments:  []string{"image/jpeg:https://foo.bar/image.jpg"},
+		MsgAttachments:  []string{"image/jpeg:https://foo.bar/image2.jpg"},
 		MockResponses: map[string][]*httpx.MockResponse{
+			"https://foo.bar/image2.jpg": {
+				httpx.NewMockResponse(200, nil, []byte(`data`)),
+			},
+			"*/v1/media": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "media" : [{"id": "5f6a7b8c-1283-4b94-988d-7276bdec4de2"}] }`)),
+			},
 			"*/v1/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Body: `{"to":"250788123123","type":"image","image":{"id":"3d4e5f6a-1283-4b94-988d-7276bdec4de2"}}`},
+			{},
+			{},
+			{Body: `{"to":"250788123123","type":"image","image":{"id":"5f6a7b8c-1283-4b94-988d-7276bdec4de2"}}`},
 			{Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"button","body":{"text":"Interactive Button Msg"},"action":{"buttons":[{"type":"reply","reply":{"id":"0","title":"BUTTON1"}}]}}}`},
 		},
 		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
@@ -1348,15 +1356,23 @@ var defaultSendTestCases = []OutgoingTestCase{
 		MsgText:         "Interactive List Msg",
 		MsgURN:          "whatsapp:250788123123",
 		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "ROW1"}, {Type: "text", Text: "ROW2"}, {Type: "text", Text: "ROW3"}, {Type: "text", Text: "ROW4"}},
-		MsgAttachments:  []string{"image/jpeg:https://foo.bar/image.jpg"},
+		MsgAttachments:  []string{"image/jpeg:https://foo.bar/image3.jpg"},
 		MockResponses: map[string][]*httpx.MockResponse{
+			"https://foo.bar/image3.jpg": {
+				httpx.NewMockResponse(200, nil, []byte(`data`)),
+			},
+			"*/v1/media": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "media" : [{"id": "6a7b8c9d-1283-4b94-988d-7276bdec4de2"}] }`)),
+			},
 			"*/v1/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Body: `{"to":"250788123123","type":"image","image":{"id":"3d4e5f6a-1283-4b94-988d-7276bdec4de2"}}`},
+			{},
+			{},
+			{Body: `{"to":"250788123123","type":"image","image":{"id":"6a7b8c9d-1283-4b94-988d-7276bdec4de2"}}`},
 			{Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"list","body":{"text":"Interactive List Msg"},"action":{"button":"Menu","sections":[{"rows":[{"id":"0","title":"ROW1"},{"id":"1","title":"ROW2"},{"id":"2","title":"ROW3"},{"id":"3","title":"ROW4"}]}]}}}`},
 		},
 		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -788,6 +788,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: courier.ErrRetryableWithReason("131053", "Media upload error"),
 	},
 	{
+		// media messages can't carry a link, so a failed upload has to error rather than fall back
 		Label:          "Audio attachment but upload fails",
 		MsgText:        "audio has no caption, sent as text",
 		MsgURN:         "whatsapp:250788123123",
@@ -799,30 +800,24 @@ var defaultSendTestCases = []OutgoingTestCase{
 			"*/v1/media": {
 				httpx.NewMockResponse(200, nil, []byte(``)),
 			},
-			"*/v1/messages": {
-				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
-				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
-			},
 		},
 		ExpectedRequests: []ExpectedRequest{
 			{},
 			{},
-			{Body: `{"to":"250788123123","type":"audio","audio":{"link":"https://foo.bar/audio.mp3"}}`},
-			{Body: `{"to":"250788123123","type":"text","text":{"body":"audio has no caption, sent as text"}}`},
 		},
-		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
+		ExpectedError: courier.ErrRetryableWithReason("media_upload_failed", "unable to upload media to WhatsApp"),
 	},
 	{
 		Label:          "Audio Send with link in text",
 		MsgText:        "audio has no caption, sent as text with a https://example.com",
 		MsgURN:         "whatsapp:250788123123",
-		MsgAttachments: []string{"audio/mpeg:https://foo.bar/audio.mp3"},
+		MsgAttachments: []string{"audio/mpeg:https://foo.bar/audio2.mp3"},
 		MockResponses: map[string][]*httpx.MockResponse{
-			"https://foo.bar/audio.mp3": {
+			"https://foo.bar/audio2.mp3": {
 				httpx.NewMockResponse(200, nil, []byte(`data`)),
 			},
 			"*/v1/media": {
-				httpx.NewMockResponse(200, nil, []byte(``)),
+				httpx.NewMockResponse(201, nil, []byte(`{ "media" : [{"id": "8a1b0c3d-1283-4b94-988d-7276bdec4de2"}] }`)),
 			},
 			"*/v1/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
@@ -832,7 +827,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{},
 			{},
-			{Body: `{"to":"250788123123","type":"audio","audio":{"link":"https://foo.bar/audio.mp3"}}`},
+			{Body: `{"to":"250788123123","type":"audio","audio":{"id":"8a1b0c3d-1283-4b94-988d-7276bdec4de2"}}`},
 			{Body: `{"to":"250788123123","type":"text","preview_url":true,"text":{"body":"audio has no caption, sent as text with a https://example.com"}}`},
 		},
 		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
@@ -847,7 +842,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 				httpx.NewMockResponse(200, nil, []byte(`data`)),
 			},
 			"*/v1/media": {
-				httpx.NewMockResponse(400, nil, []byte(`{}`)),
+				httpx.NewMockResponse(201, nil, []byte(`{ "media" : [{"id": "1b2c3d4e-1283-4b94-988d-7276bdec4de2"}] }`)),
 			},
 			"*/v1/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
@@ -856,22 +851,31 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{},
 			{},
-			{Body: `{"to":"250788123123","type":"document","document":{"link":"https://foo.bar/document.pdf","caption":"document caption","filename":"document.pdf"}}`},
+			{Body: `{"to":"250788123123","type":"document","document":{"id":"1b2c3d4e-1283-4b94-988d-7276bdec4de2","caption":"document caption","filename":"document.pdf"}}`},
 		},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
+		// the filename still comes from the attachment URL even though the payload references media by id
 		Label:          "Document Send, document link",
 		MsgText:        "document caption",
 		MsgURN:         "whatsapp:250788123123",
-		MsgAttachments: []string{"document:https://foo.bar/document.pdf"},
+		MsgAttachments: []string{"document:https://foo.bar/document3.pdf"},
 		MockResponses: map[string][]*httpx.MockResponse{
+			"https://foo.bar/document3.pdf": {
+				httpx.NewMockResponse(200, nil, []byte(`data`)),
+			},
+			"*/v1/media": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "media" : [{"id": "2c3d4e5f-1283-4b94-988d-7276bdec4de2"}] }`)),
+			},
 			"*/v1/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Body: `{"to":"250788123123","type":"document","document":{"link":"https://foo.bar/document.pdf","caption":"document caption","filename":"document.pdf"}}`},
+			{},
+			{},
+			{Body: `{"to":"250788123123","type":"document","document":{"id":"2c3d4e5f-1283-4b94-988d-7276bdec4de2","caption":"document caption","filename":"document3.pdf"}}`},
 		},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
@@ -885,7 +889,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 				httpx.NewMockResponse(200, nil, []byte(`data`)),
 			},
 			"*/v1/media": {
-				httpx.NewMockResponse(400, nil, []byte(`{}`)),
+				httpx.NewMockResponse(201, nil, []byte(`{ "media" : [{"id": "3d4e5f6a-1283-4b94-988d-7276bdec4de2"}] }`)),
 			},
 			"*/v1/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
@@ -894,7 +898,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{},
 			{},
-			{Body: `{"to":"250788123123","type":"image","image":{"link":"https://foo.bar/image.jpg","caption":"image caption"}}`},
+			{Body: `{"to":"250788123123","type":"image","image":{"id":"3d4e5f6a-1283-4b94-988d-7276bdec4de2","caption":"image caption"}}`},
 		},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
@@ -908,7 +912,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 				httpx.NewMockResponse(200, nil, []byte(`data`)),
 			},
 			"*/v1/media": {
-				httpx.NewMockResponse(400, nil, []byte(`{}`)),
+				httpx.NewMockResponse(201, nil, []byte(`{ "media" : [{"id": "4e5f6a7b-1283-4b94-988d-7276bdec4de2"}] }`)),
 			},
 			"*/v1/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
@@ -917,7 +921,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{
 			{},
 			{},
-			{Body: `{"to":"250788123123","type":"video","video":{"link":"https://foo.bar/video.mp4","caption":"video caption"}}`},
+			{Body: `{"to":"250788123123","type":"video","video":{"id":"4e5f6a7b-1283-4b94-988d-7276bdec4de2","caption":"video caption"}}`},
 		},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
@@ -1139,6 +1143,34 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
+		// a component with no variables of its own serializes as "parameters":null
+		Label:     "Template Send with static body",
+		MsgText:   "templated message",
+		MsgURN:    "whatsapp:250788123123",
+		MsgLocale: "eng",
+		MsgTemplating: `{
+			"template": {"uuid": "171f8a4d-f725-46d7-85a6-11aceff0bfe3", "name": "revive_issue"},
+			"components": [
+				{"type": "header/media", "name": "header", "variables": {"1": 0}},
+				{"type": "body/text", "name": "body", "variables": {}}
+			],
+			"variables": [
+				{"type": "image", "value": "image/jpeg:https://foo.bar/image.jpg"}
+			],
+			"language": "en_US"
+		}`,
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(200, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Path: "/v1/messages",
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"image","image":{"link":"https://foo.bar/image.jpg"}}]},{"type":"body","parameters":null}]}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
 		Label:     "Template Send with text header",
 		MsgText:   "templated message",
 		MsgURN:    "whatsapp:250788123123",
@@ -1306,7 +1338,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Body: `{"to":"250788123123","type":"image","image":{"link":"https://foo.bar/image.jpg"}}`},
+			{Body: `{"to":"250788123123","type":"image","image":{"id":"3d4e5f6a-1283-4b94-988d-7276bdec4de2"}}`},
 			{Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"button","body":{"text":"Interactive Button Msg"},"action":{"buttons":[{"type":"reply","reply":{"id":"0","title":"BUTTON1"}}]}}}`},
 		},
 		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
@@ -1324,7 +1356,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Body: `{"to":"250788123123","type":"image","image":{"link":"https://foo.bar/image.jpg"}}`},
+			{Body: `{"to":"250788123123","type":"image","image":{"id":"3d4e5f6a-1283-4b94-988d-7276bdec4de2"}}`},
 			{Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"list","body":{"text":"Interactive List Msg"},"action":{"button":"Menu","sections":[{"rows":[{"id":"0","title":"ROW1"},{"id":"1","title":"ROW2"},{"id":"2","title":"ROW3"},{"id":"3","title":"ROW4"}]}]}}}`},
 		},
 		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
@@ -1535,31 +1567,21 @@ var mediaCacheSendTestCases = []OutgoingTestCase{
 			"*/v1/media": {
 				httpx.NewMockResponse(401, nil, []byte(`{ "errors": [{"code":1005,"title":"Access denied","details":"Invalid credentials."}] }`)),
 			},
-			"*/v1/messages": {
-				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
-			},
 		},
 		ExpectedRequests: []ExpectedRequest{
 			{},
 			{Body: "media bytes"},
-			{BodyContains: `/document.pdf`},
 		},
-		ExpectedExtIDs: []string{"157b5e14568e8"},
+		ExpectedError: courier.ErrRetryableWithReason("media_upload_failed", "unable to upload media to WhatsApp"),
 	},
 	{
+		// the failed upload above is cached, so this one errors without re-attempting the download
 		Label:          "Previous Media Upload Error",
 		MsgText:        "document caption",
 		MsgURN:         "whatsapp:250788123123",
 		MsgAttachments: []string{"application/pdf:https://foo.bar/document.pdf"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"*/v1/messages": {
-				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{BodyContains: `/document.pdf`},
-		},
-		ExpectedExtIDs: []string{"157b5e14568e8"},
+		MockResponses:  map[string][]*httpx.MockResponse{},
+		ExpectedError:  courier.ErrRetryableWithReason("media_upload_failed", "unable to upload media to WhatsApp"),
 	},
 	{
 		Label:          "Media Upload OK",


### PR DESCRIPTION
Follow-up to #1107, which I closed after @norkans7 pointed out that Turn's media messages must reference media by the id returned from `/v1/media` — `link` is documented for media templated messages and interactive headers, but not for plain media messages.

That correction exposed a pre-existing problem in the opposite direction, which is what this PR fixes.

## The problem

When `fetchMediaID` can't produce an id, the handler falls back to putting the attachment URL in the payload:

```go
mediaID, err := h.fetchMediaID(ctx, msg, mediaURL, clog)
if err != nil { slog.Error(...) }
if err == nil && mediaID != "" { mediaURL = "" }
mediaPayload := &mediaObject{ID: mediaID, Link: mediaURL}
```

There are three ways to reach that: the media download failed, the upload failed, or a recent failure for the same URL is still in the 15 minute failure cache. In each case we build a media message carrying a `link`, which is not a shape the channel accepts.

This isn't silent — `makeAPIRequest` turns the rejection into `ErrFailedWithReason` / `ErrRetryableWithReason`, so the message does get marked. But the failure is attributed to the channel rejecting the send, when the actual cause was our own upload never succeeding, and we spend a round trip to find out.

## The fix

Return a retryable error as soon as there's no media id:

```go
if mediaID == "" {
    return nil, courier.ErrRetryableWithReason("media_upload_failed", "unable to upload media to WhatsApp")
}
```

The message goes to the errored queue and is retried, the channel log records `media_upload_failed` against the real cause, and no request is made that we expect to be rejected.

`Link` is dropped from `mediaObject` — nothing sets it now, and leaving it there invites exactly this mistake back.

## Also included

Two pieces salvaged from the closed #1107, neither of which depended on its wrong premise:

- A template test for a component with no variables of its own, pinning the `"parameters":null` serialization introduced by #1105 rather than leaving it assumed.
- Removal of a dead commented-out `whatsapp.GetMsgPayloads` line at the send call site.

## Test plan

- `Media Upload Error` and `Previous Media Upload Error` now assert the retryable error rather than a link payload; the latter also asserts that a cached failure short-circuits without re-attempting the download.
- `Audio attachment but upload fails` keeps its failing upload and asserts the error, with no message request made.
- The remaining attachment cases (`Audio Send with link in text`, `Document Send`, `Document Send, document link`, `Image Send`, `Video Send`) previously mocked `/v1/media` returning 400 or an empty body and asserted the link fallback. They now mock a successful upload and assert the `id` payload — the path they should have been covering.
- The two interactive-with-attachment cases were relying on an earlier case having populated the shared media cache for the same URL, which this change would have turned into a confusing failure on any reorder. They now use their own media URLs with their own download and upload mocks.
- Every non-template attachment case now uses a distinct media URL, so none depends on another's cached id. The valkey cache is flushed per suite rather than per case, which is what made that sharing possible.
- `go test -p=1 ./...` passes; `gofmt` clean.

## Note on retry behavior

A cached upload failure now makes the send fail fast for up to 15 minutes rather than degrading. That is the intended outcome: if media genuinely can't be uploaded, the message should fail, and failing without re-downloading is better than retrying uselessly. Worth being aware of when reading channel logs.