### PR TITLE
Stop using the same structs for incoming msg/event db rows and spool files

### DIFF
--- a/backends/rapidpro/backend_test.go
+++ b/backends/rapidpro/backend_test.go
@@ -1113,12 +1113,12 @@ func (ts *BackendTestSuite) TestWriteMsg() {
 	err = ts.b.WriteMsg(ctx, msg6, clog)
 	ts.NoError(err)
 
-	ts.assertQueuedContactTask(msg6.ContactID_, "msg_received", map[string]any{
+	ts.assertQueuedContactTask(contact.ID_, "msg_received", map[string]any{
 		"channel_id":      float64(10),
 		"msg_uuid":        string(msg6.UUID()),
 		"msg_external_id": msg6.ExternalID(),
 		"urn":             msg6.URN().String(),
-		"urn_id":          float64(msg6.ContactURNID_),
+		"urn_id":          float64(contact.URNID_),
 		"text":            msg6.Text(),
 		"attachments":     nil,
 		"new_contact":     contact.IsNew_,
@@ -1132,12 +1132,12 @@ func (ts *BackendTestSuite) TestWriteMsg() {
 	err = ts.b.WriteMsg(ctx, msg7, clog)
 	ts.NoError(err)
 
-	ts.assertQueuedContactTask(msg7.ContactID_, "msg_received", map[string]any{
+	ts.assertQueuedContactTask(contact.ID_, "msg_received", map[string]any{
 		"channel_id":      float64(10),
 		"msg_uuid":        string(msg7.UUID()),
 		"msg_external_id": msg7.ExternalID(),
 		"urn":             msg7.URN().String(),
-		"urn_id":          float64(msg7.ContactURNID_),
+		"urn_id":          float64(contact.URNID_),
 		"text":            msg7.Text(),
 		"attachments":     nil,
 		"new_contact":     contact.IsNew_,
@@ -1152,12 +1152,12 @@ func (ts *BackendTestSuite) TestWriteMsg() {
 	err = ts.b.WriteMsg(ctx, msg8, clog)
 	ts.NoError(err)
 
-	ts.assertQueuedContactTask(msg8.ContactID_, "msg_received", map[string]any{
+	ts.assertQueuedContactTask(contact.ID_, "msg_received", map[string]any{
 		"channel_id":      float64(10),
 		"msg_uuid":        string(msg8.UUID()),
 		"msg_external_id": msg8.ExternalID(),
 		"urn":             msg8.URN().String(),
-		"urn_id":          float64(msg8.ContactURNID_),
+		"urn_id":          float64(contact.URNID_),
 		"text":            msg8.Text(),
 		"attachments":     nil,
 		"new_contact":     contact.IsNew_,

--- a/backends/rapidpro/channel_event.go
+++ b/backends/rapidpro/channel_event.go
@@ -14,7 +14,7 @@ func writeChannelEvent(ctx context.Context, b *backend, event *models.ChannelEve
 
 	// failed writing, write to our spool instead
 	if err != nil {
-		slog.Error("error writing channel event to db", "error", err, "channel_id", event.ChannelID_, "event_type", event.EventType_)
+		slog.Error("error writing channel event to db", "error", err, "channel", event.ChannelUUID_, "event_type", event.EventType_)
 	}
 
 	if err != nil {
@@ -27,16 +27,12 @@ func writeChannelEvent(ctx context.Context, b *backend, event *models.ChannelEve
 // writeChannelEventToDB writes the passed in channel event to our db
 func writeChannelEventToDB(ctx context.Context, b *backend, e *models.ChannelEvent, clog *models.ChannelLog) error {
 	// grab the contact for this event
-	contact, err := contactForURN(ctx, b, e.OrgID_, e.Channel_, e.URN_, nil, e.ContactName_, true, clog)
+	contact, err := contactForURN(ctx, b, e.Channel_.OrgID(), e.Channel_, e.URN_, nil, e.ContactName_, true, clog)
 	if err != nil {
 		return err
 	}
 
-	// set our contact and urn id
-	e.ContactID_ = contact.ID_
-	e.ContactURNID_ = contact.URNID_
-
-	if err := models.InsertChannelEvent(ctx, b.rt.DB, e); err != nil {
+	if err := models.InsertChannelEvent(ctx, b.rt.DB, e, contact); err != nil {
 		return err
 	}
 

--- a/backends/rapidpro/contact.go
+++ b/backends/rapidpro/contact.go
@@ -172,17 +172,17 @@ func contactForMsg(ctx context.Context, b *backend, m *models.MsgIn, clog *model
 
 	// simple case: no alternative URN to consider, look up or create by the primary URN
 	if altURN == urns.NilURN {
-		return contactForURN(ctx, b, m.OrgID_, m.Channel_, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+		return contactForURN(ctx, b, m.Channel_.OrgID(), m.Channel_, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
 	}
 
 	// try the primary URN first, without creating a contact
-	contact, err := contactForURN(ctx, b, m.OrgID_, m.Channel_, m.URN_, m.URNAuthTokens_, m.ContactName_, false, clog)
+	contact, err := contactForURN(ctx, b, m.Channel_.OrgID(), m.Channel_, m.URN_, m.URNAuthTokens_, m.ContactName_, false, clog)
 	if err != nil || contact != nil {
 		return contact, err
 	}
 
 	// the primary URN didn't match an existing contact, try the alternative
-	contact, err = contactForURN(ctx, b, m.OrgID_, m.Channel_, altURN, nil, "", false, clog)
+	contact, err = contactForURN(ctx, b, m.Channel_.OrgID(), m.Channel_, altURN, nil, "", false, clog)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func contactForMsg(ctx context.Context, b *backend, m *models.MsgIn, clog *model
 	}
 
 	// no existing contact matched either URN, create one from the primary URN
-	return contactForURN(ctx, b, m.OrgID_, m.Channel_, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
+	return contactForURN(ctx, b, m.Channel_.OrgID(), m.Channel_, m.URN_, m.URNAuthTokens_, m.ContactName_, true, clog)
 }
 
 // altLookupURN returns an alternative URN to look up an existing contact by when the message's primary URN doesn't

--- a/backends/rapidpro/mailroom.go
+++ b/backends/rapidpro/mailroom.go
@@ -21,7 +21,7 @@ func queueMsgHandling(ctx context.Context, rc redis.Conn, c *models.Contact, m *
 		"msg_uuid":        m.UUID(),
 		"msg_external_id": m.ExternalID(),
 		"urn":             m.URN().String(),
-		"urn_id":          m.ContactURNID_,
+		"urn_id":          c.URNID_,
 		"text":            m.Text(),
 		"attachments":     m.Attachments(),
 		"new_contact":     c.IsNew_,
@@ -33,21 +33,23 @@ func queueMsgHandling(ctx context.Context, rc redis.Conn, c *models.Contact, m *
 		body["payload"] = m.Payload_
 	}
 
-	return queueMailroomTask(ctx, rc, "msg_received", m.OrgID_, m.ContactID_, body)
+	return queueMailroomTask(ctx, rc, "msg_received", channel.OrgID_, c.ID_, body)
 }
 
 func queueEventHandling(ctx context.Context, rc redis.Conn, c *models.Contact, e *models.ChannelEvent) error {
+	channel := e.Channel()
+
 	body := map[string]any{
 		"event_uuid":  e.UUID(),
 		"event_type":  e.EventType_,
-		"urn_id":      e.ContactURNID_,
-		"channel_id":  e.ChannelID_,
+		"urn_id":      c.URNID_,
+		"channel_id":  channel.ID_,
 		"extra":       e.Extra(),
 		"new_contact": c.IsNew_,
 		"occurred_on": e.OccurredOn_,
 	}
 
-	return queueMailroomTask(ctx, rc, "event_received", e.OrgID_, e.ContactID_, body)
+	return queueMailroomTask(ctx, rc, "event_received", channel.OrgID_, c.ID_, body)
 }
 
 func queueMsgDeleted(ctx context.Context, rc redis.Conn, ch *models.Channel, msgUUID models.MsgUUID, contactID models.ContactID) error {

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -89,11 +89,7 @@ func writeMsgToDB(ctx context.Context, b *backend, m *models.MsgIn, clog *models
 		return nil, fmt.Errorf("error getting contact for message: %w", err)
 	}
 
-	// set our contact and urn id
-	m.ContactID_ = contact.ID_
-	m.ContactURNID_ = contact.URNID_
-
-	if err := models.InsertIncomingMsg(ctx, b.rt.DB, m); err != nil {
+	if err := models.InsertIncomingMsg(ctx, b.rt.DB, m, contact); err != nil {
 		return nil, fmt.Errorf("error inserting message: %w", err)
 	}
 
@@ -165,7 +161,7 @@ func (b *backend) checkMsgAlreadyReceived(ctx context.Context, m *models.MsgIn) 
 	defer rc.Close()
 
 	// if we have an external id use that
-	if m.ExternalIdentifier_ != "" {
+	if m.ExternalID_ != "" {
 		fingerprint := fmt.Sprintf("%s|%s|%s", m.Channel().UUID(), m.URN().Identity(), m.ExternalID())
 
 		if uuid, _ := b.receivedExternalIDs.Get(ctx, rc, fingerprint); uuid != "" {
@@ -194,7 +190,7 @@ func (b *backend) recordMsgReceived(ctx context.Context, m *models.MsgIn) {
 	rc := b.rt.VK.Get()
 	defer rc.Close()
 
-	if m.ExternalIdentifier_ != "" {
+	if m.ExternalID_ != "" {
 		fingerprint := fmt.Sprintf("%s|%s|%s", m.Channel().UUID(), m.URN().Identity(), m.ExternalID())
 
 		if err := b.receivedExternalIDs.Set(ctx, rc, fingerprint, string(m.UUID())); err != nil {

--- a/core/models/channel_event.go
+++ b/core/models/channel_event.go
@@ -74,8 +74,8 @@ func (e *ChannelEvent) WithExtra(extra map[string]string) *ChannelEvent {
 }
 func (e *ChannelEvent) WithOccurredOn(t time.Time) *ChannelEvent { e.OccurredOn_ = t; return e }
 
-// channelEventRow is the database representation of a channel event
-type channelEventRow struct {
+// dbChannelEvent is the database representation of a channel event
+type dbChannelEvent struct {
 	UUID         ChannelEventUUID `db:"uuid"`
 	OrgID        OrgID            `db:"org_id"`
 	ChannelID    ChannelID        `db:"channel_id"`
@@ -100,7 +100,7 @@ func InsertChannelEvent(ctx context.Context, db *sqlx.DB, e *ChannelEvent, conta
 		logUUIDs[i] = string(e.LogUUIDs[i])
 	}
 
-	row := &channelEventRow{
+	row := &dbChannelEvent{
 		UUID:         e.UUID_,
 		OrgID:        e.Channel_.OrgID(),
 		ChannelID:    e.Channel_.ID(),

--- a/core/models/channel_event.go
+++ b/core/models/channel_event.go
@@ -26,46 +26,40 @@ const (
 	EventTypeWelcomeMessage  ChannelEventType = "welcome_message"
 )
 
-// ChannelEvent represents an event on a channel.. that isn't a new message or status update
+// ChannelEvent is an event on a channel - that isn't a new message or status update - as created by a handler, and
+// is also what we marshal to spool files when the database is down. It doesn't carry any database ids - those are
+// resolved when it's written.
 type ChannelEvent struct {
-	UUID_         ChannelEventUUID `db:"uuid"               json:"uuid"`
-	OrgID_        OrgID            `db:"org_id"             json:"org_id"`
-	ChannelID_    ChannelID        `db:"channel_id"         json:"channel_id"`
-	URN_          urns.URN         `db:"urn"                json:"urn"`
-	EventType_    ChannelEventType `db:"event_type"         json:"event_type"`
-	Extra_        null.Map[string] `db:"extra"              json:"extra"`
-	OccurredOn_   time.Time        `db:"occurred_on"        json:"occurred_on"`
-	ContactID_    ContactID        `db:"contact_id"         json:"-"`
-	ContactURNID_ ContactURNID     `db:"contact_urn_id"     json:"-"`
-	LogUUIDs      pq.StringArray   `db:"log_uuids"          json:"log_uuids"`
+	UUID_        ChannelEventUUID  `json:"uuid"`
+	ChannelUUID_ ChannelUUID       `json:"channel_uuid"`
+	URN_         urns.URN          `json:"urn"`
+	EventType_   ChannelEventType  `json:"event_type"`
+	Extra_       map[string]string `json:"extra,omitempty"`
+	OccurredOn_  time.Time         `json:"occurred_on"`
+	LogUUIDs     []clogs.UUID      `json:"log_uuids"`
 
-	// not stored on the event itself but included in spool files and needed for queueing to mailroom
-	ChannelUUID_ ChannelUUID `db:"-" json:"channel_uuid"`
-	ContactName_ string      `db:"-" json:"contact_name"`
+	// optional extra set by handlers, used to update the contact
+	ContactName_ string `json:"contact_name,omitempty"`
 
-	Channel_ *Channel `db:"-" json:"-"`
+	Channel_ *Channel `json:"-"`
 }
 
 // NewChannelEvent creates a new channel event for the given channel and event type
 func NewChannelEvent(channel *Channel, eventType ChannelEventType, urn urns.URN, clogUUID clogs.UUID) *ChannelEvent {
 	return &ChannelEvent{
-		UUID_:       ChannelEventUUID(uuids.NewV7()),
-		OrgID_:      channel.OrgID(),
-		ChannelID_:  channel.ID(),
-		URN_:        urn,
-		EventType_:  eventType,
-		OccurredOn_: time.Now().In(time.UTC),
-		LogUUIDs:    pq.StringArray{string(clogUUID)},
-
+		UUID_:        ChannelEventUUID(uuids.NewV7()),
 		ChannelUUID_: channel.UUID(),
-		Channel_:     channel,
+		URN_:         urn,
+		EventType_:   eventType,
+		OccurredOn_:  time.Now().In(time.UTC),
+		LogUUIDs:     []clogs.UUID{clogUUID},
+
+		Channel_: channel,
 	}
 }
 
 func (e *ChannelEvent) EventUUID() uuids.UUID       { return uuids.UUID(e.UUID_) }
 func (e *ChannelEvent) UUID() ChannelEventUUID      { return e.UUID_ }
-func (e *ChannelEvent) OrgID() OrgID                { return e.OrgID_ }
-func (e *ChannelEvent) ChannelID() ChannelID        { return e.ChannelID_ }
 func (e *ChannelEvent) ChannelUUID() ChannelUUID    { return e.ChannelUUID_ }
 func (e *ChannelEvent) Channel() *Channel           { return e.Channel_ }
 func (e *ChannelEvent) URN() urns.URN               { return e.URN_ }
@@ -75,10 +69,24 @@ func (e *ChannelEvent) OccurredOn() time.Time       { return e.OccurredOn_ }
 
 func (e *ChannelEvent) WithContactName(name string) *ChannelEvent { e.ContactName_ = name; return e }
 func (e *ChannelEvent) WithExtra(extra map[string]string) *ChannelEvent {
-	e.Extra_ = null.Map[string](extra)
+	e.Extra_ = extra
 	return e
 }
 func (e *ChannelEvent) WithOccurredOn(t time.Time) *ChannelEvent { e.OccurredOn_ = t; return e }
+
+// channelEventRow is the database representation of a channel event
+type channelEventRow struct {
+	UUID         ChannelEventUUID `db:"uuid"`
+	OrgID        OrgID            `db:"org_id"`
+	ChannelID    ChannelID        `db:"channel_id"`
+	URN          urns.URN         `db:"urn"`
+	EventType    ChannelEventType `db:"event_type"`
+	Extra        null.Map[string] `db:"extra"`
+	OccurredOn   time.Time        `db:"occurred_on"`
+	ContactID    ContactID        `db:"contact_id"`
+	ContactURNID ContactURNID     `db:"contact_urn_id"`
+	LogUUIDs     pq.StringArray   `db:"log_uuids"`
+}
 
 const sqlInsertChannelEvent = `
 INSERT INTO
@@ -86,7 +94,25 @@ INSERT INTO
 				   VALUES(:org_id, :uuid, :channel_id, :contact_id, :contact_urn_id, :event_type, :extra, :occurred_on,       NOW(),    'P', :log_uuids)`
 
 // InsertChannelEvent inserts the passed in channel event into the database
-func InsertChannelEvent(ctx context.Context, db *sqlx.DB, e *ChannelEvent) error {
-	_, err := db.NamedExecContext(ctx, sqlInsertChannelEvent, e)
+func InsertChannelEvent(ctx context.Context, db *sqlx.DB, e *ChannelEvent, contact *Contact) error {
+	logUUIDs := make(pq.StringArray, len(e.LogUUIDs))
+	for i := range e.LogUUIDs {
+		logUUIDs[i] = string(e.LogUUIDs[i])
+	}
+
+	row := &channelEventRow{
+		UUID:         e.UUID_,
+		OrgID:        e.Channel_.OrgID(),
+		ChannelID:    e.Channel_.ID(),
+		URN:          e.URN_,
+		EventType:    e.EventType_,
+		Extra:        null.Map[string](e.Extra_),
+		OccurredOn:   e.OccurredOn_,
+		ContactID:    contact.ID_,
+		ContactURNID: contact.URNID_,
+		LogUUIDs:     logUUIDs,
+	}
+
+	_, err := db.NamedExecContext(ctx, sqlInsertChannelEvent, row)
 	return err
 }

--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -66,31 +66,27 @@ const (
 	MsgArchived MsgVisibility = "A"
 )
 
-// MsgIn is an incoming message which can be written to the database or marshaled to a spool file
+// MsgIn is an incoming message as created by a handler, and is also what we marshal to spool files when the
+// database is down. It doesn't carry any database ids - those are resolved when it's written.
 type MsgIn struct {
-	OrgID_              OrgID          `db:"org_id"                 json:"org_id"`
-	UUID_               MsgUUID        `db:"uuid"                   json:"uuid"`
-	Text_               string         `db:"text"                   json:"text"`
-	Attachments_        pq.StringArray `db:"attachments"            json:"attachments"`
-	ExternalIdentifier_ null.String    `db:"external_identifier"    json:"external_identifier"`
-	ChannelID_          ChannelID      `db:"channel_id"             json:"channel_id"`
-	ContactID_          ContactID      `db:"contact_id"             json:"contact_id"`
-	ContactURNID_       ContactURNID   `db:"contact_urn_id"         json:"contact_urn_id"`
-	CreatedOn_          time.Time      `db:"created_on"             json:"created_on"`
-	ModifiedOn_         time.Time      `db:"modified_on"            json:"modified_on"`
-	SentOn_             *time.Time     `db:"sent_on"                json:"sent_on"`
-	LogUUIDs            pq.StringArray `db:"log_uuids"              json:"log_uuids"`
+	UUID_        MsgUUID      `json:"uuid"`
+	ChannelUUID_ ChannelUUID  `json:"channel_uuid"`
+	URN_         urns.URN     `json:"urn"`
+	Text_        string       `json:"text"`
+	Attachments_ []string     `json:"attachments,omitempty"`
+	ExternalID_  string       `json:"external_id,omitempty"`
+	CreatedOn_   time.Time    `json:"created_on"`
+	ReceivedOn_  *time.Time   `json:"received_on,omitempty"`
+	LogUUIDs     []clogs.UUID `json:"log_uuids"`
 
-	// not stored on the msg itself but included in spool files and needed for queueing to mailroom
-	ChannelUUID_   ChannelUUID       `db:"-" json:"channel_uuid"`
-	URN_           urns.URN          `db:"-" json:"urn"`
-	ContactName_   string            `db:"-" json:"contact_name"`
-	URNAuthTokens_ map[string]string `db:"-" json:"auth_tokens"`
-	NewURN_        *NewURNSpec       `db:"-" json:"new_urn,omitempty"`
-	Payload_       json.RawMessage   `db:"-" json:"payload,omitempty"`
+	// optional extras set by handlers, used to update the contact or passed to mailroom for handling
+	ContactName_   string            `json:"contact_name,omitempty"`
+	URNAuthTokens_ map[string]string `json:"auth_tokens,omitempty"`
+	NewURN_        *NewURNSpec       `json:"new_urn,omitempty"`
+	Payload_       json.RawMessage   `json:"payload,omitempty"`
 
-	Channel_   *Channel `db:"-" json:"-"`
-	Duplicate_ bool     `db:"-" json:"-"`
+	Channel_   *Channel `json:"-"`
+	Duplicate_ bool     `json:"-"`
 }
 
 // NewIncomingMsg creates a new incoming message
@@ -98,28 +94,25 @@ func NewIncomingMsg(channel *Channel, urn urns.URN, text string, extID string, c
 	now := time.Now()
 
 	return &MsgIn{
-		OrgID_:              channel.OrgID(),
-		UUID_:               MsgUUID(uuids.NewV7()),
-		Text_:               text,
-		ExternalIdentifier_: null.String(extID),
-		ChannelID_:          channel.ID(),
-		CreatedOn_:          now,
-		ModifiedOn_:         now,
-		SentOn_:             &now,
-		LogUUIDs:            pq.StringArray{string(clogUUID)},
-
+		UUID_:        MsgUUID(uuids.NewV7()),
 		ChannelUUID_: channel.UUID(),
 		URN_:         urn,
-		Channel_:     channel,
+		Text_:        text,
+		ExternalID_:  extID,
+		CreatedOn_:   now,
+		ReceivedOn_:  &now,
+		LogUUIDs:     []clogs.UUID{clogUUID},
+
+		Channel_: channel,
 	}
 }
 
 func (m *MsgIn) EventUUID() uuids.UUID  { return uuids.UUID(m.UUID_) }
 func (m *MsgIn) UUID() MsgUUID          { return m.UUID_ }
-func (m *MsgIn) ExternalID() string     { return string(m.ExternalIdentifier_) }
+func (m *MsgIn) ExternalID() string     { return m.ExternalID_ }
 func (m *MsgIn) Text() string           { return m.Text_ }
-func (m *MsgIn) Attachments() []string  { return []string(m.Attachments_) }
-func (m *MsgIn) ReceivedOn() *time.Time { return m.SentOn_ }
+func (m *MsgIn) Attachments() []string  { return m.Attachments_ }
+func (m *MsgIn) ReceivedOn() *time.Time { return m.ReceivedOn_ }
 func (m *MsgIn) URN() urns.URN          { return m.URN_ }
 func (m *MsgIn) Channel() *Channel      { return m.Channel_ }
 
@@ -132,23 +125,57 @@ func (m *MsgIn) WithURNAuthTokens(tokens map[string]string) *MsgIn {
 	m.URNAuthTokens_ = tokens
 	return m
 }
-func (m *MsgIn) WithReceivedOn(date time.Time) *MsgIn { m.SentOn_ = &date; return m }
+func (m *MsgIn) WithReceivedOn(date time.Time) *MsgIn { m.ReceivedOn_ = &date; return m }
 func (m *MsgIn) WithNewURN(urn urns.URN, action NewURNAction) *MsgIn {
 	m.NewURN_ = &NewURNSpec{Value: urn, Action: action}
 	return m
 }
 func (m *MsgIn) WithPayload(payload json.RawMessage) *MsgIn { m.Payload_ = payload; return m }
 
+// msgInRow is the database representation of an incoming message
+type msgInRow struct {
+	OrgID              OrgID          `db:"org_id"`
+	UUID               MsgUUID        `db:"uuid"`
+	Text               string         `db:"text"`
+	Attachments        pq.StringArray `db:"attachments"`
+	ExternalIdentifier null.String    `db:"external_identifier"`
+	ChannelID          ChannelID      `db:"channel_id"`
+	ContactID          ContactID      `db:"contact_id"`
+	ContactURNID       ContactURNID   `db:"contact_urn_id"`
+	CreatedOn          time.Time      `db:"created_on"`
+	SentOn             *time.Time     `db:"sent_on"`
+	LogUUIDs           pq.StringArray `db:"log_uuids"`
+}
+
 const sqlInsertIncomingMsg = `
 INSERT INTO
 	msgs_msg(org_id, uuid, direction, text, attachments, msg_type, msg_count, error_count, high_priority, status, is_android,
              visibility, external_identifier, channel_id, contact_id, contact_urn_id, created_on, modified_on, sent_on, log_uuids)
     VALUES(:org_id, :uuid, 'I', :text, :attachments, 'T', 1, 0, FALSE, 'P', FALSE,
-             'V', :external_identifier, :channel_id, :contact_id, :contact_urn_id, :created_on, :modified_on, :sent_on, :log_uuids)`
+             'V', :external_identifier, :channel_id, :contact_id, :contact_urn_id, :created_on, :created_on, :sent_on, :log_uuids)`
 
 // InsertIncomingMsg inserts the passed in incoming message into the database
-func InsertIncomingMsg(ctx context.Context, db *sqlx.DB, m *MsgIn) error {
-	_, err := db.NamedExecContext(ctx, sqlInsertIncomingMsg, m)
+func InsertIncomingMsg(ctx context.Context, db *sqlx.DB, m *MsgIn, contact *Contact) error {
+	logUUIDs := make(pq.StringArray, len(m.LogUUIDs))
+	for i := range m.LogUUIDs {
+		logUUIDs[i] = string(m.LogUUIDs[i])
+	}
+
+	row := &msgInRow{
+		OrgID:              m.Channel_.OrgID(),
+		UUID:               m.UUID_,
+		Text:               m.Text_,
+		Attachments:        pq.StringArray(m.Attachments_),
+		ExternalIdentifier: null.String(m.ExternalID_),
+		ChannelID:          m.Channel_.ID(),
+		ContactID:          contact.ID_,
+		ContactURNID:       contact.URNID_,
+		CreatedOn:          m.CreatedOn_,
+		SentOn:             m.ReceivedOn_,
+		LogUUIDs:           logUUIDs,
+	}
+
+	_, err := db.NamedExecContext(ctx, sqlInsertIncomingMsg, row)
 	return err
 }
 

--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -132,8 +132,8 @@ func (m *MsgIn) WithNewURN(urn urns.URN, action NewURNAction) *MsgIn {
 }
 func (m *MsgIn) WithPayload(payload json.RawMessage) *MsgIn { m.Payload_ = payload; return m }
 
-// msgInRow is the database representation of an incoming message
-type msgInRow struct {
+// dbMsgIn is the database representation of an incoming message
+type dbMsgIn struct {
 	OrgID              OrgID          `db:"org_id"`
 	UUID               MsgUUID        `db:"uuid"`
 	Text               string         `db:"text"`
@@ -161,7 +161,7 @@ func InsertIncomingMsg(ctx context.Context, db *sqlx.DB, m *MsgIn, contact *Cont
 		logUUIDs[i] = string(m.LogUUIDs[i])
 	}
 
-	row := &msgInRow{
+	row := &dbMsgIn{
 		OrgID:              m.Channel_.OrgID(),
 		UUID:               m.UUID_,
 		Text:               m.Text_,

--- a/test/backend.go
+++ b/test/backend.go
@@ -14,7 +14,6 @@ import (
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
-	"github.com/nyaruka/null/v3"
 )
 
 type SavedAttachment struct {
@@ -92,11 +91,11 @@ func (mb *MockBackend) DeleteMsgByExternalID(ctx context.Context, channel *model
 // NewIncomingMsg creates a new message from the given params
 func (mb *MockBackend) NewIncomingMsg(ctx context.Context, channel *models.Channel, urn urns.URN, text string, extID string, clog *models.ChannelLog) *models.MsgIn {
 	m := &models.MsgIn{
-		Text_:               text,
-		ExternalIdentifier_: null.String(extID),
-		ChannelUUID_:        channel.UUID(),
-		URN_:                urn,
-		Channel_:            channel,
+		Text_:        text,
+		ExternalID_:  extID,
+		ChannelUUID_: channel.UUID(),
+		URN_:         urn,
+		Channel_:     channel,
 	}
 
 	uuid := mb.seenExternalIDs[fmt.Sprintf("%s|%s", m.Channel().UUID(), m.ExternalID())]


### PR DESCRIPTION
## Summary

Follows the same simplification made in mailroom: the database representation of incoming messages and channel events is no longer the same struct as their in-memory/spool representation. `MsgIn` and `ChannelEvent` are now plain handler-facing structs (JSON tags only) and the database row is a private struct built at insert time.

## Changes

- **`models.MsgIn` / `models.ChannelEvent`** carry no database ids anymore — `OrgID_`, `ChannelID_`, `ContactID_` and `ContactURNID_` are gone. They hold only what handlers set and what a spool flush needs to reconstruct the write.
- **Private row structs** (`msgInRow`, `channelEventRow`) own the `db:` tags. `InsertIncomingMsg` / `InsertChannelEvent` take the resolved `*Contact` and build the row from msg/event + channel + contact, so the write path no longer mutates the message to carry contact ids.
- **Field types simplify** now that they don't need to be scannable: `Attachments_ []string` (was `pq.StringArray`), `ExternalID_ string` (was `null.String`), `LogUUIDs []clogs.UUID`, `Extra_ map[string]string` (was `null.Map`). The wrapper types live only in the row structs.
- **Mailroom task queueing** takes org/contact ids from the channel and resolved contact rather than from fields copied onto the message.

## Behavior examples

Spool file shape changes (spool files are short-lived recovery state and do not need to survive an upgrade):

| | before | after |
|---|---|---|
| msg keys | `org_id`, `channel_id`, `contact_id`, `contact_urn_id`, `modified_on`, `sent_on`, `external_identifier`, ... | dropped ids (re-resolved on flush), `received_on`, `external_id` |
| event keys | `org_id`, `channel_id`, ... | dropped ids (re-resolved on flush) |

Database writes are unchanged except `modified_on` on incoming messages, which is now always written equal to `created_on` (previously both were set to the same timestamp at construction anyway).

## Test plan

- [x] `go vet ./...` and `gofmt -l .` clean
- [x] Full test suite (63 packages, integration-level, including spool flush round-trip tests) passes