### PR TITLE
Split the HTTP server into web/ and the sender into core/sender

### DIFF
--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/gocommon/aws/dynamo"
+)
+
+// tests our connections to backing services, logging any failures but always moving forward
+func testConnections(rt *runtime.Runtime) {
+	log := slog.With("comp", "server")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// test Postgres
+	if err := rt.DB.PingContext(ctx); err != nil {
+		log.Error("db not reachable", "error", err)
+	} else {
+		log.Info("db ok")
+	}
+
+	// test DynamoDB
+	if err := dynamo.Test(ctx, rt.Dynamo, rt.Config.DynamoTablePrefix+"Main"); err != nil {
+		log.Error("dynamodb not reachable", "error", err)
+	} else {
+		log.Info("dynamodb ok")
+	}
+
+	// test Valkey
+	vc := rt.VK.Get()
+	defer vc.Close()
+	if _, err := vc.Do("PING"); err != nil {
+		log.Error("valkey not reachable", "error", err)
+	} else {
+		log.Info("valkey ok")
+	}
+
+	// test S3 bucket access
+	if err := rt.S3.Test(ctx, rt.Config.S3AttachmentsBucket); err != nil {
+		log.Error("attachments bucket not accessible", "error", err)
+	} else {
+		log.Info("attachments bucket ok")
+	}
+
+	// test that the Centrifugo server is reachable and accepts our key
+	if err := rt.Centrifugo.Client.Info(ctx); err != nil {
+		log.Error("centrifugo not reachable", "error", err)
+	} else {
+		log.Info("centrifugo ok")
+	}
+}

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -1,19 +1,22 @@
-package courier
+package cmd
 
 import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/aws/cwatch"
 )
 
-func (s *Server) startMetricsReporter(interval time.Duration) {
-	s.waitGroup.Add(1)
+// startMetricsReporter reports our metrics to cloudwatch on the given interval until stopped
+func startMetricsReporter(rt *runtime.Runtime, interval time.Duration, stop chan bool, wg *sync.WaitGroup) {
+	wg.Add(1)
 
 	// both sqlx and redis provide wait stats which are cummulative that we need to convert into increments by
 	// tracking their previous values
@@ -21,7 +24,7 @@ func (s *Server) startMetricsReporter(interval time.Duration) {
 
 	report := func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		count, err := s.reportMetrics(ctx, &dbWaitDuration, &redisWaitDuration)
+		count, err := reportMetrics(ctx, rt, &dbWaitDuration, &redisWaitDuration)
 		cancel()
 		if err != nil {
 			slog.Error("error reporting metrics", "error", err)
@@ -33,12 +36,12 @@ func (s *Server) startMetricsReporter(interval time.Duration) {
 	go func() {
 		defer func() {
 			slog.Info("metrics reporter exiting")
-			s.waitGroup.Done()
+			wg.Done()
 		}()
 
 		for {
 			select {
-			case <-s.stopChan:
+			case <-stop:
 				report()
 				return
 			case <-time.After(interval):
@@ -48,15 +51,15 @@ func (s *Server) startMetricsReporter(interval time.Duration) {
 	}()
 }
 
-func (s *Server) reportMetrics(ctx context.Context, dbWaitDuration, redisWaitDuration *time.Duration) (int, error) {
-	if s.rt.Config.MetricsReporting == "off" {
+func reportMetrics(ctx context.Context, rt *runtime.Runtime, dbWaitDuration, redisWaitDuration *time.Duration) (int, error) {
+	if rt.Config.MetricsReporting == "off" {
 		return 0, nil
 	}
 
-	metrics := s.rt.Stats.Extract().ToMetrics(s.rt.Config.MetricsReporting == "advanced")
+	metrics := rt.Stats.Extract().ToMetrics(rt.Config.MetricsReporting == "advanced")
 
 	// get queue sizes
-	rc := s.rt.VK.Get()
+	rc := rt.VK.Get()
 	defer rc.Close()
 	active, err := redis.Strings(rc.Do("ZRANGE", fmt.Sprintf("%s:active", models.MsgQueueName), "0", "-1"))
 	if err != nil {
@@ -87,8 +90,8 @@ func (s *Server) reportMetrics(ctx context.Context, dbWaitDuration, redisWaitDur
 	}
 
 	// calculate DB and redis pool metrics
-	dbStats := s.rt.DB.Stats()
-	redisStats := s.rt.VK.Stats()
+	dbStats := rt.DB.Stats()
+	redisStats := rt.VK.Stats()
 	dbWaitDurationInPeriod := dbStats.WaitDuration - *dbWaitDuration
 	redisWaitDurationInPeriod := redisStats.WaitDuration - *redisWaitDuration
 	*dbWaitDuration = dbStats.WaitDuration
@@ -105,13 +108,13 @@ func (s *Server) reportMetrics(ctx context.Context, dbWaitDuration, redisWaitDur
 		cwatch.Datum("ValkeyConnectionsWaitDuration", float64(redisWaitDurationInPeriod)/float64(time.Second), cwtypes.StandardUnitSeconds),
 		cwatch.Datum("QueuedMsgs", float64(bulkSize), cwtypes.StandardUnitCount, cwatch.Dimension("QueueName", "bulk")),
 		cwatch.Datum("QueuedMsgs", float64(prioritySize), cwtypes.StandardUnitCount, cwatch.Dimension("QueueName", "priority")),
-		cwatch.Datum("DynamoSpooledItems", float64(s.rt.Spool.Size()), cwtypes.StandardUnitCount),
+		cwatch.Datum("DynamoSpooledItems", float64(rt.Spool.Size()), cwtypes.StandardUnitCount),
 		cwatch.Datum("PostgresSpooledItems", float64(msgSpoolSize), cwtypes.StandardUnitCount, cwatch.Dimension("SpoolName", "msgs")),
 		cwatch.Datum("PostgresSpooledItems", float64(statusSpoolSize), cwtypes.StandardUnitCount, cwatch.Dimension("SpoolName", "statuses")),
 		cwatch.Datum("PostgresSpooledItems", float64(eventSpoolSize), cwtypes.StandardUnitCount, cwatch.Dimension("SpoolName", "events")),
 	)
 
-	if err := s.rt.CW.Send(ctx, metrics...); err != nil {
+	if err := rt.CW.Send(ctx, metrics...); err != nil {
 		return 0, fmt.Errorf("error sending metrics: %w", err)
 	}
 

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -67,32 +67,10 @@ func Service(defaults *runtime.Config, version, date string) error {
 	// log what we can and can't reach before we start doing anything with it
 	testConnections(rt)
 
-	if err := rt.Start(); err != nil {
-		return fmt.Errorf("error starting runtime: %w", err)
-	}
-
-	// start the caches, spools and batched writers used by the read and write paths
-	if err := models.Start(rt); err != nil {
+	svc, err := startService(rt)
+	if err != nil {
 		return err
 	}
-
-	stop := make(chan bool)
-	wg := &sync.WaitGroup{}
-
-	// start our dethrottler if we are going to be doing some sending
-	if cfg.MaxWorkers > 0 {
-		queue.StartDethrottler(rt.VK, stop, wg, models.MsgQueueName)
-	}
-
-	startMetricsReporter(rt, time.Minute, stop, wg)
-
-	server := web.NewServer(rt)
-	if err := server.Start(); err != nil {
-		return err
-	}
-
-	foreman := sender.NewForeman(rt, cfg.MaxWorkers)
-	foreman.Start()
 
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
@@ -105,20 +83,73 @@ func Service(defaults *runtime.Config, version, date string) error {
 	})
 	defer watchdog.Stop()
 
-	// stop sending first so in-flight sends finish before the writers they depend on go away
-	foreman.Stop()
+	svc.stop()
 
-	if err := server.Stop(); err != nil {
-		return err
+	return nil
+}
+
+// service is the set of components this process runs, in the order they're started
+type service struct {
+	rt      *runtime.Runtime
+	quit    chan bool
+	waitFor *sync.WaitGroup
+	server  *web.Server
+	foreman *sender.Foreman
+}
+
+// startService starts each component in turn, unwinding whatever is already running if one of them fails, so that a
+// failure part way through doesn't leave the process with half a runtime
+func startService(rt *runtime.Runtime) (*service, error) {
+	s := &service{rt: rt, quit: make(chan bool), waitFor: &sync.WaitGroup{}}
+
+	if err := rt.Start(); err != nil {
+		return nil, fmt.Errorf("error starting runtime: %w", err)
+	}
+
+	// start the caches, spools and batched writers used by the read and write paths
+	if err := models.Start(rt); err != nil {
+		rt.Stop()
+		return nil, err
+	}
+
+	// start our dethrottler if we are going to be doing some sending
+	if rt.Config.MaxWorkers > 0 {
+		queue.StartDethrottler(rt.VK, s.quit, s.waitFor, models.MsgQueueName)
+	}
+
+	startMetricsReporter(rt, time.Minute, s.quit, s.waitFor)
+
+	server := web.NewServer(rt)
+	if err := server.Start(); err != nil {
+		s.stop()
+		return nil, err
+	}
+	s.server = server
+
+	foreman := sender.NewForeman(rt, rt.Config.MaxWorkers)
+	foreman.Start()
+	s.foreman = foreman
+
+	return s, nil
+}
+
+// stop stops each component in the reverse of the order it was started, skipping those which never started
+func (s *service) stop() {
+	// stop sending first so that in-flight sends finish before the writers they depend on go away
+	if s.foreman != nil {
+		s.foreman.Stop()
+	}
+	if s.server != nil {
+		if err := s.server.Stop(); err != nil {
+			slog.Error("error stopping server", "error", err)
+		}
 	}
 
 	// stop the dethrottler and metrics reporter
-	close(stop)
-	wg.Wait()
+	close(s.quit)
+	s.waitFor.Wait()
 
-	// stop the caches, spools and batched writers, then the runtime itself
+	// then the caches, spools and batched writers, and finally the runtime itself
 	models.Stop()
-	rt.Stop()
-
-	return nil
+	s.rt.Stop()
 }

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -1,15 +1,20 @@
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/nyaruka/courier/v26"
+	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/core/sender"
 	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/courier/v26/utils/queue"
+	"github.com/nyaruka/courier/v26/web"
 	slogmulti "github.com/samber/slog-multi"
 	slogsentry "github.com/samber/slog-sentry/v2"
 )
@@ -59,10 +64,35 @@ func Service(defaults *runtime.Config, version, date string) error {
 		return err
 	}
 
-	server := courier.NewServer(rt)
+	// log what we can and can't reach before we start doing anything with it
+	testConnections(rt)
+
+	if err := rt.Start(); err != nil {
+		return fmt.Errorf("error starting runtime: %w", err)
+	}
+
+	// start the caches, spools and batched writers used by the read and write paths
+	if err := models.Start(rt); err != nil {
+		return err
+	}
+
+	stop := make(chan bool)
+	wg := &sync.WaitGroup{}
+
+	// start our dethrottler if we are going to be doing some sending
+	if cfg.MaxWorkers > 0 {
+		queue.StartDethrottler(rt.VK, stop, wg, models.MsgQueueName)
+	}
+
+	startMetricsReporter(rt, time.Minute, stop, wg)
+
+	server := web.NewServer(rt)
 	if err := server.Start(); err != nil {
 		return err
 	}
+
+	foreman := sender.NewForeman(rt, cfg.MaxWorkers)
+	foreman.Start()
 
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
@@ -75,5 +105,20 @@ func Service(defaults *runtime.Config, version, date string) error {
 	})
 	defer watchdog.Stop()
 
-	return server.Stop()
+	// stop sending first so in-flight sends finish before the writers they depend on go away
+	foreman.Stop()
+
+	if err := server.Stop(); err != nil {
+		return err
+	}
+
+	// stop the dethrottler and metrics reporter
+	close(stop)
+	wg.Wait()
+
+	// stop the caches, spools and batched writers, then the runtime itself
+	models.Stop()
+	rt.Stop()
+
+	return nil
 }

--- a/core/sender/sender.go
+++ b/core/sender/sender.go
@@ -1,171 +1,37 @@
-package courier
+package sender
 
 import (
 	"context"
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
+	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils/clogs"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-type SendResult struct {
-	externalIDs []string
-	newURN      urns.URN
-}
-
-func (r *SendResult) AddExternalID(id string) {
-	r.externalIDs = append(r.externalIDs, id)
-}
-
-func (r *SendResult) ExternalIDs() []string {
-	return r.externalIDs
-}
-
-func (r *SendResult) SetNewURN(urn urns.URN) {
-	r.newURN = urn
-}
-
-func (r *SendResult) NewURN() urns.URN {
-	return r.newURN
-}
-
-type SendError struct {
-	msg       string
-	retryable bool
-	loggable  bool
-
-	clogCode    string
-	clogMsg     string
-	clogExtCode string
-}
-
-func (e *SendError) Error() string {
-	return e.msg
-}
-
-// ErrChannelConfig should be returned by a handler send method when channel config is invalid
-var ErrChannelConfig error = &SendError{
-	msg:       "channel config invalid",
-	retryable: false,
-	loggable:  true,
-	clogCode:  "channel_config",
-	clogMsg:   "Channel configuration is missing required values.",
-}
-
-// ErrMessageInvalid should be returned by a handler send method when the message it has received is invalid
-var ErrMessageInvalid error = &SendError{
-	msg:       "message invalid",
-	retryable: false,
-	loggable:  true,
-	clogCode:  "message_invalid",
-	clogMsg:   "Message is missing required values.",
-}
-
-// ErrConnectionFailed should be returned when connection to the channel fails (timeout or 5XX response)
-var ErrConnectionFailed error = &SendError{
-	msg:       "channel connection failed",
-	retryable: true,
-	loggable:  false,
-	clogCode:  "connection_failed",
-	clogMsg:   "Connection to server failed.",
-}
-
-// ErrConnectionThrottled should be returned when channel tells us we're rate limited
-var ErrConnectionThrottled error = &SendError{
-	msg:       "channel rate limited",
-	retryable: true,
-	loggable:  false,
-	clogCode:  "connection_throttled",
-	clogMsg:   "Connection to server has been rate limited.",
-}
-
-// ErrResponseStatus should be returned when the response from the channel has a non-success status code
-var ErrResponseStatus error = &SendError{
-	msg:       "response status code",
-	retryable: false,
-	loggable:  false,
-	clogCode:  "response_status",
-	clogMsg:   "Response has non-success status code.",
-}
-
-// ErrResponseContent should be returned when the response content from the channel indicates non-succeess
-var ErrResponseContent error = &SendError{
-	msg:       "response content",
-	retryable: false,
-	loggable:  false,
-	clogCode:  "response_content",
-	clogMsg:   "Response content indicates non-success.",
-}
-
-// ErrResponseUnparseable should be returned when channel response can't be parsed in expected format
-var ErrResponseUnparseable error = &SendError{
-	msg:       "response couldn't be parsed",
-	retryable: false,
-	loggable:  true,
-	clogCode:  "response_unparseable",
-	clogMsg:   "Response could not be parsed in the expected format.",
-}
-
-// ErrResponseUnexpected should be returned when channel response doesn't match what we expect
-var ErrResponseUnexpected error = &SendError{
-	msg:       "response not expected values",
-	retryable: false,
-	loggable:  true,
-	clogCode:  "response_unexpected",
-	clogMsg:   "Response doesn't match expected values.",
-}
-
-// ErrContactStopped should be returned when channel tells us explicitly that the contact has opted-out
-var ErrContactStopped error = &SendError{
-	msg:       "contact opted out",
-	retryable: false,
-	loggable:  false,
-	clogCode:  "contact_stopped",
-	clogMsg:   "Contact has opted-out of messages from this channel.",
-}
-
-func ErrFailedWithReason(code, desc string) *SendError {
-	return &SendError{
-		msg:         "channel rejected send with reason",
-		retryable:   false,
-		loggable:    false,
-		clogCode:    "rejected_with_reason",
-		clogMsg:     desc,
-		clogExtCode: code,
-	}
-}
-
-// ErrRetryableWithReason is like ErrFailedWithReason but for failures that may be transient and so should be retried
-func ErrRetryableWithReason(code, desc string) *SendError {
-	return &SendError{
-		msg:         "channel rejected send with retryable reason",
-		retryable:   true,
-		loggable:    false,
-		clogCode:    "rejected_with_reason",
-		clogMsg:     desc,
-		clogExtCode: code,
-	}
-}
-
 // Foreman takes care of managing our set of sending workers and assigns msgs for each to send
 type Foreman struct {
-	server           *Server
+	rt               *runtime.Runtime
 	senders          []*Sender
 	availableSenders chan *Sender
 	quit             chan bool
+	waitGroup        *sync.WaitGroup
 }
 
 // NewForeman creates a new Foreman for the passed in server with the number of max senders
-func NewForeman(server *Server, maxSenders int) *Foreman {
+func NewForeman(rt *runtime.Runtime, maxSenders int) *Foreman {
 	foreman := &Foreman{
-		server:           server,
+		rt:               rt,
 		senders:          make([]*Sender, maxSenders),
 		availableSenders: make(chan *Sender, maxSenders),
 		quit:             make(chan bool),
+		waitGroup:        &sync.WaitGroup{},
 	}
 
 	for i := 0; i < maxSenders; i++ {
@@ -190,13 +56,16 @@ func (f *Foreman) Stop() {
 	}
 	close(f.quit)
 	slog.Info("foreman stopping", "comp", "foreman", "state", "stopping")
+
+	// wait for the assign loop and all senders to finish what they're doing
+	f.waitGroup.Wait()
 }
 
 // Assign is our main loop for the Foreman, it takes care of popping the next outgoing messages from our
 // backend and assigning them to workers
 func (f *Foreman) Assign() {
-	f.server.WaitGroup().Add(1)
-	defer f.server.WaitGroup().Done()
+	f.waitGroup.Add(1)
+	defer f.waitGroup.Done()
 	log := slog.With("comp", "foreman")
 
 	log.Info("senders started and waiting",
@@ -216,7 +85,7 @@ func (f *Foreman) Assign() {
 		case sender := <-f.availableSenders:
 			// see if we have a message to work on
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-			msg, err := models.PopNextOutgoingMsg(ctx, f.server.rt)
+			msg, err := models.PopNextOutgoingMsg(ctx, f.rt)
 			cancel()
 
 			if err == nil && msg != nil {
@@ -260,10 +129,10 @@ func NewSender(foreman *Foreman, id int) *Sender {
 
 // Start starts our Sender's goroutine and has it start waiting for tasks from the foreman
 func (w *Sender) Start() {
-	w.foreman.server.WaitGroup().Add(1)
+	w.foreman.waitGroup.Add(1)
 
 	go func() {
-		defer w.foreman.server.WaitGroup().Done()
+		defer w.foreman.waitGroup.Done()
 		slog.Debug("started", "comp", "sender", "sender_id", w.id)
 		for {
 			// list ourselves as available for work
@@ -291,8 +160,7 @@ func (w *Sender) Stop() {
 func (w *Sender) sendMessage(msg *models.MsgOut) {
 	log := slog.With("comp", "sender", "sender_id", w.id, "channel_uuid", msg.Channel().UUID())
 
-	server := w.foreman.server
-	rt := server.rt
+	rt := w.foreman.rt
 
 	// we don't want any individual send taking more than 35s
 	sendCTX, cancel := context.WithTimeout(context.Background(), time.Second*35)
@@ -323,9 +191,9 @@ func (w *Sender) sendMessage(msg *models.MsgOut) {
 	}
 
 	var status *models.StatusUpdate
-	var res *SendResult
+	var res *courier.SendResult
 	var redactValues []string
-	handler := server.GetHandler(msg.Channel())
+	handler := courier.GetActiveHandler(msg.Channel().ChannelType())
 	if handler != nil {
 		redactValues = handler.RedactValues(msg.Channel())
 	}
@@ -367,9 +235,9 @@ func (w *Sender) sendMessage(msg *models.MsgOut) {
 	models.OnSendComplete(writeCTX, rt, msg, status, newURN, clog)
 }
 
-func (w *Sender) sendByHandler(ctx context.Context, h ChannelHandler, m *models.MsgOut, clog *models.ChannelLog, log *slog.Logger) (*models.StatusUpdate, *SendResult) {
-	rt := w.foreman.server.rt
-	res := &SendResult{}
+func (w *Sender) sendByHandler(ctx context.Context, h courier.ChannelHandler, m *models.MsgOut, clog *models.ChannelLog, log *slog.Logger) (*models.StatusUpdate, *courier.SendResult) {
+	rt := w.foreman.rt
+	res := &courier.SendResult{}
 	err := h.Send(ctx, m, res, clog)
 
 	status := models.NewStatusUpdate(m.Channel(), m.UUID(), models.MsgStatusWired, clog)
@@ -379,21 +247,21 @@ func (w *Sender) sendByHandler(ctx context.Context, h ChannelHandler, m *models.
 		status.SetExternalIdentifier(res.ExternalIDs()[0])
 	}
 
-	var serr *SendError
+	var serr *courier.SendError
 	if errors.As(err, &serr) {
-		if serr.loggable {
+		if serr.Loggable() {
 			log.Error("error sending message", "error", err)
 		}
-		if serr.retryable {
+		if serr.Retryable() {
 			status.SetStatus(models.MsgStatusErrored)
 		} else {
 			status.SetStatus(models.MsgStatusFailed)
 		}
 
-		clog.Error(&clogs.Error{Code: serr.clogCode, ExtCode: serr.clogExtCode, Message: serr.clogMsg})
+		clog.Error(serr.ClogError())
 
 		// if handler returned ErrContactStopped need to write a stop event
-		if serr == ErrContactStopped {
+		if serr == courier.ErrContactStopped {
 			channelEvent := models.NewChannelEvent(m.Channel(), models.EventTypeStopContact, m.URN(), clog)
 			if err = models.WriteChannelEvent(ctx, rt, channelEvent, clog); err != nil {
 				log.Error("error writing stop event", "error", err)

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,156 @@
+package courier
+
+import (
+	"github.com/nyaruka/courier/v26/utils/clogs"
+	"github.com/nyaruka/gocommon/urns"
+)
+
+type SendResult struct {
+	externalIDs []string
+	newURN      urns.URN
+}
+
+func (r *SendResult) AddExternalID(id string) {
+	r.externalIDs = append(r.externalIDs, id)
+}
+
+func (r *SendResult) ExternalIDs() []string {
+	return r.externalIDs
+}
+
+func (r *SendResult) SetNewURN(urn urns.URN) {
+	r.newURN = urn
+}
+
+func (r *SendResult) NewURN() urns.URN {
+	return r.newURN
+}
+
+type SendError struct {
+	msg       string
+	retryable bool
+	loggable  bool
+
+	clogCode    string
+	clogMsg     string
+	clogExtCode string
+}
+
+func (e *SendError) Error() string {
+	return e.msg
+}
+
+// Retryable returns whether a send which failed this way should be tried again later
+func (e *SendError) Retryable() bool { return e.retryable }
+
+// Loggable returns whether this failure indicates a problem on our side worth logging as an error
+func (e *SendError) Loggable() bool { return e.loggable }
+
+// ClogError returns the user facing error to record on the channel log
+func (e *SendError) ClogError() *clogs.Error {
+	return &clogs.Error{Code: e.clogCode, ExtCode: e.clogExtCode, Message: e.clogMsg}
+}
+
+// ErrChannelConfig should be returned by a handler send method when channel config is invalid
+var ErrChannelConfig error = &SendError{
+	msg:       "channel config invalid",
+	retryable: false,
+	loggable:  true,
+	clogCode:  "channel_config",
+	clogMsg:   "Channel configuration is missing required values.",
+}
+
+// ErrMessageInvalid should be returned by a handler send method when the message it has received is invalid
+var ErrMessageInvalid error = &SendError{
+	msg:       "message invalid",
+	retryable: false,
+	loggable:  true,
+	clogCode:  "message_invalid",
+	clogMsg:   "Message is missing required values.",
+}
+
+// ErrConnectionFailed should be returned when connection to the channel fails (timeout or 5XX response)
+var ErrConnectionFailed error = &SendError{
+	msg:       "channel connection failed",
+	retryable: true,
+	loggable:  false,
+	clogCode:  "connection_failed",
+	clogMsg:   "Connection to server failed.",
+}
+
+// ErrConnectionThrottled should be returned when channel tells us we're rate limited
+var ErrConnectionThrottled error = &SendError{
+	msg:       "channel rate limited",
+	retryable: true,
+	loggable:  false,
+	clogCode:  "connection_throttled",
+	clogMsg:   "Connection to server has been rate limited.",
+}
+
+// ErrResponseStatus should be returned when the response from the channel has a non-success status code
+var ErrResponseStatus error = &SendError{
+	msg:       "response status code",
+	retryable: false,
+	loggable:  false,
+	clogCode:  "response_status",
+	clogMsg:   "Response has non-success status code.",
+}
+
+// ErrResponseContent should be returned when the response content from the channel indicates non-succeess
+var ErrResponseContent error = &SendError{
+	msg:       "response content",
+	retryable: false,
+	loggable:  false,
+	clogCode:  "response_content",
+	clogMsg:   "Response content indicates non-success.",
+}
+
+// ErrResponseUnparseable should be returned when channel response can't be parsed in expected format
+var ErrResponseUnparseable error = &SendError{
+	msg:       "response couldn't be parsed",
+	retryable: false,
+	loggable:  true,
+	clogCode:  "response_unparseable",
+	clogMsg:   "Response could not be parsed in the expected format.",
+}
+
+// ErrResponseUnexpected should be returned when channel response doesn't match what we expect
+var ErrResponseUnexpected error = &SendError{
+	msg:       "response not expected values",
+	retryable: false,
+	loggable:  true,
+	clogCode:  "response_unexpected",
+	clogMsg:   "Response doesn't match expected values.",
+}
+
+// ErrContactStopped should be returned when channel tells us explicitly that the contact has opted-out
+var ErrContactStopped error = &SendError{
+	msg:       "contact opted out",
+	retryable: false,
+	loggable:  false,
+	clogCode:  "contact_stopped",
+	clogMsg:   "Contact has opted-out of messages from this channel.",
+}
+
+func ErrFailedWithReason(code, desc string) *SendError {
+	return &SendError{
+		msg:         "channel rejected send with reason",
+		retryable:   false,
+		loggable:    false,
+		clogCode:    "rejected_with_reason",
+		clogMsg:     desc,
+		clogExtCode: code,
+	}
+}
+
+// ErrRetryableWithReason is like ErrFailedWithReason but for failures that may be transient and so should be retried
+func ErrRetryableWithReason(code, desc string) *SendError {
+	return &SendError{
+		msg:         "channel rejected send with retryable reason",
+		retryable:   true,
+		loggable:    false,
+		clogCode:    "rejected_with_reason",
+		clogMsg:     desc,
+		clogExtCode: code,
+	}
+}

--- a/handler.go
+++ b/handler.go
@@ -19,6 +19,10 @@ type ChannelHandleFunc func(context.Context, *models.Channel, http.ResponseWrite
 
 // ChannelHandler is the interface all handlers must satisfy
 type ChannelHandler interface {
+	// SetRuntime is called before Initialize to give the handler the runtime it should use. Handlers embedding
+	// handlers.BaseHandler get it from there rather than implementing it themselves.
+	SetRuntime(*runtime.Runtime)
+
 	Initialize(*Registry) error
 	Runtime() *runtime.Runtime
 	ChannelType() models.ChannelType
@@ -92,21 +96,16 @@ type Route struct {
 	Func    ChannelHandleFunc
 }
 
-// Registry is what a channel handler is initialized with. It carries the runtime the handler needs, and collects
-// the routes it registers so that the web server can mount them - which is what keeps the handler contract free of
-// any dependency on the HTTP server itself.
+// Registry is what a channel handler is initialized with. It collects the routes the handler registers so that the
+// web server can mount them, which is what keeps the handler contract free of any dependency on the server itself.
 type Registry struct {
-	rt     *runtime.Runtime
 	routes []*Route
 }
 
-// NewRegistry creates a new registry for handlers initialized against the given runtime
-func NewRegistry(rt *runtime.Runtime) *Registry {
-	return &Registry{rt: rt}
+// NewRegistry creates a new registry for a handler to register its routes with
+func NewRegistry() *Registry {
+	return &Registry{}
 }
-
-// Runtime returns the runtime handlers should use
-func (r *Registry) Runtime() *runtime.Runtime { return r.rt }
 
 // AddHandlerRoute records a route which the handler wants to serve
 func (r *Registry) AddHandlerRoute(handler ChannelHandler, method string, action string, logType clogs.Type, handlerFunc ChannelHandleFunc) {

--- a/handler.go
+++ b/handler.go
@@ -23,7 +23,7 @@ type ChannelHandler interface {
 	// handlers.BaseHandler get it from there rather than implementing it themselves.
 	SetRuntime(*runtime.Runtime)
 
-	Initialize(*Registry) error
+	Initialize(*Routes) error
 	Runtime() *runtime.Runtime
 	ChannelType() models.ChannelType
 	ChannelName() string
@@ -87,7 +87,7 @@ func GetActiveHandler(ct models.ChannelType) ChannelHandler {
 var registeredHandlers = make(map[models.ChannelType]ChannelHandler)
 var activeHandlers = make(map[models.ChannelType]ChannelHandler)
 
-// Route is an HTTP route a channel handler serves, registered during its initialization
+// Route is an HTTP route a channel handler serves, added during its initialization
 type Route struct {
 	Handler ChannelHandler
 	Method  string
@@ -96,21 +96,21 @@ type Route struct {
 	Func    ChannelHandleFunc
 }
 
-// Registry is what a channel handler is initialized with. It collects the routes the handler registers so that the
-// web server can mount them, which is what keeps the handler contract free of any dependency on the server itself.
-type Registry struct {
+// Routes is what a channel handler is initialized with, and collects the routes it wants to serve so that the web
+// server can mount them - which is what keeps the handler contract free of any dependency on the server itself.
+type Routes struct {
 	routes []*Route
 }
 
-// NewRegistry creates a new registry for a handler to register its routes with
-func NewRegistry() *Registry {
-	return &Registry{}
+// NewRoutes creates an empty set of routes for a handler to add to
+func NewRoutes() *Routes {
+	return &Routes{}
 }
 
-// AddHandlerRoute records a route which the handler wants to serve
-func (r *Registry) AddHandlerRoute(handler ChannelHandler, method string, action string, logType clogs.Type, handlerFunc ChannelHandleFunc) {
+// Add adds a route which the handler wants to serve
+func (r *Routes) Add(handler ChannelHandler, method string, action string, logType clogs.Type, handlerFunc ChannelHandleFunc) {
 	r.routes = append(r.routes, &Route{Handler: handler, Method: method, Action: action, LogType: logType, Func: handlerFunc})
 }
 
-// Routes returns the routes registered so far
-func (r *Registry) Routes() []*Route { return r.routes }
+// All returns every route added so far
+func (r *Routes) All() []*Route { return r.routes }

--- a/handler.go
+++ b/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/courier/v26/utils/clogs"
 	"github.com/nyaruka/goflow/core/events"
 )
 
@@ -18,7 +19,7 @@ type ChannelHandleFunc func(context.Context, *models.Channel, http.ResponseWrite
 
 // ChannelHandler is the interface all handlers must satisfy
 type ChannelHandler interface {
-	Initialize(*Server) error
+	Initialize(*Registry) error
 	Runtime() *runtime.Runtime
 	ChannelType() models.ChannelType
 	ChannelName() string
@@ -59,5 +60,58 @@ func GetHandler(ct models.ChannelType) ChannelHandler {
 	return registeredHandlers[ct]
 }
 
+// RegisteredHandlers returns all the handlers compiled into this build, for the server to initialize
+func RegisteredHandlers() []ChannelHandler {
+	hs := make([]ChannelHandler, 0, len(registeredHandlers))
+	for _, h := range registeredHandlers {
+		hs = append(hs, h)
+	}
+	return hs
+}
+
+// ActivateHandler marks a handler as one this instance is serving, i.e. it was included by config and initialized
+func ActivateHandler(handler ChannelHandler) {
+	activeHandlers[handler.ChannelType()] = handler
+}
+
+// GetActiveHandler returns the handler this instance is serving for the given channel type, or nil if that channel
+// type isn't being served - which is how sending fails fast for a channel this instance doesn't handle.
+func GetActiveHandler(ct models.ChannelType) ChannelHandler {
+	return activeHandlers[ct]
+}
+
 var registeredHandlers = make(map[models.ChannelType]ChannelHandler)
 var activeHandlers = make(map[models.ChannelType]ChannelHandler)
+
+// Route is an HTTP route a channel handler serves, registered during its initialization
+type Route struct {
+	Handler ChannelHandler
+	Method  string
+	Action  string
+	LogType clogs.Type
+	Func    ChannelHandleFunc
+}
+
+// Registry is what a channel handler is initialized with. It carries the runtime the handler needs, and collects
+// the routes it registers so that the web server can mount them - which is what keeps the handler contract free of
+// any dependency on the HTTP server itself.
+type Registry struct {
+	rt     *runtime.Runtime
+	routes []*Route
+}
+
+// NewRegistry creates a new registry for handlers initialized against the given runtime
+func NewRegistry(rt *runtime.Runtime) *Registry {
+	return &Registry{rt: rt}
+}
+
+// Runtime returns the runtime handlers should use
+func (r *Registry) Runtime() *runtime.Runtime { return r.rt }
+
+// AddHandlerRoute records a route which the handler wants to serve
+func (r *Registry) AddHandlerRoute(handler ChannelHandler, method string, action string, logType clogs.Type, handlerFunc ChannelHandleFunc) {
+	r.routes = append(r.routes, &Route{Handler: handler, Method: method, Action: action, LogType: logType, Func: handlerFunc})
+}
+
+// Routes returns the routes registered so far
+func (r *Registry) Routes() []*Route { return r.routes }

--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -41,8 +41,8 @@ type moForm struct {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "callback", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "delivery", models.ChannelLogTypeMsgStatus, h.receiveStatus)

--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -42,7 +42,6 @@ type moForm struct {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "callback", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "delivery", models.ChannelLogTypeMsgStatus, h.receiveStatus)

--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -41,11 +41,11 @@ type moForm struct {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "callback", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "delivery", models.ChannelLogTypeMsgStatus, h.receiveStatus)
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "callback", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "delivery", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil
 }
 

--- a/handlers/arabiacell/handler.go
+++ b/handlers/arabiacell/handler.go
@@ -35,8 +35,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	receiveHandler := handlers.NewTelReceiveHandler(h, "M", "B")
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
 	return nil

--- a/handlers/arabiacell/handler.go
+++ b/handlers/arabiacell/handler.go
@@ -36,7 +36,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	receiveHandler := handlers.NewTelReceiveHandler(h, "M", "B")
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
 	return nil

--- a/handlers/arabiacell/handler.go
+++ b/handlers/arabiacell/handler.go
@@ -35,9 +35,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
+func (h *handler) Initialize(r *courier.Routes) error {
 	receiveHandler := handlers.NewTelReceiveHandler(h, "M", "B")
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
 	return nil
 }
 

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -44,7 +44,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.statusMessage)
 	return nil

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -43,9 +43,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.statusMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.statusMessage)
 	return nil
 }
 

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -43,8 +43,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.statusMessage)
 	return nil

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -52,9 +52,9 @@ func WithRedactConfigKeys(keys ...string) func(*BaseHandler) {
 	}
 }
 
-// SetRegistry is called during initialization to give the handler the runtime it should use
-func (h *BaseHandler) SetRegistry(reg *courier.Registry) {
-	h.rt = reg.Runtime()
+// SetRuntime gives the handler the runtime it should use, and is called before Initialize
+func (h *BaseHandler) SetRuntime(rt *runtime.Runtime) {
+	h.rt = rt
 }
 
 // Runtime returns the runtime instance on the BaseHandler

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -52,9 +52,9 @@ func WithRedactConfigKeys(keys ...string) func(*BaseHandler) {
 	}
 }
 
-// SetServer can be used to change the server on a BaseHandler
-func (h *BaseHandler) SetServer(server *courier.Server) {
-	h.rt = server.Runtime()
+// SetRegistry is called during initialization to give the handler the runtime it should use
+func (h *BaseHandler) SetRegistry(reg *courier.Registry) {
+	h.rt = reg.Runtime()
 }
 
 // Runtime returns the runtime instance on the BaseHandler

--- a/handlers/base_test.go
+++ b/handlers/base_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/test"
@@ -46,7 +45,7 @@ func TestRequestHTTP(t *testing.T) {
 	server := web.NewServer(rt)
 
 	h := handlers.NewBaseHandler("NX", "Test")
-	h.SetRegistry(courier.NewRegistry(server.Runtime()))
+	h.SetRuntime(server.Runtime())
 
 	req, _ := http.NewRequest("POST", "https://api.messages.com/send.json", nil)
 	resp, respBody, err := h.RequestHTTP(req, clog)

--- a/handlers/base_test.go
+++ b/handlers/base_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/testsuite"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/stretchr/testify/assert"
@@ -42,10 +43,10 @@ func TestRequestHTTP(t *testing.T) {
 		},
 	})
 
-	server := courier.NewServer(rt)
+	server := web.NewServer(rt)
 
 	h := handlers.NewBaseHandler("NX", "Test")
-	h.SetServer(server)
+	h.SetRegistry(courier.NewRegistry(server.Runtime()))
 
 	req, _ := http.NewRequest("POST", "https://api.messages.com/send.json", nil)
 	resp, respBody, err := h.RequestHTTP(req, clog)

--- a/handlers/burstsms/handler.go
+++ b/handlers/burstsms/handler.go
@@ -38,8 +38,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	receiveHandler := handlers.NewTelReceiveHandler(h, "mobile", "response")
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
 

--- a/handlers/burstsms/handler.go
+++ b/handlers/burstsms/handler.go
@@ -38,12 +38,12 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
+func (h *handler) Initialize(r *courier.Routes) error {
 	receiveHandler := handlers.NewTelReceiveHandler(h, "mobile", "response")
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
 
 	statusHandler := handlers.NewExternalIDStatusHandler(h, statusMap, "message_id", "status")
-	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, statusHandler)
+	r.Add(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, statusHandler)
 	return nil
 }
 

--- a/handlers/burstsms/handler.go
+++ b/handlers/burstsms/handler.go
@@ -39,7 +39,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	receiveHandler := handlers.NewTelReceiveHandler(h, "mobile", "response")
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
 

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -38,7 +38,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.receiveStatus))
 	return nil

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -37,8 +37,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.receiveStatus))
 	return nil

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -37,9 +37,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.receiveStatus))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.receiveStatus))
 	return nil
 }
 

--- a/handlers/clickmobile/handler.go
+++ b/handlers/clickmobile/handler.go
@@ -38,8 +38,8 @@ func newHandler() courier.ChannelHandler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("CM"), "Click Mobile")}
 }
 
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil

--- a/handlers/clickmobile/handler.go
+++ b/handlers/clickmobile/handler.go
@@ -38,9 +38,9 @@ func newHandler() courier.ChannelHandler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("CM"), "Click Mobile")}
 }
 
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/clickmobile/handler.go
+++ b/handlers/clickmobile/handler.go
@@ -39,7 +39,6 @@ func newHandler() courier.ChannelHandler {
 }
 
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil

--- a/handlers/clicksend/handler.go
+++ b/handlers/clicksend/handler.go
@@ -31,8 +31,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.NewTelReceiveHandler(h, "from", "body"))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.NewTelReceiveHandler(h, "from", "body"))
 	return nil
 }
 

--- a/handlers/clicksend/handler.go
+++ b/handlers/clicksend/handler.go
@@ -32,7 +32,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.NewTelReceiveHandler(h, "from", "body"))
 	return nil
 }

--- a/handlers/clicksend/handler.go
+++ b/handlers/clicksend/handler.go
@@ -31,8 +31,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.NewTelReceiveHandler(h, "from", "body"))
 	return nil
 }

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -51,7 +51,6 @@ func init() {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodGet, "delivered", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -50,9 +50,9 @@ func init() {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodGet, "delivered", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodGet, "delivered", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil
 }
 

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -50,8 +50,8 @@ func init() {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodGet, "delivered", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -45,8 +45,8 @@ func newWAHandler(channelType models.ChannelType, name string) courier.ChannelHa
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvent))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }
 

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -45,8 +45,8 @@ func newWAHandler(channelType models.ChannelType, name string) courier.ChannelHa
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -46,7 +46,6 @@ func newWAHandler(channelType models.ChannelType, name string) courier.ChannelHa
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/utils/clogs"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
@@ -1046,10 +1047,10 @@ func TestSendEvent(t *testing.T) {
 		"base_url":   "https://waba-v2.360dialog.io",
 	})
 
-	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
+	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
 	h := newWAHandler(models.ChannelType("D3C"), "360Dialog").(*handler)
-	h.Initialize(s)
+	s.MountHandler(h)
 
 	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://waba-v2.360dialog.io/messages": {

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -33,8 +33,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -33,9 +33,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil
 }
 

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -34,7 +34,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -66,24 +66,24 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 
 	sentHandler := h.buildStatusHandler("sent")
-	s.AddHandlerRoute(h, http.MethodGet, "sent", models.ChannelLogTypeMsgStatus, sentHandler)
-	s.AddHandlerRoute(h, http.MethodPost, "sent", models.ChannelLogTypeMsgStatus, sentHandler)
+	r.Add(h, http.MethodGet, "sent", models.ChannelLogTypeMsgStatus, sentHandler)
+	r.Add(h, http.MethodPost, "sent", models.ChannelLogTypeMsgStatus, sentHandler)
 
 	deliveredHandler := h.buildStatusHandler("delivered")
-	s.AddHandlerRoute(h, http.MethodGet, "delivered", models.ChannelLogTypeMsgStatus, deliveredHandler)
-	s.AddHandlerRoute(h, http.MethodPost, "delivered", models.ChannelLogTypeMsgStatus, deliveredHandler)
+	r.Add(h, http.MethodGet, "delivered", models.ChannelLogTypeMsgStatus, deliveredHandler)
+	r.Add(h, http.MethodPost, "delivered", models.ChannelLogTypeMsgStatus, deliveredHandler)
 
 	failedHandler := h.buildStatusHandler("failed")
-	s.AddHandlerRoute(h, http.MethodGet, "failed", models.ChannelLogTypeMsgStatus, failedHandler)
-	s.AddHandlerRoute(h, http.MethodPost, "failed", models.ChannelLogTypeMsgStatus, failedHandler)
+	r.Add(h, http.MethodGet, "failed", models.ChannelLogTypeMsgStatus, failedHandler)
+	r.Add(h, http.MethodPost, "failed", models.ChannelLogTypeMsgStatus, failedHandler)
 
-	s.AddHandlerRoute(h, http.MethodPost, "stopped", models.ChannelLogTypeEventReceive, h.receiveStopContact)
-	s.AddHandlerRoute(h, http.MethodGet, "stopped", models.ChannelLogTypeEventReceive, h.receiveStopContact)
+	r.Add(h, http.MethodPost, "stopped", models.ChannelLogTypeEventReceive, h.receiveStopContact)
+	r.Add(h, http.MethodGet, "stopped", models.ChannelLogTypeEventReceive, h.receiveStopContact)
 
 	return nil
 }

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -66,8 +66,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -67,7 +67,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -63,8 +63,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
 	return nil

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -64,7 +64,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
 	return nil

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -63,9 +63,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
 	return nil
 }
 

--- a/handlers/facebook_legacy/handler_test.go
+++ b/handlers/facebook_legacy/handler_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/stretchr/testify/assert"
@@ -696,7 +697,7 @@ func TestDescribeURN(t *testing.T) {
 
 	channel := testChannels[0]
 	handler := newHandler()
-	handler.Initialize(courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())))
+	web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, channel, nil, handler.RedactValues(channel))
 
 	tcs := []struct {

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -49,9 +49,9 @@ func newHandler() courier.ChannelHandler {
 	}
 }
 
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "register", models.ChannelLogTypeEventReceive, h.registerContact)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "register", models.ChannelLogTypeEventReceive, h.registerContact)
 	return nil
 }
 

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -50,7 +50,6 @@ func newHandler() courier.ChannelHandler {
 }
 
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "register", models.ChannelLogTypeEventReceive, h.registerContact)
 	return nil

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -49,8 +49,8 @@ func newHandler() courier.ChannelHandler {
 	}
 }
 
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "register", models.ChannelLogTypeEventReceive, h.registerContact)
 	return nil

--- a/handlers/freshchat/handler.go
+++ b/handlers/freshchat/handler.go
@@ -44,8 +44,8 @@ func newHandler(channelType models.ChannelType, name string, validateSignatures 
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }

--- a/handlers/freshchat/handler.go
+++ b/handlers/freshchat/handler.go
@@ -44,8 +44,8 @@ func newHandler(channelType models.ChannelType, name string, validateSignatures 
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, payload *moPayload, clog *models.ChannelLog) ([]courier.Event, error) {

--- a/handlers/freshchat/handler.go
+++ b/handlers/freshchat/handler.go
@@ -45,7 +45,6 @@ func newHandler(channelType models.ChannelType, name string, validateSignatures 
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }

--- a/handlers/globe/handler.go
+++ b/handlers/globe/handler.go
@@ -40,7 +40,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }

--- a/handlers/globe/handler.go
+++ b/handlers/globe/handler.go
@@ -39,8 +39,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }
 

--- a/handlers/globe/handler.go
+++ b/handlers/globe/handler.go
@@ -39,8 +39,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -33,8 +33,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -33,9 +33,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil
 }
 

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -34,7 +34,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/hormuud/handler.go
+++ b/handlers/hormuud/handler.go
@@ -39,7 +39,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/hormuud/handler.go
+++ b/handlers/hormuud/handler.go
@@ -38,8 +38,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/hormuud/handler.go
+++ b/handlers/hormuud/handler.go
@@ -38,8 +38,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/i2sms/handler.go
+++ b/handlers/i2sms/handler.go
@@ -39,7 +39,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receive)
 	return nil
 }

--- a/handlers/i2sms/handler.go
+++ b/handlers/i2sms/handler.go
@@ -38,8 +38,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receive)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receive)
 	return nil
 }
 

--- a/handlers/i2sms/handler.go
+++ b/handlers/i2sms/handler.go
@@ -38,8 +38,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receive)
 	return nil
 }

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -32,9 +32,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
-	s.AddHandlerRoute(h, http.MethodPost, "delivered", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.statusMessage))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
+	r.Add(h, http.MethodPost, "delivered", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.statusMessage))
 	return nil
 }
 

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -33,7 +33,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "delivered", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.statusMessage))
 	return nil

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -32,8 +32,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "delivered", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.statusMessage))
 	return nil

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -33,8 +33,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -33,9 +33,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil
 }
 

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -34,7 +34,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -54,7 +54,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
 	s.AddHandlerRoute(h, http.MethodPost, "rcv/msg/message", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "rcv/event/menu", models.ChannelLogTypeEventReceive, handlers.JSONPayload(h, h.receiveMessage))

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -53,8 +53,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
 	s.AddHandlerRoute(h, http.MethodPost, "rcv/msg/message", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "rcv/event/menu", models.ChannelLogTypeEventReceive, handlers.JSONPayload(h, h.receiveMessage))

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -53,11 +53,11 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
-	s.AddHandlerRoute(h, http.MethodPost, "rcv/msg/message", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
-	s.AddHandlerRoute(h, http.MethodPost, "rcv/event/menu", models.ChannelLogTypeEventReceive, handlers.JSONPayload(h, h.receiveMessage))
-	s.AddHandlerRoute(h, http.MethodPost, "rcv/event/follow", models.ChannelLogTypeEventReceive, handlers.JSONPayload(h, h.receiveMessage))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
+	r.Add(h, http.MethodPost, "rcv/msg/message", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
+	r.Add(h, http.MethodPost, "rcv/event/menu", models.ChannelLogTypeEventReceive, handlers.JSONPayload(h, h.receiveMessage))
+	r.Add(h, http.MethodPost, "rcv/event/follow", models.ChannelLogTypeEventReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }
 

--- a/handlers/jiochat/handler_test.go
+++ b/handlers/jiochat/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/testsuite"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/stretchr/testify/assert"
@@ -288,9 +289,9 @@ func TestDescribeURN(t *testing.T) {
 	defer rc.Close()
 	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 
-	s := courier.NewServer(rt)
+	s := web.NewServer(rt)
 	handler := newHandler().(*handler)
-	handler.Initialize(s)
+	s.MountHandler(handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 
 	tcs := []struct {
@@ -321,14 +322,14 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	rt.HTTP = &http.Client{Timeout: 30 * time.Second}
 	rt.HTTPProxied = rt.HTTP
 
-	s := courier.NewServer(rt)
+	s := web.NewServer(rt)
 	rt.HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://channels.jiochat.com/auth/token.action": {
 			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"access_token": "SESAME"}`)),
 		},
 	})
 	handler := newHandler().(*handler)
-	handler.Initialize(s)
+	s.MountHandler(handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 
 	// check that request has the fetched access token

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -37,7 +37,6 @@ func init() {
 
 // Initialize implements courier.ChannelHandler
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.statusMessage))
 	return nil

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -36,8 +36,8 @@ func init() {
 }
 
 // Initialize implements courier.ChannelHandler
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.statusMessage))
 	return nil

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -36,9 +36,9 @@ func init() {
 }
 
 // Initialize implements courier.ChannelHandler
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.statusMessage))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.statusMessage))
 	return nil
 }
 

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -42,9 +42,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
-	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
+	r.Add(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil
 }
 

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -43,7 +43,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
 	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -42,8 +42,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
 	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -43,8 +43,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgReceive, h.receiveStatus)
 	return nil

--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -44,7 +44,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgReceive, h.receiveStatus)
 	return nil

--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -43,9 +43,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgReceive, h.receiveStatus)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodGet, "status", models.ChannelLogTypeMsgReceive, h.receiveStatus)
 	return nil
 }
 

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -56,8 +56,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }
 

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -56,8 +56,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -57,7 +57,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }

--- a/handlers/line/handler_test.go
+++ b/handlers/line/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/testsuite"
 	"github.com/nyaruka/courier/v26/utils/clogs"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
@@ -711,9 +712,9 @@ func TestBuildAttachmentRequest(t *testing.T) {
 func TestSendEvent(t *testing.T) {
 	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "LN", "2020", "US", []string{urns.Line.Prefix}, map[string]any{"auth_token": "AccessToken"})
 
-	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
+	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 	h := newHandler().(*handler)
-	h.Initialize(s)
+	s.MountHandler(h)
 
 	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://api.line.me/v2/bot/chat/loading/start": {

--- a/handlers/m3tech/handler.go
+++ b/handlers/m3tech/handler.go
@@ -33,8 +33,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/m3tech/handler.go
+++ b/handlers/m3tech/handler.go
@@ -33,8 +33,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/m3tech/handler.go
+++ b/handlers/m3tech/handler.go
@@ -34,7 +34,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/macrokiosk/handler.go
+++ b/handlers/macrokiosk/handler.go
@@ -41,11 +41,11 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
-	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.Add(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/macrokiosk/handler.go
+++ b/handlers/macrokiosk/handler.go
@@ -41,8 +41,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)

--- a/handlers/macrokiosk/handler.go
+++ b/handlers/macrokiosk/handler.go
@@ -42,7 +42,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)

--- a/handlers/mblox/handler.go
+++ b/handlers/mblox/handler.go
@@ -35,8 +35,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/mblox/handler.go
+++ b/handlers/mblox/handler.go
@@ -35,8 +35,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }
 

--- a/handlers/mblox/handler.go
+++ b/handlers/mblox/handler.go
@@ -36,7 +36,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -91,7 +91,6 @@ func newHandler(channelType models.ChannelType, name string, validateSignatures 
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -90,8 +90,8 @@ func newHandler(channelType models.ChannelType, name string, validateSignatures 
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -90,9 +90,9 @@ func newHandler(channelType models.ChannelType, name string, validateSignatures 
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 
 	return nil
 }

--- a/handlers/messangi/handler.go
+++ b/handlers/messangi/handler.go
@@ -40,9 +40,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
+func (h *handler) Initialize(r *courier.Routes) error {
 	receiveHandler := handlers.NewTelReceiveHandler(h, "mobile", "mo")
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
 	return nil
 }
 

--- a/handlers/messangi/handler.go
+++ b/handlers/messangi/handler.go
@@ -41,7 +41,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	receiveHandler := handlers.NewTelReceiveHandler(h, "mobile", "mo")
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
 	return nil

--- a/handlers/messangi/handler.go
+++ b/handlers/messangi/handler.go
@@ -40,8 +40,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	receiveHandler := handlers.NewTelReceiveHandler(h, "mobile", "mo")
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)
 	return nil

--- a/handlers/meta/facebook_test.go
+++ b/handlers/meta/facebook_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
@@ -280,7 +281,7 @@ func TestFacebookDescribeURN(t *testing.T) {
 
 	channel := facebookTestChannels[0]
 	handler := newHandler("FBA", "Facebook")
-	handler.Initialize(courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())))
+	web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, channel, nil, handler.RedactValues(channel))
 
 	tcs := []struct {
@@ -604,10 +605,10 @@ func TestFacebookOutgoing(t *testing.T) {
 func TestFacebookSendEvent(t *testing.T) {
 	channel := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "FBA", "12345", "", []string{urns.Facebook.Prefix}, map[string]any{models.ConfigAuthToken: "a123"})
 
-	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
+	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
 	h := newHandler("FBA", "Facebook").(*handler)
-	h.Initialize(s)
+	s.MountHandler(h)
 
 	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://graph.facebook.com/v25.0/me/messages*": {
@@ -680,10 +681,10 @@ func TestSigning(t *testing.T) {
 }
 
 func TestFacebookBuildAttachmentRequest(t *testing.T) {
-	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
+	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
 	handler := &handler{NewBaseHandler(models.ChannelType("FBA"), "Facebook", DisableUUIDRouting())}
-	handler.Initialize(s)
+	s.MountHandler(handler)
 	req, _ := handler.BuildAttachmentRequest(context.Background(), facebookTestChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, http.Header{}, req.Header)

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -77,9 +77,9 @@ type handler struct {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
 	return nil
 }
 

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -78,7 +78,6 @@ type handler struct {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
 	return nil

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -77,8 +77,8 @@ type handler struct {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
 	return nil

--- a/handlers/meta/instagram_test.go
+++ b/handlers/meta/instagram_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/stretchr/testify/assert"
@@ -458,7 +459,7 @@ func TestInstagramDescribeURN(t *testing.T) {
 
 	channel := instgramTestChannels[0]
 	handler := newHandler("IG", "Instagram")
-	handler.Initialize(courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())))
+	web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, channel, nil, handler.RedactValues(channel))
 
 	tcs := []struct {
@@ -478,10 +479,10 @@ func TestInstagramDescribeURN(t *testing.T) {
 }
 
 func TestInstagramBuildAttachmentRequest(t *testing.T) {
-	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
+	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
 	handler := &handler{NewBaseHandler(models.ChannelType("IG"), "Instagram", DisableUUIDRouting())}
-	handler.Initialize(s)
+	s.MountHandler(handler)
 	req, _ := handler.BuildAttachmentRequest(context.Background(), facebookTestChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, http.Header{}, req.Header)

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/utils/clogs"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
@@ -1160,7 +1161,7 @@ func TestWhatsAppOutgoing(t *testing.T) {
 func TestWhatsAppDescribeURN(t *testing.T) {
 	channel := whatsappTestChannels[0]
 	handler := newHandler("WAC", "Cloud API WhatsApp")
-	handler.Initialize(newServerWithWAC())
+	newServerWithWAC().MountHandler(handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, channel, nil, handler.RedactValues(channel))
 
 	tcs := []struct {
@@ -1182,16 +1183,16 @@ func TestWhatsAppDescribeURN(t *testing.T) {
 func TestWhatsAppBuildAttachmentRequest(t *testing.T) {
 	s := newServerWithWAC()
 	handler := &handler{NewBaseHandler(models.ChannelType("WAC"), "WhatsApp Cloud", DisableUUIDRouting())}
-	handler.Initialize(s)
+	s.MountHandler(handler)
 	req, _ := handler.BuildAttachmentRequest(context.Background(), whatsappTestChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer wac_admin_system_user_token", req.Header.Get("Authorization"))
 }
 
-func newServerWithWAC() *courier.Server {
+func newServerWithWAC() *web.Server {
 	cfg := runtime.NewDefaultConfig()
 	cfg.WhatsappAdminSystemUserToken = "wac_admin_system_user_token"
-	return courier.NewServer(runtime.NewTestRuntime(cfg))
+	return web.NewServer(runtime.NewTestRuntime(cfg))
 }
 
 func TestWhatsAppSendEvent(t *testing.T) {
@@ -1203,10 +1204,10 @@ func TestWhatsAppSendEvent(t *testing.T) {
 
 	cfg := runtime.NewDefaultConfig()
 	cfg.WhatsappAdminSystemUserToken = "wac_admin_system_user_token"
-	s := courier.NewServer(runtime.NewTestRuntime(cfg))
+	s := web.NewServer(runtime.NewTestRuntime(cfg))
 
 	h := newHandler("WAC", "WhatsApp Cloud").(*handler)
-	h.Initialize(s)
+	s.MountHandler(h)
 
 	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://graph.facebook.com/12345_ID/messages": {

--- a/handlers/mtarget/handler.go
+++ b/handlers/mtarget/handler.go
@@ -45,7 +45,6 @@ var statusMapping = map[string]models.MsgStatus{
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
 
 	statusHandler := handlers.NewExternalIDStatusHandler(h, statusMapping, "MsgId", "Status")

--- a/handlers/mtarget/handler.go
+++ b/handlers/mtarget/handler.go
@@ -44,8 +44,8 @@ var statusMapping = map[string]models.MsgStatus{
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
 
 	statusHandler := handlers.NewExternalIDStatusHandler(h, statusMapping, "MsgId", "Status")

--- a/handlers/mtarget/handler.go
+++ b/handlers/mtarget/handler.go
@@ -44,11 +44,11 @@ var statusMapping = map[string]models.MsgStatus{
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
 
 	statusHandler := handlers.NewExternalIDStatusHandler(h, statusMapping, "MsgId", "Status")
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, statusHandler)
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, statusHandler)
 	return nil
 }
 

--- a/handlers/mtn/handler.go
+++ b/handlers/mtn/handler.go
@@ -45,7 +45,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize implements courier.ChannelHandler
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/mtn/handler.go
+++ b/handlers/mtn/handler.go
@@ -44,8 +44,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize implements courier.ChannelHandler
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }
 

--- a/handlers/mtn/handler.go
+++ b/handlers/mtn/handler.go
@@ -44,8 +44,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize implements courier.ChannelHandler
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -93,8 +93,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -94,7 +94,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -93,11 +93,11 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
-	s.AddHandlerRoute(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.Add(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil
 }
 

--- a/handlers/novo/handler.go
+++ b/handlers/novo/handler.go
@@ -40,8 +40,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/novo/handler.go
+++ b/handlers/novo/handler.go
@@ -40,8 +40,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/novo/handler.go
+++ b/handlers/novo/handler.go
@@ -41,7 +41,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/playmobile/handler.go
+++ b/handlers/playmobile/handler.go
@@ -42,8 +42,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/playmobile/handler.go
+++ b/handlers/playmobile/handler.go
@@ -43,7 +43,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/playmobile/handler.go
+++ b/handlers/playmobile/handler.go
@@ -42,8 +42,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -49,8 +49,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -49,9 +49,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -50,7 +50,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil

--- a/handlers/rocketchat/handler.go
+++ b/handlers/rocketchat/handler.go
@@ -37,7 +37,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }

--- a/handlers/rocketchat/handler.go
+++ b/handlers/rocketchat/handler.go
@@ -36,8 +36,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }
 

--- a/handlers/rocketchat/handler.go
+++ b/handlers/rocketchat/handler.go
@@ -36,8 +36,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }

--- a/handlers/slack/handler.go
+++ b/handlers/slack/handler.go
@@ -47,7 +47,6 @@ func newHandler() courier.ChannelHandler {
 }
 
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/slack/handler.go
+++ b/handlers/slack/handler.go
@@ -46,8 +46,8 @@ func newHandler() courier.ChannelHandler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("SL"), "Slack", handlers.WithRedactConfigKeys(configBotToken, configUserToken, configValidationToken))}
 }
 
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }
 

--- a/handlers/slack/handler.go
+++ b/handlers/slack/handler.go
@@ -46,8 +46,8 @@ func newHandler() courier.ChannelHandler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("SL"), "Slack", handlers.WithRedactConfigKeys(configBotToken, configUserToken, configValidationToken))}
 }
 
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/slack/handler_test.go
+++ b/handlers/slack/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/utils/clogs"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/stretchr/testify/assert"
@@ -385,7 +386,7 @@ func TestDescribeURN(t *testing.T) {
 	defer server.Close()
 
 	handler := newHandler()
-	handler.Initialize(courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())))
+	web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 	urn, _ := urns.New(urns.Slack, "U012345")
 

--- a/handlers/smscentral/handler.go
+++ b/handlers/smscentral/handler.go
@@ -33,7 +33,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/smscentral/handler.go
+++ b/handlers/smscentral/handler.go
@@ -32,8 +32,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/smscentral/handler.go
+++ b/handlers/smscentral/handler.go
@@ -32,8 +32,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -40,7 +40,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -39,8 +39,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -39,8 +39,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -48,7 +48,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -47,8 +47,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }
 

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -47,8 +47,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	return nil
 }

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/utils/clogs"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
@@ -1247,10 +1248,10 @@ func TestSendEvent(t *testing.T) {
 	defer func(u string) { apiURL = u }(apiURL)
 	apiURL = "https://api.telegram.org"
 
-	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
+	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
 	h := newHandler().(*handler)
-	h.Initialize(s)
+	s.MountHandler(h)
 
 	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://api.telegram.org/botauth_token/sendChatAction": {

--- a/handlers/telesom/handler.go
+++ b/handlers/telesom/handler.go
@@ -34,8 +34,8 @@ func newHandler() courier.ChannelHandler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("TS"), "Telesom")}
 }
 
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil

--- a/handlers/telesom/handler.go
+++ b/handlers/telesom/handler.go
@@ -35,7 +35,6 @@ func newHandler() courier.ChannelHandler {
 }
 
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil

--- a/handlers/telesom/handler.go
+++ b/handlers/telesom/handler.go
@@ -34,9 +34,9 @@ func newHandler() courier.ChannelHandler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("TS"), "Telesom")}
 }
 
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/test.go
+++ b/handlers/test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/testsuite"
 	"github.com/nyaruka/courier/v26/utils/clogs"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/i18n"
@@ -80,7 +81,7 @@ type IncomingTestCase struct {
 }
 
 // utility method to make a request to a handler URL
-func testHandlerRequest(tb testing.TB, s *courier.Server, path string, headers map[string]string, data string, multipartFormFields map[string]string, expectedStatus int, expectedBodyContains string, requestPrepFunc RequestPrepFunc) string {
+func testHandlerRequest(tb testing.TB, s *web.Server, path string, headers map[string]string, data string, multipartFormFields map[string]string, expectedStatus int, expectedBodyContains string, requestPrepFunc RequestPrepFunc) string {
 	var req *http.Request
 	var err error
 	url := fmt.Sprintf("https://%s%s", s.Runtime().Config.Domain, path)
@@ -152,7 +153,7 @@ func (t localOnlyTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	return t.RoundTripper.RoundTrip(r)
 }
 
-func newServer(rt *runtime.Runtime) *courier.Server {
+func newServer(rt *runtime.Runtime) *web.Server {
 	// for benchmarks, log to null
 	log.SetOutput(io.Discard)
 
@@ -160,7 +161,7 @@ func newServer(rt *runtime.Runtime) *courier.Server {
 	rt.Config.FacebookApplicationSecret = "fb_app_secret"
 	rt.Config.WhatsappAdminSystemUserToken = "wac_admin_system_user_token"
 
-	return courier.NewServer(rt)
+	return web.NewServer(rt)
 }
 
 // RunIncomingTestCases runs all the passed in tests cases for the passed in channel configurations
@@ -192,7 +193,7 @@ func RunIncomingTestCases(t *testing.T, channels []*models.Channel, handler cour
 	// re-register the handler under test so that lookups by channel type - e.g. the URN describer used when
 	// creating a contact - resolve to this instance rather than the uninitialized one from its init()
 	courier.RegisterHandler(handler)
-	handler.Initialize(s)
+	require.NoError(t, s.MountHandler(handler))
 
 	// capture the events and channel logs of each handled request
 	var handledEvents []courier.Event
@@ -465,7 +466,7 @@ func RunOutgoingTestCases(t *testing.T, channel *models.Channel, handler courier
 
 	s := newServer(rt)
 	testsuite.InsertChannel(t, rt, channel)
-	handler.Initialize(s)
+	require.NoError(t, s.MountHandler(handler))
 
 	for _, tc := range testCases {
 		t.Run(tc.Label, func(t *testing.T) {

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -39,7 +39,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -38,8 +38,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -38,9 +38,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil
 }
 

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -55,8 +55,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
 
 	return nil
 }

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -56,7 +56,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
 
 	return nil

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -55,8 +55,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h, h.receiveEvents))
 
 	return nil

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -88,7 +88,6 @@ func init() {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -87,9 +87,9 @@ func init() {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil
 }
 

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -87,8 +87,8 @@ func init() {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/utils/clogs"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
@@ -1539,10 +1540,10 @@ func TestSendEvent(t *testing.T) {
 		},
 	)
 
-	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
+	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
 	h := newTWIMLHandler("TWA", "Twilio Whatsapp", true).(*handler)
-	h.Initialize(s)
+	s.MountHandler(h)
 
 	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://messaging.twilio.com/v3/Indicators/Typing.json": {

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -73,7 +73,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -72,8 +72,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }
 

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -72,8 +72,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -94,7 +94,6 @@ func newHandler() courier.ChannelHandler {
 }
 
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -93,8 +93,8 @@ func newHandler() courier.ChannelHandler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("VK"), "VK")}
 }
 
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -93,8 +93,8 @@ func newHandler() courier.ChannelHandler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("VK"), "VK")}
 }
 
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h, h.receiveEvent))
 	return nil
 }
 

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/utils/clogs"
+	"github.com/nyaruka/courier/v26/web"
 )
 
 const (
@@ -389,7 +390,7 @@ func TestDescribeURN(t *testing.T) {
 	defer server.Close()
 
 	handler := newHandler()
-	handler.Initialize(courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())))
+	web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 	urn, _ := urns.New(urns.VK, "123456789")
 	data := map[string]string{"name": "John Doe"}
@@ -654,9 +655,9 @@ func TestOutgoing(t *testing.T) {
 func TestSendEvent(t *testing.T) {
 	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "VK", "2020", "US", []string{urns.VK.Prefix}, map[string]any{models.ConfigAuthToken: "token123xyz"})
 
-	s := courier.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
+	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 	h := newHandler().(*handler)
-	h.Initialize(s)
+	s.MountHandler(h)
 
 	s.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://api.vk.com/method/messages.setActivity.json*": {

--- a/handlers/wavy/handler.go
+++ b/handlers/wavy/handler.go
@@ -33,10 +33,10 @@ func init() {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
-	s.AddHandlerRoute(h, http.MethodPost, "sent", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.sentStatusMessage))
-	s.AddHandlerRoute(h, http.MethodPost, "delivered", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.deliveredStatusMessage))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
+	r.Add(h, http.MethodPost, "sent", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.sentStatusMessage))
+	r.Add(h, http.MethodPost, "delivered", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.deliveredStatusMessage))
 	return nil
 }
 

--- a/handlers/wavy/handler.go
+++ b/handlers/wavy/handler.go
@@ -33,8 +33,8 @@ func init() {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "sent", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.sentStatusMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "delivered", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.deliveredStatusMessage))

--- a/handlers/wavy/handler.go
+++ b/handlers/wavy/handler.go
@@ -34,7 +34,6 @@ func init() {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "sent", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.sentStatusMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "delivered", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.deliveredStatusMessage))

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -53,9 +53,9 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
-	s.AddHandlerRoute(h, http.MethodPost, "", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
+	r.Add(h, http.MethodPost, "", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -53,8 +53,8 @@ func newHandler() courier.ChannelHandler {
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
 	s.AddHandlerRoute(h, http.MethodPost, "", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -54,7 +54,6 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
 	s.AddHandlerRoute(h, http.MethodPost, "", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil

--- a/handlers/wechat/handler_test.go
+++ b/handlers/wechat/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/testsuite"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
@@ -243,9 +244,9 @@ func TestDescribeURN(t *testing.T) {
 	defer rc.Close()
 	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 
-	s := courier.NewServer(rt)
+	s := web.NewServer(rt)
 	handler := newHandler().(*handler)
-	handler.Initialize(s)
+	s.MountHandler(handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 
 	tcs := []struct {
@@ -276,14 +277,14 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	rt.HTTP = &http.Client{Timeout: 30 * time.Second}
 	rt.HTTPProxied = rt.HTTP
 
-	s := courier.NewServer(rt)
+	s := web.NewServer(rt)
 	rt.HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://api.weixin.qq.com/cgi-bin/token?appid=app-id&grant_type=client_credential&secret=app-secret123": {
 			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"access_token": "SESAME"}`)),
 		},
 	})
 	handler := newHandler().(*handler)
-	handler.Initialize(s)
+	s.MountHandler(handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 
 	// check that request has the fetched access token
@@ -314,14 +315,14 @@ func TestFetchAccessTokenThrottled(t *testing.T) {
 	rt.HTTP = &http.Client{Timeout: 30 * time.Second}
 	rt.HTTPProxied = rt.HTTP
 
-	s := courier.NewServer(rt)
+	s := web.NewServer(rt)
 	rt.HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://api.weixin.qq.com/cgi-bin/token?appid=app-id&grant_type=client_credential&secret=app-secret123": {
 			httpx.NewMockResponse(429, nil, []byte(`{"errcode": 45009, "errmsg": "reach max api daily quota limit"}`)),
 		},
 	})
 	handler := newHandler().(*handler)
-	handler.Initialize(s)
+	s.MountHandler(handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 
 	// a rate limited token fetch is throttling rather than an empty token
@@ -457,9 +458,9 @@ func TestSendEvent(t *testing.T) {
 	defer rc.Close()
 	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 
-	s := courier.NewServer(rt)
+	s := web.NewServer(rt)
 	h := newHandler().(*handler)
-	h.Initialize(s)
+	s.MountHandler(h)
 
 	rt.HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://api.weixin.qq.com/cgi-bin/message/custom/typing*": {

--- a/handlers/whatsapp_legacy/handler.go
+++ b/handlers/whatsapp_legacy/handler.go
@@ -30,8 +30,8 @@ func newWAHandler(channelType models.ChannelType, name string) courier.ChannelHa
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, h.receiveEvents)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, h.receiveEvents)
 	return nil
 }
 

--- a/handlers/whatsapp_legacy/handler.go
+++ b/handlers/whatsapp_legacy/handler.go
@@ -30,8 +30,8 @@ func newWAHandler(channelType models.ChannelType, name string) courier.ChannelHa
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, h.receiveEvents)
 	return nil
 }

--- a/handlers/whatsapp_legacy/handler.go
+++ b/handlers/whatsapp_legacy/handler.go
@@ -31,7 +31,6 @@ func newWAHandler(channelType models.ChannelType, name string) courier.ChannelHa
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, h.receiveEvents)
 	return nil
 }

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -39,8 +39,8 @@ func newHandler() courier.ChannelHandler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("YO"), "YO!")}
 }
 
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -39,8 +39,8 @@ func newHandler() courier.ChannelHandler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("YO"), "YO!")}
 }
 
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -40,7 +40,6 @@ func newHandler() courier.ChannelHandler {
 }
 
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -38,7 +38,6 @@ func newHandler(channelType models.ChannelType, name string) courier.ChannelHand
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s *courier.Registry) error {
-	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.receiveStatus))
 	return nil

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -37,9 +37,9 @@ func newHandler(channelType models.ChannelType, name string) courier.ChannelHand
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
-	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.receiveStatus))
+func (h *handler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
+	r.Add(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.receiveStatus))
 	return nil
 }
 

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -37,8 +37,8 @@ func newHandler(channelType models.ChannelType, name string) courier.ChannelHand
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *handler) Initialize(s *courier.Server) error {
-	h.SetServer(s)
+func (h *handler) Initialize(s *courier.Registry) error {
+	h.SetRegistry(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h, h.receiveMessage))
 	s.AddHandlerRoute(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h, h.receiveStatus))
 	return nil

--- a/log.go
+++ b/log.go
@@ -1,12 +1,28 @@
 package courier
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/nyaruka/courier/v26/core/models"
 )
+
+// for use in request.Context
+type contextKey int
+
+const (
+	contextRequestURL contextKey = iota
+	contextRequestStart
+)
+
+// WithRequestContext returns a context carrying the request details that the logging below reports. The web server
+// puts them there before invoking a handler, so that handlers can log without being passed them explicitly.
+func WithRequestContext(ctx context.Context, url string, start time.Time) context.Context {
+	ctx = context.WithValue(ctx, contextRequestURL, url)
+	return context.WithValue(ctx, contextRequestStart, start)
+}
 
 // LogMsgStatusReceived logs our that we received a new MsgStatus
 func LogMsgStatusReceived(r *http.Request, status *models.StatusUpdate) {

--- a/responses.go
+++ b/responses.go
@@ -13,8 +13,8 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 )
 
-// writeAndLogRequestError writes a JSON response for the passed in message and logs an info messages
-func writeAndLogRequestError(ctx context.Context, h ChannelHandler, w http.ResponseWriter, r *http.Request, c *models.Channel, err error) error {
+// WriteAndLogRequestError writes a JSON response for the passed in message and logs an info message
+func WriteAndLogRequestError(ctx context.Context, h ChannelHandler, w http.ResponseWriter, r *http.Request, c *models.Channel, err error) error {
 	LogRequestError(r, c, err)
 	return h.WriteRequestError(ctx, w, err)
 }

--- a/test/handler.go
+++ b/test/handler.go
@@ -30,6 +30,7 @@ func NewMockHandler() courier.ChannelHandler {
 }
 
 func (h *mockHandler) Runtime() *runtime.Runtime             { return h.rt }
+func (h *mockHandler) SetRuntime(rt *runtime.Runtime)        { h.rt = rt }
 func (h *mockHandler) ChannelName() string                   { return "Mock Handler" }
 func (h *mockHandler) ChannelType() models.ChannelType       { return models.ChannelType("MCK") }
 func (h *mockHandler) UseChannelRouteUUID() bool             { return true }
@@ -41,7 +42,6 @@ func (h *mockHandler) GetChannel(ctx context.Context, r *http.Request) (*models.
 
 // Initialize is called by the engine once everything is loaded
 func (h *mockHandler) Initialize(s *courier.Registry) error {
-	h.rt = s.Runtime()
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
 	return nil
 }

--- a/test/handler.go
+++ b/test/handler.go
@@ -40,7 +40,7 @@ func (h *mockHandler) GetChannel(ctx context.Context, r *http.Request) (*models.
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *mockHandler) Initialize(s *courier.Server) error {
+func (h *mockHandler) Initialize(s *courier.Registry) error {
 	h.rt = s.Runtime()
 	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
 	return nil

--- a/test/handler.go
+++ b/test/handler.go
@@ -41,8 +41,8 @@ func (h *mockHandler) GetChannel(ctx context.Context, r *http.Request) (*models.
 }
 
 // Initialize is called by the engine once everything is loaded
-func (h *mockHandler) Initialize(s *courier.Registry) error {
-	s.AddHandlerRoute(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
+func (h *mockHandler) Initialize(r *courier.Routes) error {
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
 	return nil
 }
 

--- a/web/attachments.go
+++ b/web/attachments.go
@@ -1,10 +1,11 @@
-package courier
+package web
 
 import (
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/nyaruka/courier/v26"
 	"io"
 	"mime"
 	"net/http"
@@ -62,7 +63,7 @@ func fetchAttachment(ctx context.Context, rt *runtime.Runtime, r *http.Request) 
 		return nil, fmt.Errorf("error getting channel: %w", err)
 	}
 
-	clog := models.NewChannelLogForAttachmentFetch(ch, GetHandler(ch.ChannelType()).RedactValues(ch))
+	clog := models.NewChannelLogForAttachmentFetch(ch, courier.GetHandler(ch.ChannelType()).RedactValues(ch))
 
 	attachment, err := FetchAndStoreAttachment(ctx, rt, ch, fa.URL, clog)
 
@@ -85,8 +86,8 @@ func FetchAndStoreAttachment(ctx context.Context, rt *runtime.Runtime, channel *
 
 	var attRequest *http.Request
 
-	handler := GetHandler(channel.ChannelType())
-	builder, isBuilder := handler.(AttachmentRequestBuilder)
+	handler := courier.GetHandler(channel.ChannelType())
+	builder, isBuilder := handler.(courier.AttachmentRequestBuilder)
 	if isBuilder {
 		attRequest, err = builder.BuildAttachmentRequest(ctx, channel, parsedURL.String(), clog)
 	} else {

--- a/web/attachments_test.go
+++ b/web/attachments_test.go
@@ -1,4 +1,4 @@
-package courier_test
+package web_test
 
 import (
 	"context"
@@ -9,10 +9,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/testsuite"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
@@ -20,7 +20,7 @@ import (
 )
 
 func TestFetchAndStoreAttachment(t *testing.T) {
-	testJPG := test.ReadFile("test/testdata/test.jpg")
+	testJPG := test.ReadFile("../test/testdata/test.jpg")
 
 	defer uuids.SetGenerator(uuids.DefaultGenerator)
 	uuids.SetGenerator(uuids.NewSeededGenerator(1234, time.Now))
@@ -57,7 +57,7 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 
 	clog := models.NewChannelLogForAttachmentFetch(mockChannel, []string{"sesame"})
 
-	att, err := courier.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello.jpg", clog)
+	att, err := web.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello.jpg", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "image/jpeg", att.ContentType)
 	assert.Equal(t, "http://localstack:4566/test-attachments/attachments/1/f884/4b62/f8844b62-b014-4975-9a98-cfcce3019710.jpg", att.URL)
@@ -66,7 +66,7 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 	assert.Len(t, clog.HttpLogs, 1)
 	assert.Equal(t, "http://mock.com/media/hello.jpg", clog.HttpLogs[0].URL)
 
-	att, err = courier.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello2", clog)
+	att, err = web.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello2", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "image/jpeg", att.ContentType)
 	assert.Equal(t, "http://localstack:4566/test-attachments/attachments/1/d4bb/9822/d4bb9822-7160-4af3-b92b-40dae35f038b.jpg", att.URL)
@@ -76,26 +76,26 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 	assert.Equal(t, "http://mock.com/media/hello2", clog.HttpLogs[1].URL)
 
 	// a non-200 response should return an unavailable attachment
-	att, err = courier.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello.mp3", clog)
+	att, err = web.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello.mp3", clog)
 	assert.NoError(t, err)
-	assert.Equal(t, &courier.Attachment{ContentType: "unavailable", URL: "http://mock.com/media/hello.mp3"}, att)
+	assert.Equal(t, &web.Attachment{ContentType: "unavailable", URL: "http://mock.com/media/hello.mp3"}, att)
 
 	// should have a logged HTTP request but no attachments will have been saved to storage
 	assert.Len(t, clog.HttpLogs, 3)
 	assert.Equal(t, "http://mock.com/media/hello.mp3", clog.HttpLogs[2].URL)
 
 	// same for a connection error
-	att, err = courier.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello.pdf", clog)
+	att, err = web.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello.pdf", clog)
 	assert.NoError(t, err)
-	assert.Equal(t, &courier.Attachment{ContentType: "unavailable", URL: "http://mock.com/media/hello.pdf"}, att)
+	assert.Equal(t, &web.Attachment{ContentType: "unavailable", URL: "http://mock.com/media/hello.pdf"}, att)
 
-	att, err = courier.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello3", clog)
+	att, err = web.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello3", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "image/jpeg", att.ContentType)
 	assert.Equal(t, "http://localstack:4566/test-attachments/attachments/1/e527/3bef/e5273bef-6a8d-421f-8920-17713634b9f5.jpg", att.URL)
 	assert.Equal(t, 17301, att.Size)
 
-	att, err = courier.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello7", clog)
+	att, err = web.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello7", clog)
 	assert.NoError(t, err)
 	assert.Equal(t, "application/octet-stream", att.ContentType)
 	assert.Equal(t, "http://localstack:4566/test-attachments/attachments/1/f879/21a1/f87921a1-0484-4660-9955-f9b28b006b78", att.URL)
@@ -104,7 +104,7 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 	// an actual error on our part (e.g. storage unavailable) should be returned as an error
 	rt.Config.S3AttachmentsBucket = "does-not-exist"
 
-	att, err = courier.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello.txt", clog)
+	att, err = web.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://mock.com/media/hello.txt", clog)
 	assert.Error(t, err)
 	assert.Nil(t, att)
 }
@@ -128,9 +128,9 @@ func TestFetchAndStoreAttachmentAccessDenied(t *testing.T) {
 	clog := models.NewChannelLogForAttachmentFetch(mockChannel, nil)
 
 	// a request denied by the SSRF blocklist should yield an "unavailable" attachment rather than an error
-	att, err := courier.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://127.0.0.1/media/blocked.jpg", clog)
+	att, err := web.FetchAndStoreAttachment(ctx, rt, mockChannel, "http://127.0.0.1/media/blocked.jpg", clog)
 	assert.NoError(t, err)
-	assert.Equal(t, &courier.Attachment{ContentType: "unavailable", URL: "http://127.0.0.1/media/blocked.jpg"}, att)
+	assert.Equal(t, &web.Attachment{ContentType: "unavailable", URL: "http://127.0.0.1/media/blocked.jpg"}, att)
 
 	// nothing is saved to storage, but the denied request is still logged
 	assert.Len(t, clog.HttpLogs, 1)

--- a/web/events.go
+++ b/web/events.go
@@ -1,9 +1,10 @@
-package courier
+package web
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/nyaruka/courier/v26"
 	"io"
 	"log/slog"
 	"net/http"
@@ -82,7 +83,7 @@ func sendEvent(ctx context.Context, s *Server, r *http.Request) (*sendEventRespo
 		return nil, fmt.Errorf("error getting channel: %w", err)
 	}
 
-	handler := s.GetHandler(ch)
+	handler := courier.GetActiveHandler(ch.ChannelType())
 	if handler == nil {
 		return &sendEventResponse{Supported: false}, nil
 	}

--- a/web/events_test.go
+++ b/web/events_test.go
@@ -1,4 +1,4 @@
-package courier_test
+package web_test
 
 import (
 	"net/http"
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/testsuite"
 	"github.com/nyaruka/courier/v26/utils"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/gocommon/aws/dynamo/dyntest"
 	"github.com/nyaruka/gocommon/httpx"
@@ -41,7 +41,7 @@ func assertChannelLogCount(t *testing.T, rt *runtime.Runtime, expected int) {
 }
 
 func TestSendEvent(t *testing.T) {
-	rt := testsuite.NewRuntime(t)
+	_, rt := testsuite.Runtime(t)
 	testsuite.ResetDB(t, rt)
 	testsuite.ResetValkey(t, rt)
 	dyntest.Truncate(t, rt.Dynamo, "TestMain")
@@ -50,7 +50,7 @@ func TestSendEvent(t *testing.T) {
 	rt.Config.InternetPort = 8180
 	rt.Config.InternalPort = 8181
 
-	server := courier.NewServer(rt)
+	server := web.NewServer(rt)
 	server.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"http://mock.com/action": {
 			httpx.NewMockResponse(200, nil, []byte(`OK`)),

--- a/web/server.go
+++ b/web/server.go
@@ -225,12 +225,12 @@ func (s *Server) mountChannelHandlers() error {
 func (s *Server) MountHandler(handler courier.ChannelHandler) error {
 	handler.SetRuntime(s.rt)
 
-	reg := courier.NewRegistry()
-	if err := handler.Initialize(reg); err != nil {
+	routes := courier.NewRoutes()
+	if err := handler.Initialize(routes); err != nil {
 		return fmt.Errorf("error initializing handler %s: %w", handler.ChannelType(), err)
 	}
 
-	for _, route := range reg.Routes() {
+	for _, route := range routes.All() {
 		s.addRoute(route)
 	}
 

--- a/web/server.go
+++ b/web/server.go
@@ -223,8 +223,9 @@ func (s *Server) mountChannelHandlers() error {
 // MountHandler initializes the given handler and mounts the routes it registers, marking it as one this instance
 // serves. Tests use it to mount a single handler without starting the listeners.
 func (s *Server) MountHandler(handler courier.ChannelHandler) error {
-	reg := courier.NewRegistry(s.rt)
+	handler.SetRuntime(s.rt)
 
+	reg := courier.NewRegistry()
 	if err := handler.Initialize(reg); err != nil {
 		return fmt.Errorf("error initializing handler %s: %w", handler.ChannelType(), err)
 	}

--- a/web/server.go
+++ b/web/server.go
@@ -1,11 +1,11 @@
-package courier
+package web
 
 import (
 	"compress/flate"
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"github.com/nyaruka/courier/v26"
 	"log/slog"
 	"net"
 	"net/http"
@@ -22,18 +22,8 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/courier/v26/utils/clogs"
-	"github.com/nyaruka/courier/v26/utils/queue"
-	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/jsonx"
-)
-
-// for use in request.Context
-type contextKey int
-
-const (
-	contextRequestURL contextKey = iota
-	contextRequestStart
 )
 
 // NewServer creates a new Server for the passed in runtime. The server will have to be started
@@ -85,31 +75,12 @@ func (s *Server) Start() error {
 		return fmt.Errorf("error binding internal listener on %s: %w", internalAddr, err)
 	}
 
-	// test our connections to backing services
-	s.testConnections()
-
-	if err := s.rt.Start(); err != nil {
-		internetLn.Close()
-		internalLn.Close()
-		return fmt.Errorf("error starting runtime: %w", err)
-	}
-
-	// start the caches, spools and batched writers used by the read and write paths
-	if err := models.Start(s.rt); err != nil {
+	// mount the routes of every handler this instance serves
+	if err := s.mountChannelHandlers(); err != nil {
 		internetLn.Close()
 		internalLn.Close()
 		return err
 	}
-
-	// start our dethrottler if we are going to be doing some sending
-	if s.rt.Config.MaxWorkers > 0 {
-		queue.StartDethrottler(s.rt.VK, s.stopChan, s.waitGroup, models.MsgQueueName)
-	}
-
-	s.startMetricsReporter(time.Minute)
-
-	// initialize our handlers (wires routes into channelRouter)
-	s.initializeChannelHandlers()
 
 	// internet listener — exposes /c/*, /
 	internetRouter := chi.NewRouter()
@@ -178,10 +149,6 @@ func (s *Server) Start() error {
 		}
 	}()
 
-	// start our foreman for outgoing messages
-	s.foreman = NewForeman(s, s.rt.Config.MaxWorkers)
-	s.foreman.Start()
-
 	return nil
 }
 
@@ -189,9 +156,6 @@ func (s *Server) Start() error {
 func (s *Server) Stop() error {
 	log := slog.With("comp", "server")
 	log.Info("stopping server", "state", "stopping")
-
-	// stop our foreman
-	s.foreman.Stop()
 
 	// shut down both HTTP servers
 	if err := s.internetServer.Shutdown(context.Background()); err != nil {
@@ -201,81 +165,24 @@ func (s *Server) Stop() error {
 		log.Error("error shutting down server", "listener", "internal", "error", err, "state", "stopping")
 	}
 
-	// stop everything
 	s.stopped = true
 	close(s.stopChan)
 
-	// wait for our senders, dethrottler and metrics reporter to stop
+	// wait for both listeners to finish serving
 	s.waitGroup.Wait()
-
-	// stop the caches, spools and batched writers
-	models.Stop()
-
-	s.rt.Stop()
 
 	log.Info("server stopped", "state", "stopped")
 	return nil
 }
 
-// tests our connections to backing services, logging any failures but always moving forward
-func (s *Server) testConnections() {
-	log := slog.With("comp", "server")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// test Postgres
-	if err := s.rt.DB.PingContext(ctx); err != nil {
-		log.Error("db not reachable", "error", err)
-	} else {
-		log.Info("db ok")
-	}
-
-	// test DynamoDB
-	if err := dynamo.Test(ctx, s.rt.Dynamo, s.rt.Config.DynamoTablePrefix+"Main"); err != nil {
-		log.Error("dynamodb not reachable", "error", err)
-	} else {
-		log.Info("dynamodb ok")
-	}
-
-	// test Valkey
-	vc := s.rt.VK.Get()
-	defer vc.Close()
-	if _, err := vc.Do("PING"); err != nil {
-		log.Error("valkey not reachable", "error", err)
-	} else {
-		log.Info("valkey ok")
-	}
-
-	// test S3 bucket access
-	if err := s.rt.S3.Test(ctx, s.rt.Config.S3AttachmentsBucket); err != nil {
-		log.Error("attachments bucket not accessible", "error", err)
-	} else {
-		log.Info("attachments bucket ok")
-	}
-
-	// test that the Centrifugo server is reachable and accepts our key
-	if err := s.rt.Centrifugo.Client.Info(ctx); err != nil {
-		log.Error("centrifugo not reachable", "error", err)
-	} else {
-		log.Info("centrifugo ok")
-	}
-}
-
-func (s *Server) GetHandler(ch *models.Channel) ChannelHandler {
-	return activeHandlers[ch.ChannelType()]
-}
-
-func (s *Server) WaitGroup() *sync.WaitGroup { return s.waitGroup }
-func (s *Server) StopChan() chan bool        { return s.stopChan }
-func (s *Server) Runtime() *runtime.Runtime  { return s.rt }
-func (s *Server) Stopped() bool              { return s.stopped }
+func (s *Server) Runtime() *runtime.Runtime { return s.rt }
+func (s *Server) Stopped() bool             { return s.stopped }
 
 func (s *Server) Router() chi.Router { return s.testRouter }
 
 // OnRequestHandled sets a hook called after each channel request is handled, with the events it produced and its
 // channel log - used by tests to capture what handlers return.
-func (s *Server) OnRequestHandled(fn func(*models.Channel, []Event, *models.ChannelLog)) {
+func (s *Server) OnRequestHandled(fn func(*models.Channel, []courier.Event, *models.ChannelLog)) {
 	s.requestHandled = fn
 }
 
@@ -285,42 +192,55 @@ type Server struct {
 	channelRouter  *chi.Mux
 	testRouter     *chi.Mux
 
-	foreman *Foreman
-
 	rt *runtime.Runtime
 
-	requestHandled func(*models.Channel, []Event, *models.ChannelLog)
+	requestHandled func(*models.Channel, []courier.Event, *models.ChannelLog)
 
 	waitGroup *sync.WaitGroup
 	stopChan  chan bool
 	stopped   bool
 }
 
-func (s *Server) initializeChannelHandlers() {
+// mounts the routes of every handler included by config, so that a request for one of its channels reaches it
+func (s *Server) mountChannelHandlers() error {
 	includes := s.rt.Config.IncludeChannels
 	excludes := s.rt.Config.ExcludeChannels
 
-	// initialize handlers which are included/not-excluded in the config
-	for _, handler := range registeredHandlers {
+	for _, handler := range courier.RegisteredHandlers() {
 		channelType := string(handler.ChannelType())
 		if (includes == nil || slices.Contains(includes, channelType)) && (excludes == nil || !slices.Contains(excludes, channelType)) {
-			err := handler.Initialize(s)
-			if err != nil {
-				log.Fatal(err)
+			if err := s.MountHandler(handler); err != nil {
+				return err
 			}
-			activeHandlers[handler.ChannelType()] = handler
 
 			slog.Info("handler initialized", "comp", "server", "handler", handler.ChannelName(), "handler_type", channelType)
 		}
 	}
 
+	return nil
 }
 
-func (s *Server) channelHandleWrapper(handler ChannelHandler, handlerFunc ChannelHandleFunc, logType clogs.Type) http.HandlerFunc {
+// MountHandler initializes the given handler and mounts the routes it registers, marking it as one this instance
+// serves. Tests use it to mount a single handler without starting the listeners.
+func (s *Server) MountHandler(handler courier.ChannelHandler) error {
+	reg := courier.NewRegistry(s.rt)
+
+	if err := handler.Initialize(reg); err != nil {
+		return fmt.Errorf("error initializing handler %s: %w", handler.ChannelType(), err)
+	}
+
+	for _, route := range reg.Routes() {
+		s.addRoute(route)
+	}
+
+	courier.ActivateHandler(handler)
+	return nil
+}
+
+func (s *Server) channelHandleWrapper(handler courier.ChannelHandler, handlerFunc courier.ChannelHandleFunc, logType clogs.Type) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// stuff a few things in our context that help with logging
-		baseCtx := context.WithValue(r.Context(), contextRequestURL, r.URL.String())
-		baseCtx = context.WithValue(baseCtx, contextRequestStart, time.Now())
+		baseCtx := courier.WithRequestContext(r.Context(), r.URL.String(), time.Now())
 
 		// add a 30 second timeout to the request
 		ctx, cancel := context.WithTimeout(baseCtx, time.Second*30)
@@ -329,14 +249,14 @@ func (s *Server) channelHandleWrapper(handler ChannelHandler, handlerFunc Channe
 
 		recorder, err := httpx.NewRecorder(r, w, true)
 		if err != nil {
-			writeAndLogRequestError(ctx, handler, w, r, nil, err)
+			courier.WriteAndLogRequestError(ctx, handler, w, r, nil, err)
 			return
 		}
 
 		// get the channel for this request - can be nil, e.g. FBA verification requests
 		channel, err := handler.GetChannel(ctx, r)
 		if err != nil {
-			writeAndLogRequestError(ctx, handler, recorder.ResponseWriter, r, channel, err)
+			courier.WriteAndLogRequestError(ctx, handler, recorder.ResponseWriter, r, channel, err)
 			return
 		}
 
@@ -352,7 +272,7 @@ func (s *Server) channelHandleWrapper(handler ChannelHandler, handlerFunc Channe
 
 				sentry.CurrentHub().Recover(panicVal)
 
-				writeAndLogRequestError(ctx, handler, recorder.ResponseWriter, r, channel, errors.New("panic handling msg"))
+				courier.WriteAndLogRequestError(ctx, handler, recorder.ResponseWriter, r, channel, errors.New("panic handling msg"))
 			}
 		}()
 
@@ -363,13 +283,13 @@ func (s *Server) channelHandleWrapper(handler ChannelHandler, handlerFunc Channe
 		// if we received an error, write it out and report it
 		if hErr != nil {
 			slog.Error("error handling request", "error", hErr, "channel", channelUUID, "url", recorder.Trace.Request.URL.String())
-			writeAndLogRequestError(ctx, handler, recorder.ResponseWriter, r, channel, hErr)
+			courier.WriteAndLogRequestError(ctx, handler, recorder.ResponseWriter, r, channel, hErr)
 		}
 
 		// end recording of the request so that we have a response trace
 		if err := recorder.End(); err != nil {
 			slog.Error("error recording request", "error", err, "channel", channelUUID)
-			writeAndLogRequestError(ctx, handler, w, r, channel, err)
+			courier.WriteAndLogRequestError(ctx, handler, w, r, channel, err)
 		}
 
 		if channel != nil {
@@ -378,17 +298,17 @@ func (s *Server) channelHandleWrapper(handler ChannelHandler, handlerFunc Channe
 			for _, event := range events {
 				switch e := event.(type) {
 				case *models.MsgIn:
-					LogMsgReceived(r, e)
+					courier.LogMsgReceived(r, e)
 					if e.Duplicate_ {
 						numIgnored++
 					} else {
 						numMsgs++
 					}
 				case *models.StatusUpdate:
-					LogMsgStatusReceived(r, e)
+					courier.LogMsgStatusReceived(r, e)
 					numStatuses++
 				case *models.ChannelEvent:
-					LogChannelEventReceived(r, e)
+					courier.LogChannelEventReceived(r, e)
 					numEvents++
 				}
 			}
@@ -411,19 +331,20 @@ func (s *Server) channelHandleWrapper(handler ChannelHandler, handlerFunc Channe
 	}
 }
 
-func (s *Server) AddHandlerRoute(handler ChannelHandler, method string, action string, logType clogs.Type, handlerFunc ChannelHandleFunc) {
-	method = strings.ToLower(method)
-	channelType := strings.ToLower(string(handler.ChannelType()))
+// mounts a route registered by a handler onto the channel router
+func (s *Server) addRoute(route *courier.Route) {
+	method := strings.ToLower(route.Method)
+	channelType := strings.ToLower(string(route.Handler.ChannelType()))
 
 	path := fmt.Sprintf("/%s/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}", channelType)
-	if !handler.UseChannelRouteUUID() {
+	if !route.Handler.UseChannelRouteUUID() {
 		path = fmt.Sprintf("/%s", channelType)
 	}
 
-	if action != "" {
-		path = fmt.Sprintf("%s/%s", path, action)
+	if route.Action != "" {
+		path = fmt.Sprintf("%s/%s", path, route.Action)
 	}
-	s.channelRouter.Method(method, path, s.channelHandleWrapper(handler, handlerFunc, logType))
+	s.channelRouter.Method(method, path, s.channelHandleWrapper(route.Handler, route.Func, route.LogType))
 }
 
 func (s *Server) handleFetchAttachment(w http.ResponseWriter, r *http.Request) {
@@ -433,7 +354,7 @@ func (s *Server) handleFetchAttachment(w http.ResponseWriter, r *http.Request) {
 	resp, err := fetchAttachment(ctx, s.rt, r)
 	if err != nil {
 		slog.Error("error fetching attachment", "error", err)
-		WriteError(w, http.StatusBadRequest, err)
+		courier.WriteError(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -449,7 +370,7 @@ func (s *Server) handleSendEvent(w http.ResponseWriter, r *http.Request) {
 	resp, err := sendEvent(ctx, s, r)
 	if err != nil {
 		slog.Error("error sending event", "error", err)
-		WriteError(w, http.StatusBadRequest, err)
+		courier.WriteError(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -467,8 +388,8 @@ func (s *Server) handle404(listener string) http.HandlerFunc {
 		} else {
 			slog.Info("not found", "listener", listener, "url", r.URL.String(), "method", r.Method, "resp_status", "404")
 		}
-		errors := []any{NewErrorData(fmt.Sprintf("not found: %s", r.URL.String()))}
-		err := WriteDataResponse(w, http.StatusNotFound, "Not Found", errors)
+		errors := []any{courier.NewErrorData(fmt.Sprintf("not found: %s", r.URL.String()))}
+		err := courier.WriteDataResponse(w, http.StatusNotFound, "Not Found", errors)
 		if err != nil {
 			slog.Error("error writing response", "error", err)
 		}
@@ -482,8 +403,8 @@ func (s *Server) handle405(listener string) http.HandlerFunc {
 		} else {
 			slog.Info("invalid method", "listener", listener, "url", r.URL.String(), "method", r.Method, "resp_status", "405")
 		}
-		errors := []any{NewErrorData(fmt.Sprintf("method not allowed: %s", r.Method))}
-		err := WriteDataResponse(w, http.StatusMethodNotAllowed, "Method Not Allowed", errors)
+		errors := []any{courier.NewErrorData(fmt.Sprintf("method not allowed: %s", r.Method))}
+		err := courier.WriteDataResponse(w, http.StatusMethodNotAllowed, "Method Not Allowed", errors)
 		if err != nil {
 			slog.Error("error writing response", "error", err)
 		}

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -1,4 +1,4 @@
-package courier_test
+package web_test
 
 import (
 	"io"
@@ -11,11 +11,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/nyaruka/courier/v26"
 	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/core/sender"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/testsuite"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/courier/v26/utils/queue"
+	"github.com/nyaruka/courier/v26/web"
 	"github.com/nyaruka/gocommon/aws/dynamo"
 	"github.com/nyaruka/gocommon/aws/dynamo/dyntest"
 	"github.com/nyaruka/gocommon/dates"
@@ -27,8 +29,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// the server no longer owns the models layer's lifecycle - that moved to the service wiring - so tests start it
+// themselves via testsuite.Runtime
 func serverRuntime(t *testing.T) *runtime.Runtime {
-	rt := testsuite.NewRuntime(t)
+	_, rt := testsuite.Runtime(t)
 	testsuite.ResetDB(t, rt)
 	testsuite.ResetValkey(t, rt)
 
@@ -40,7 +44,7 @@ func serverRuntime(t *testing.T) *runtime.Runtime {
 func TestIncoming(t *testing.T) {
 	rt := serverRuntime(t)
 
-	s := courier.NewServer(rt)
+	s := web.NewServer(rt)
 
 	// capture the channel logs of handled requests
 	var clogs []*models.ChannelLog
@@ -81,7 +85,7 @@ func TestOutgoing(t *testing.T) {
 	rt := serverRuntime(t)
 	dyntest.Truncate(t, rt.Dynamo, "TestMain")
 
-	s := courier.NewServer(rt)
+	s := web.NewServer(rt)
 	rt.HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"http://mock.com/send": {
 			httpx.NewMockResponse(200, nil, []byte(`SENT`)),
@@ -94,6 +98,11 @@ func TestOutgoing(t *testing.T) {
 
 	require.NoError(t, s.Start())
 	defer s.Stop()
+
+	// sending is its own component now, so the test drives one alongside the server
+	foreman := sender.NewForeman(rt, 32)
+	foreman.Start()
+	defer foreman.Stop()
 
 	// create two channels but only one of them has a handler (MCK)
 	brokenChannel := test.NewMockChannel("53e5aafa-8155-449d-9009-fcb30d54bd26", "XX", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
@@ -214,13 +223,13 @@ func TestOutgoing(t *testing.T) {
 }
 
 func TestFetchAttachment(t *testing.T) {
-	testJPG := test.ReadFile("test/testdata/test.jpg")
+	testJPG := test.ReadFile("../test/testdata/test.jpg")
 
 	rt := serverRuntime(t)
 	rt.Config.AuthToken = "sesame"
 	rt.S3.Client.CreateBucket(t.Context(), &s3.CreateBucketInput{Bucket: aws.String("test-attachments")})
 
-	server := courier.NewServer(rt)
+	server := web.NewServer(rt)
 	server.Runtime().HTTP.Transport = httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"http://mock.com/media/hello.jpg": {
 			httpx.NewMockResponse(200, nil, testJPG),
@@ -302,7 +311,7 @@ func TestListeners(t *testing.T) {
 	rt := serverRuntime(t)
 	rt.Config.AuthToken = "sesame"
 
-	server := courier.NewServer(rt)
+	server := web.NewServer(rt)
 	require.NoError(t, server.Start())
 	defer server.Stop()
 


### PR DESCRIPTION
## Summary

Completes the de-abstraction plan started in #1108. The root package was doing four jobs at once — the channel handler contract, the HTTP server, the sending loop, and the process lifecycle. This splits the last three out, leaving root as the contract handlers are written against.

| package | holds |
|---|---|
| `courier` (root) | `ChannelHandler`, `ChannelHandleFunc`, `Event`, `Routes`/`Route`, the handler registry, `SendResult`/`SendError`, response writers, request logging |
| `web/` | `Server`, routing, the channel request wrapper, `/ci/attachment/fetch`, `/ci/event/send` |
| `core/sender/` | `Foreman` and `Sender` |
| `cmd/` | lifecycle wiring, connection tests, metrics reporter |

## How the dependency cycle was broken

`ChannelHandler.Initialize(*Server)` meant the package defining the contract had to import the one defining `Server` — and `core/sender` needs that same contract to call `Send`. So the server couldn't move while handlers were still initialized with it.

Handlers are now initialized with a `*courier.Routes`, which collects the routes they want to serve:

```go
func (h *handler) Initialize(r *courier.Routes) error {
	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
	return nil
}
```

The runtime reaches the handler by its own path: `ChannelHandler` has `SetRuntime`, which the server calls before `Initialize` and which `BaseHandler` implements once — so no handler stashes it itself, and `courier.Routes` only ever holds routes.

`web.Server.MountHandler` sets the runtime on the handler, calls `Initialize`, mounts the routes it added onto chi, and marks it active. The contract never names the server, so `web` and `core/sender` can both import it.

## Changes

**Lifecycle moved to the service wiring.** `web.Server.Start`/`Stop` now only bind, serve and shut down HTTP. `cmd.Service` starts the runtime, models layer, dethrottler, metrics reporter, server and foreman, and unwinds in reverse — stopping sending first so in-flight sends finish before the writers they depend on go away.

**Startup and shutdown unwind properly.** `startService` starts each component in turn and stops whatever is already running if a later one fails, so a bind failure doesn't leave the runtime, models layer, dethrottler and metrics goroutine orphaned. `service.stop()` runs the reverse order unconditionally, skipping components that never started. The teardown is an explicit call rather than deferred because a deferred `watchdog.Stop()` would fire first and disarm the shutdown watchdog.

**`core/sender`** takes a runtime instead of reaching into the server, owns its own wait group, and looks handlers up via `courier.GetActiveHandler`.

**Two things changed rather than moved.** `SendError`'s fields are private and `core/sender` needs them, so it gained `Retryable()`, `Loggable()` and `ClogError()` accessors instead of exporting the fields. The request-context keys moved into `log.go` behind `courier.WithRequestContext`, since the logging helpers handlers call are what read them.

## Behavior examples

No user-facing change. The internal shape does:

| before | after |
|---|---|
| `courier.NewServer(rt)` | `web.NewServer(rt)` |
| `func (h *handler) Initialize(s *courier.Server) error` | `func (h *handler) Initialize(r *courier.Routes) error` |
| `s.Start()` starts runtime, models, dethrottler, metrics, HTTP, foreman | `s.Start()` serves HTTP; `cmd.Service` starts the rest |
| `server.GetHandler(ch)` | `courier.GetActiveHandler(ch.ChannelType())` |

## Test plan

- Full suite green in the test container (`go test -p=1 ./...`): 63 packages, 0 failures.
- The 53 handler `Initialize` methods are signature-only changes, compiler-verified.
- Custom handler tests that called `handler.Initialize(s)` now call `s.MountHandler(handler)`, which initializes and mounts exactly as the server does.
- The server tests start their own models layer and foreman, since the server no longer owns either.

## Notes for review

- Root is the handler contract rather than a literal `service.go` — the contract has to be importable by both `web` and `core/sender`, so it can't live in either, and `cmd` already had the wiring.
- `Routes` is a concrete struct, not an interface, keeping with the rest of this refactor.

