### PR TITLE
Support attachment headers on WhatsApp CTA URL messages

### DIFF
--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -1015,14 +1015,12 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		MockResponses: map[string][]*httpx.MockResponse{
 			"*/12345_ID/messages": {
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
-				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"image","image":{"link":"https://foo.bar/image.jpg"}}`},
-			{Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"cta_url","body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Visit","url":"https://example.com"}}}}`},
+			{Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"cta_url","header":{"type":"image","image":{"link":"https://foo.bar/image.jpg"}},"body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Visit","url":"https://example.com"}}}}`},
 		},
-		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
 		Label:           "Interactive with URL button missing URL, sent as text",

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -73,10 +73,11 @@ func buildContentPayloads(msg *models.MsgOut, maxMsgLength int, clog *models.Cha
 	var payloads []SendRequest
 
 	// determine if the attachment can be used as a header in an interactive message - button (max 3, not shown as a
-	// list) and CTA URL messages support media headers
+	// list) and CTA URL messages support media headers, but interactive messages require body text so without text
+	// the attachment has to be sent as a standalone media message
 	headerCapable := len(urlQRs) > 0 || (len(qrs) > 0 && len(qrs) <= 3 && !qrsAsList)
 	hasHeaderAttachment := false
-	if len(msg.Attachments()) > 0 && headerCapable && len(locationQRs) == 0 && len(formQRs) == 0 {
+	if len(msg.Attachments()) > 0 && len(msgParts) > 0 && headerCapable && len(locationQRs) == 0 && len(formQRs) == 0 {
 		attType, _ := handlers.SplitAttachment(msg.Attachments()[0])
 		attType = strings.Split(attType, "/")[0]
 		// only certain media types can be used as an interactive header

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -72,9 +72,11 @@ func buildContentPayloads(msg *models.MsgOut, maxMsgLength int, clog *models.Cha
 
 	var payloads []SendRequest
 
-	// determine if the attachment can be used as a header in an interactive message
+	// determine if the attachment can be used as a header in an interactive message - button (max 3, not shown as a
+	// list) and CTA URL messages support media headers
+	headerCapable := len(urlQRs) > 0 || (len(qrs) > 0 && len(qrs) <= 3 && !qrsAsList)
 	hasHeaderAttachment := false
-	if len(msg.Attachments()) > 0 && len(qrs) > 0 && len(qrs) <= 3 && len(locationQRs) == 0 && len(formQRs) == 0 && len(urlQRs) == 0 && !qrsAsList {
+	if len(msg.Attachments()) > 0 && headerCapable && len(locationQRs) == 0 && len(formQRs) == 0 {
 		attType, _ := handlers.SplitAttachment(msg.Attachments()[0])
 		attType = strings.Split(attType, "/")[0]
 		// only certain media types can be used as an interactive header
@@ -121,14 +123,18 @@ func buildContentPayloads(msg *models.MsgOut, maxMsgLength int, clog *models.Cha
 			payloads = append(payloads, buildFlowPayload(msg, part, formQRs[0]))
 
 		case isLastPart && len(urlQRs) > 0:
-			payloads = append(payloads, buildCTAURLPayload(msg, part, urlQRs[0]))
-
-		case isLastPart && len(qrs) > 0 && !qrsAsList:
-			ps, err := buildButtonPayload(msg, part, qrs, hasHeaderAttachment)
+			p, err := buildCTAURLPayload(msg, part, urlQRs[0], hasHeaderAttachment)
 			if err != nil {
 				return nil, err
 			}
-			payloads = append(payloads, ps...)
+			payloads = append(payloads, p)
+
+		case isLastPart && len(qrs) > 0 && !qrsAsList:
+			p, err := buildButtonPayload(msg, part, qrs, hasHeaderAttachment)
+			if err != nil {
+				return nil, err
+			}
+			payloads = append(payloads, p)
 
 		case isLastPart && len(qrs) > 0 && qrsAsList:
 			payloads = append(payloads, buildListPayload(msg, part, qrs, menuButton))
@@ -220,18 +226,27 @@ func buildFlowPayload(msg *models.MsgOut, body string, qr models.QuickReply) Sen
 	return p
 }
 
-func buildCTAURLPayload(msg *models.MsgOut, body string, qr models.QuickReply) SendRequest {
+func buildCTAURLPayload(msg *models.MsgOut, body string, qr models.QuickReply, useAttachmentHeader bool) (SendRequest, error) {
 	p := newBasePayload(msg)
 	p.Type = "interactive"
 	interactive := Interactive{Type: "cta_url", Body: struct {
 		Text string `json:"text"`
 	}{Text: body}}
+
+	if useAttachmentHeader {
+		header, err := buildAttachmentHeader(msg)
+		if err != nil {
+			return SendRequest{}, err
+		}
+		interactive.Header = header
+	}
+
 	interactive.Action = &Action{
 		Name:       "cta_url",
 		Parameters: &ActionParameters{DisplayText: qr.GetText(), URL: qr.Extra},
 	}
 	p.Interactive = &interactive
-	return p
+	return p, nil
 }
 
 func buildButtons(qrs []models.QuickReply) []Button {
@@ -244,8 +259,7 @@ func buildButtons(qrs []models.QuickReply) []Button {
 	return btns
 }
 
-func buildButtonPayload(msg *models.MsgOut, body string, qrs []models.QuickReply, useAttachmentHeader bool) ([]SendRequest, error) {
-	var payloads []SendRequest
+func buildButtonPayload(msg *models.MsgOut, body string, qrs []models.QuickReply, useAttachmentHeader bool) (SendRequest, error) {
 	p := newBasePayload(msg)
 	p.Type = "interactive"
 
@@ -254,30 +268,39 @@ func buildButtonPayload(msg *models.MsgOut, body string, qrs []models.QuickReply
 	}{Text: body}}
 
 	if useAttachmentHeader {
-		attType, attURL := handlers.SplitAttachment(msg.Attachments()[0])
-		attType = strings.Split(attType, "/")[0]
-		if attType == "application" {
-			attType = "document"
+		header, err := buildAttachmentHeader(msg)
+		if err != nil {
+			return SendRequest{}, err
 		}
-
-		switch attType {
-		case "image":
-			interactive.Header = &Header{Type: "image", Image: &Media{Link: attURL}}
-		case "video":
-			interactive.Header = &Header{Type: "video", Video: &Media{Link: attURL}}
-		case "document":
-			filename, err := utils.BasePathForURL(attURL)
-			if err != nil {
-				return nil, err
-			}
-			interactive.Header = &Header{Type: "document", Document: &Media{Link: attURL, Filename: filename}}
-		}
+		interactive.Header = header
 	}
 
 	interactive.Action = &Action{Buttons: buildButtons(qrs)}
 	p.Interactive = &interactive
-	payloads = append(payloads, p)
-	return payloads, nil
+	return p, nil
+}
+
+// buildAttachmentHeader creates an interactive message header from the message's first attachment
+func buildAttachmentHeader(msg *models.MsgOut) (*Header, error) {
+	attType, attURL := handlers.SplitAttachment(msg.Attachments()[0])
+	attType = strings.Split(attType, "/")[0]
+	if attType == "application" {
+		attType = "document"
+	}
+
+	switch attType {
+	case "image":
+		return &Header{Type: "image", Image: &Media{Link: attURL}}, nil
+	case "video":
+		return &Header{Type: "video", Video: &Media{Link: attURL}}, nil
+	case "document":
+		filename, err := utils.BasePathForURL(attURL)
+		if err != nil {
+			return nil, err
+		}
+		return &Header{Type: "document", Document: &Media{Link: attURL, Filename: filename}}, nil
+	}
+	return nil, nil
 }
 
 func buildListPayload(msg *models.MsgOut, body string, qrs []models.QuickReply, menuButton string) SendRequest {

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -389,6 +389,45 @@ func TestGetMsgPayloads(t *testing.T) {
 			},
 		},
 		{
+			label:                 "URL QR with image attachment - should use image as header of cta_url",
+			text:                  "Check out our site",
+			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},
+			quickReplies:          []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "interactive", payloads[0].Type)
+				assert.Equal(t, "cta_url", payloads[0].Interactive.Type)
+				assert.Equal(t, "Check out our site", payloads[0].Interactive.Body.Text)
+				// Check header
+				assert.NotNil(t, payloads[0].Interactive.Header)
+				assert.Equal(t, "image", payloads[0].Interactive.Header.Type)
+				assert.NotNil(t, payloads[0].Interactive.Header.Image)
+				assert.Equal(t, "https://example.com/image.jpg", payloads[0].Interactive.Header.Image.Link)
+				assert.Equal(t, &whatsapp.ActionParameters{DisplayText: "Visit", URL: "https://example.com"}, payloads[0].Interactive.Action.Parameters)
+			},
+		},
+		{
+			label:                 "URL QR with audio attachment - should NOT use as header, audio not supported",
+			text:                  "Check out our site",
+			attachments:           []string{"audio/mp3:https://example.com/audio.mp3"},
+			quickReplies:          []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 2,
+			expectedType:          "audio",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, 2, len(payloads))
+				// First should be audio (not used as header)
+				assert.Equal(t, "audio", payloads[0].Type)
+				// Second should be cta_url interactive WITHOUT header
+				assert.Equal(t, "interactive", payloads[1].Type)
+				assert.Equal(t, "cta_url", payloads[1].Interactive.Type)
+				assert.Nil(t, payloads[1].Interactive.Header)
+			},
+		},
+		{
 			label:                 "URL QR without URL - should be ignored and logged",
 			text:                  "Check out our site",
 			quickReplies:          []models.QuickReply{{Type: "url", Text: "Visit"}},

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -428,6 +428,34 @@ func TestGetMsgPayloads(t *testing.T) {
 			},
 		},
 		{
+			label:                 "URL QR with image attachment but no text - attachment sent standalone, not dropped",
+			text:                  "",
+			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},
+			quickReplies:          []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "image",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "image", payloads[0].Type)
+				assert.Equal(t, "https://example.com/image.jpg", payloads[0].Image.Link)
+			},
+		},
+		{
+			label:                 "Text QRs with image attachment but no text - attachment sent standalone, not dropped",
+			text:                  "",
+			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},
+			quickReplies:          []models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "text", Text: "No"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "image",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "image", payloads[0].Type)
+				assert.Equal(t, "https://example.com/image.jpg", payloads[0].Image.Link)
+			},
+		},
+		{
 			label:                 "URL QR without URL - should be ignored and logged",
 			text:                  "Check out our site",
 			quickReplies:          []models.QuickReply{{Type: "url", Text: "Visit"}},


### PR DESCRIPTION
## Summary

A message with a media attachment and a URL quick reply was previously sent as two separate messages: the attachment as a standalone media message, followed by the CTA URL button as an interactive message. The WhatsApp `cta_url` interactive message type supports image/video/document headers ([docs](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-cta-url-messages)), just like reply-button messages, so the two are now combined into a single message. This covers both channel types that share these payloads (WAC and D3C); TN builds its payloads separately and is unchanged.

## Changes

- Extend the header-attachment eligibility check in `buildContentPayloads` to messages with URL quick replies, so the first image/video/document attachment becomes the header of the `cta_url` interactive message instead of a standalone message. Audio attachments still go separately since headers don't support them.
- Extract the header construction previously inlined in `buildButtonPayload` into a shared `buildAttachmentHeader` helper used by both button and CTA URL payloads, and simplify `buildButtonPayload` to return a single payload.
- Require non-empty message text before using an attachment as an interactive header: interactive messages need body text, so without text the attachment is sent as a standalone media message rather than being silently dropped. This also fixes a pre-existing version of the same bug on the button (text quick replies) path.

## Test plan

- New payload tests: URL quick reply + image (single `cta_url` with image header), + audio (still two messages, no header), and empty-text + attachment + quick replies (URL and text variants, attachment sent standalone).
- Updated the WAC handler test that documented the old two-message behavior.
- `./handlers/meta/...`, `./handlers/dialog360/...` and `./handlers/turn/...` pass.

Form (Flows) quick replies with attachments still send as two messages and could get the same treatment in a follow-up.