### PR TITLE
Use dynamodb-local instead of localstack for DynamoDB in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,13 @@ jobs:
       localstack:
         image: localstack/localstack:4.14
         env:
-          SERVICES: s3,dynamodb,cloudwatch
+          SERVICES: s3,cloudwatch
         ports:
           - 4566:4566
+      dynamodb:
+        image: amazon/dynamodb-local:3.3.1
+        ports:
+          - 8000:8000
 
     steps:
       - name: Checkout code

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -27,7 +27,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.MediaDomain = "nyaruka.s3.com"
 
 	// AWS credentials and region are resolved from the standard SDK default chain, so export them as
-	// the standard env vars (localstack values) rather than via courier config
+	// the standard env vars (dev values) rather than via courier config
 	t.Setenv("AWS_ACCESS_KEY_ID", "root")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "tembatemba")
 	t.Setenv("AWS_REGION", "us-east-1")
@@ -36,7 +36,7 @@ func Runtime(t *testing.T) (context.Context, *runtime.Runtime) {
 	cfg.S3Endpoint = "http://localstack:4566"
 	cfg.S3AttachmentsBucket = "test-attachments"
 	cfg.S3PathStyle = true
-	cfg.DynamoEndpoint = "http://localstack:4566"
+	cfg.DynamoEndpoint = "http://dynamodb:8000"
 	cfg.DynamoTablePrefix = "Test"
 	cfg.SpoolDir = absPath("./_test_spool")
 


### PR DESCRIPTION
Points the test suite at a dedicated `amazon/dynamodb-local` service (`http://dynamodb:8000`) instead of localstack's DynamoDB, and adds that service to CI (localstack there now provides S3/CloudWatch only).

dynamodb-local is the same engine localstack wraps for DynamoDB, so behavior is unchanged — but it is officially maintained, much lighter, and supports persistence, which localstack's Community edition license-gated. The shared dev services stack now runs it alongside localstack, so devcontainer test runs reach it on the same hostname CI uses.