### PR TITLE
Port TN handler onto the shared WhatsApp payload builder

### DIFF
--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -93,8 +93,14 @@ func buildContentPayloads(msg *models.MsgOut, maxMsgLength int, clog *models.Cha
 		}
 
 		caption := ""
-		attType, _ := handlers.SplitAttachment(att)
-		attType = strings.Split(attType, "/")[0]
+		contentType, _ := handlers.SplitAttachment(att)
+		attType := strings.Split(contentType, "/")[0]
+
+		// skip attachment types that can't be sent as media messages
+		if attType != "image" && attType != "audio" && attType != "video" && attType != "application" && attType != "document" {
+			clog.Error(models.ErrorMediaUnsupported(contentType))
+			continue
+		}
 
 		// only non-audio single attachment messages can have captions
 		if attType != "audio" && len(msgParts) == 1 && len(msg.Attachments()) == 1 && len(qrs) == 0 && len(locationQRs) == 0 && len(formQRs) == 0 && len(urlQRs) == 0 {

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -470,6 +470,21 @@ func TestGetMsgPayloads(t *testing.T) {
 			},
 		},
 		{
+			label:                 "Unsupported attachment type - should be skipped and logged, text still sent",
+			text:                  "Here's a contact",
+			attachments:           []string{"text/vcard:https://example.com/contact.vcf"},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "text",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "text", payloads[0].Type)
+				assert.Equal(t, "Here's a contact", payloads[0].Text.Body)
+				assert.Len(t, clog.Errors, 1)
+				assert.Equal(t, "media_unsupported", clog.Errors[0].Code)
+			},
+		},
+		{
 			label:                 "Text between 1024 and 4096 without attachments or QRs - should be a single text message",
 			text:                  strings.Repeat("x", 2000),
 			urn:                   "whatsapp:250788123123",

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -496,9 +496,6 @@ func (h *handler) buildPayloads(ctx context.Context, msg *models.MsgOut, clog *m
 func (h *handler) convertPayload(ctx context.Context, msg *models.MsgOut, rcpt recipient, request whatsapp.SendRequest, clog *models.ChannelLog) (any, error) {
 	switch request.Type {
 	case "text":
-		if request.Text == nil {
-			return nil, fmt.Errorf("unsupported attachment type on message: %s", msg.UUID())
-		}
 		payload := mtTextPayload{recipient: rcpt, Type: "text", PreviewURL: request.Text.PreviewURL}
 		payload.Text.Body = request.Text.Body
 		return payload, nil

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/buger/jsonparser"
@@ -21,7 +20,6 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/handlers/meta/whatsapp"
-	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/cache"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/i18n"
@@ -396,51 +394,12 @@ type mtTextPayload struct {
 	} `json:"text"`
 }
 
+// interactive messages have the same shape as their Cloud API counterparts, and their headers CAN reference
+// media by link
 type mtInteractivePayload struct {
 	recipient
-	Type        string `json:"type" validate:"required"`
-	Interactive struct {
-		Type   string `json:"type" validate:"required"` //"text" | "image" | "video" | "document"
-		Header *struct {
-			Type     string `json:"type"`
-			Text     string `json:"text,omitempty"`
-			Video    string `json:"video,omitempty"`
-			Image    string `json:"image,omitempty"`
-			Document string `json:"document,omitempty"`
-		} `json:"header,omitempty"`
-		Body struct {
-			Text string `json:"text"`
-		} `json:"body" validate:"required"`
-		Footer *struct {
-			Text string `json:"text"`
-		} `json:"footer,omitempty"`
-		Action struct {
-			Name       string                     `json:"name,omitempty"`
-			Button     string                     `json:"button,omitempty"`
-			Sections   []mtSection                `json:"sections,omitempty"`
-			Buttons    []mtButton                 `json:"buttons,omitempty"`
-			Parameters *whatsapp.ActionParameters `json:"parameters,omitempty"`
-		} `json:"action" validate:"required"`
-	} `json:"interactive"`
-}
-
-type mtSection struct {
-	Title string         `json:"title,omitempty"`
-	Rows  []mtSectionRow `json:"rows" validate:"required"`
-}
-
-type mtSectionRow struct {
-	ID          string `json:"id" validate:"required"`
-	Title       string `json:"title,omitempty"`
-	Description string `json:"description,omitempty"`
-}
-
-type mtButton struct {
-	Type  string `json:"type" validate:"required"`
-	Reply struct {
-		ID    string `json:"id" validate:"required"`
-		Title string `json:"title" validate:"required"`
-	} `json:"reply" validate:"required"`
+	Type        string                `json:"type" validate:"required"`
+	Interactive *whatsapp.Interactive `json:"interactive"`
 }
 
 // media messages reference media by the id returned from /v1/media - they can't carry a link
@@ -485,10 +444,7 @@ type mtVideoPayload struct {
 	Video *mediaObject `json:"video"`
 }
 
-func buildPayloads(ctx context.Context, msg *models.MsgOut, h *handler, clog *models.ChannelLog) ([]any, error) {
-	var payloads []any
-	var err error
-
+func (h *handler) buildPayloads(ctx context.Context, msg *models.MsgOut, clog *models.ChannelLog) ([]any, error) {
 	rcpt := newRecipient(msg)
 
 	// Template messages must be sent as a single template payload. Mailroom/goflow may also
@@ -518,299 +474,73 @@ func buildPayloads(ctx context.Context, msg *models.MsgOut, h *handler, clog *mo
 		return []any{payload}, nil
 	}
 
-	parts := handlers.SplitMsgByChannel(msg.Channel(), msg.Text(), maxMsgLength)
-
-	sqrs := handlers.FilterSupportedQuickReplies(msg.QuickReplies(), clog, models.QuickReplyTypeText, models.QuickReplyTypeLocation, models.QuickReplyTypeForm, models.QuickReplyTypeURL)
-	qrs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeText)
-	qrsAsList := false
-	for i, qr := range qrs {
-		if i > 2 || qr.Extra != "" {
-			qrsAsList = true
-		}
+	requests, err := whatsapp.GetMsgPayloads(ctx, msg, maxMsgLength, clog)
+	if err != nil {
+		return nil, err
 	}
 
-	locationQRs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeLocation)
-	formQRs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeForm)
-	urlQRs := handlers.FilterQuickRepliesByType(sqrs, models.QuickReplyTypeURL)
-
-	isInteractiveMsg := len(qrs) > 0 || len(locationQRs) > 0 || len(formQRs) > 0 || len(urlQRs) > 0
-
-	textAsCaption := false
-
-	if len(msg.Attachments()) > 0 {
-		for attachmentCount, attachment := range msg.Attachments() {
-
-			mimeType, mediaURL := handlers.SplitAttachment(attachment)
-			mediaID, err := h.fetchMediaID(ctx, msg, mediaURL, clog)
-			if err != nil {
-				slog.Error("error while uploading media to whatsapp", "error", err, "channel_uuid", msg.Channel().UUID())
-			}
-
-			// media messages must reference media uploaded to /v1/media by id - unlike template headers and
-			// interactive headers, they can't carry a link, so without an id there's no request worth making
-			if mediaID == "" {
-				return nil, channels.ErrRetryableWithReason("media_upload_failed", "unable to upload media to WhatsApp")
-			}
-
-			mediaPayload := &mediaObject{ID: mediaID}
-			if strings.HasPrefix(mimeType, "audio") {
-				payload := mtAudioPayload{
-					recipient: rcpt,
-					Type:      "audio",
-				}
-				payload.Audio = mediaPayload
-				payloads = append(payloads, payload)
-			} else if strings.HasPrefix(mimeType, "application") || strings.HasPrefix(mimeType, "document") {
-				payload := mtDocumentPayload{
-					recipient: rcpt,
-					Type:      "document",
-				}
-				if attachmentCount == 0 && !isInteractiveMsg {
-					mediaPayload.Caption = msg.Text()
-					textAsCaption = true
-				}
-				mediaPayload.Filename, err = utils.BasePathForURL(mediaURL)
-
-				// Logging error
-				if err != nil {
-					slog.Error("Error while parsing the media URL", "error", err, "channel_uuid", msg.Channel().UUID())
-				}
-				payload.Document = mediaPayload
-				payloads = append(payloads, payload)
-			} else if strings.HasPrefix(mimeType, "image") {
-				payload := mtImagePayload{
-					recipient: rcpt,
-					Type:      "image",
-				}
-				if attachmentCount == 0 && !isInteractiveMsg {
-					mediaPayload.Caption = msg.Text()
-					textAsCaption = true
-				}
-				payload.Image = mediaPayload
-				payloads = append(payloads, payload)
-			} else if strings.HasPrefix(mimeType, "video") {
-				payload := mtVideoPayload{
-					recipient: rcpt,
-					Type:      "video",
-				}
-				if attachmentCount == 0 && !isInteractiveMsg {
-					mediaPayload.Caption = msg.Text()
-					textAsCaption = true
-				}
-				payload.Video = mediaPayload
-				payloads = append(payloads, payload)
-			} else {
-				clog.Error(models.ErrorMediaUnsupported(mimeType))
-				break
-			}
+	payloads := make([]any, 0, len(requests))
+	for _, request := range requests {
+		payload, err := h.convertPayload(ctx, msg, rcpt, request, clog)
+		if err != nil {
+			return nil, err
 		}
-
-		if !textAsCaption && !isInteractiveMsg {
-			for _, part := range parts {
-
-				//check if you have a link
-				var payload mtTextPayload
-				if strings.Contains(part, "https://") || strings.Contains(part, "http://") {
-					payload = mtTextPayload{
-						recipient:  rcpt,
-						Type:       "text",
-						PreviewURL: true,
-					}
-				} else {
-					payload = mtTextPayload{
-						recipient: rcpt,
-						Type:      "text",
-					}
-				}
-				payload.Text.Body = part
-				payloads = append(payloads, payload)
-			}
-		}
-
-		if isInteractiveMsg {
-			for i, part := range parts {
-				if i < (len(parts) - 1) { //if split into more than one message, the first parts will be text and the last interactive
-					payload := mtTextPayload{
-						recipient: rcpt,
-						Type:      "text",
-					}
-					payload.Text.Body = part
-					payloads = append(payloads, payload)
-
-				} else {
-					payload := mtInteractivePayload{
-						recipient: rcpt,
-						Type:      "interactive",
-					}
-
-					if len(locationQRs) > 0 {
-						payload.Interactive.Type = "location_request_message"
-						payload.Interactive.Body.Text = part
-						payload.Interactive.Action.Name = "send_location"
-						payloads = append(payloads, payload)
-
-					} else if len(formQRs) > 0 {
-						qr := formQRs[0]
-						payload.Interactive.Type = "flow"
-						payload.Interactive.Body.Text = part
-						payload.Interactive.Action.Name = "flow"
-						payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
-							FlowMessageVersion: "3",
-							FlowID:             qr.Extra,
-							FlowCTA:            qr.GetText(),
-						}
-						payloads = append(payloads, payload)
-
-					} else if len(urlQRs) > 0 {
-						qr := urlQRs[0]
-						payload.Interactive.Type = "cta_url"
-						payload.Interactive.Body.Text = part
-						payload.Interactive.Action.Name = "cta_url"
-						payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
-							DisplayText: qr.GetText(),
-							URL:         qr.Extra,
-						}
-						payloads = append(payloads, payload)
-
-					} else if !qrsAsList { // we show buttons
-						payload.Interactive.Type = "button"
-						payload.Interactive.Body.Text = part
-						btns := make([]mtButton, len(qrs))
-						for btnIdx, qr := range qrs {
-							btns[btnIdx] = mtButton{
-								Type: "reply",
-							}
-							btns[btnIdx].Reply.ID = fmt.Sprint(btnIdx)
-							btns[btnIdx].Reply.Title = qr.Text
-						}
-						payload.Interactive.Action.Buttons = btns
-						payloads = append(payloads, payload)
-					} else {
-						payload.Interactive.Type = "list"
-						payload.Interactive.Body.Text = part
-						payload.Interactive.Action.Button = "Menu"
-						section := mtSection{
-							Rows: make([]mtSectionRow, len(qrs)),
-						}
-						for rowIdx, qr := range qrs {
-							section.Rows[rowIdx] = mtSectionRow{
-								ID:          fmt.Sprint(rowIdx),
-								Title:       qr.Text,
-								Description: qr.Extra,
-							}
-						}
-						payload.Interactive.Action.Sections = []mtSection{
-							section,
-						}
-						payloads = append(payloads, payload)
-					}
-				}
-			}
-		}
-
-	} else {
-		if isInteractiveMsg {
-			for i, part := range parts {
-				if i < (len(parts) - 1) { //if split into more than one message, the first parts will be text and the last interactive
-					payload := mtTextPayload{
-						recipient: rcpt,
-						Type:      "text",
-					}
-					payload.Text.Body = part
-					payloads = append(payloads, payload)
-
-				} else {
-					payload := mtInteractivePayload{
-						recipient: rcpt,
-						Type:      "interactive",
-					}
-
-					if len(locationQRs) > 0 {
-						payload.Interactive.Type = "location_request_message"
-						payload.Interactive.Body.Text = part
-						payload.Interactive.Action.Name = "send_location"
-						payloads = append(payloads, payload)
-
-					} else if len(formQRs) > 0 {
-						qr := formQRs[0]
-						payload.Interactive.Type = "flow"
-						payload.Interactive.Body.Text = part
-						payload.Interactive.Action.Name = "flow"
-						payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
-							FlowMessageVersion: "3",
-							FlowID:             qr.Extra,
-							FlowCTA:            qr.GetText(),
-						}
-						payloads = append(payloads, payload)
-
-					} else if len(urlQRs) > 0 {
-						qr := urlQRs[0]
-						payload.Interactive.Type = "cta_url"
-						payload.Interactive.Body.Text = part
-						payload.Interactive.Action.Name = "cta_url"
-						payload.Interactive.Action.Parameters = &whatsapp.ActionParameters{
-							DisplayText: qr.GetText(),
-							URL:         qr.Extra,
-						}
-						payloads = append(payloads, payload)
-
-					} else if !qrsAsList { // we show buttons
-						payload.Interactive.Type = "button"
-						payload.Interactive.Body.Text = part
-						btns := make([]mtButton, len(qrs))
-						for i, qr := range qrs {
-							btns[i] = mtButton{
-								Type: "reply",
-							}
-							btns[i].Reply.ID = fmt.Sprint(i)
-							btns[i].Reply.Title = qr.Text
-						}
-						payload.Interactive.Action.Buttons = btns
-						payloads = append(payloads, payload)
-					} else {
-						payload.Interactive.Type = "list"
-						payload.Interactive.Body.Text = part
-						payload.Interactive.Action.Button = "Menu"
-						section := mtSection{
-							Rows: make([]mtSectionRow, len(qrs)),
-						}
-						for i, qr := range qrs {
-							section.Rows[i] = mtSectionRow{
-								ID:          fmt.Sprint(i),
-								Title:       qr.Text,
-								Description: qr.Extra,
-							}
-						}
-						payload.Interactive.Action.Sections = []mtSection{
-							section,
-						}
-						payloads = append(payloads, payload)
-					}
-				}
-			}
-		} else {
-			for _, part := range parts {
-
-				// check if you have a link
-				var payload mtTextPayload
-				if strings.Contains(part, "https://") || strings.Contains(part, "http://") {
-					payload = mtTextPayload{
-						recipient:  rcpt,
-						Type:       "text",
-						PreviewURL: true,
-					}
-				} else {
-					payload = mtTextPayload{
-						recipient: rcpt,
-						Type:      "text",
-					}
-				}
-				payload.Text.Body = part
-				payloads = append(payloads, payload)
-			}
-		}
+		payloads = append(payloads, payload)
 	}
-	return payloads, err
+	return payloads, nil
+}
+
+// convertPayload converts a Cloud API style send request from the shared payload builder into this API's format:
+// media messages must reference media uploaded to /v1/media by id - unlike template headers and interactive
+// headers, they can't carry a link - and URL previews are a top level field.
+func (h *handler) convertPayload(ctx context.Context, msg *models.MsgOut, rcpt recipient, request whatsapp.SendRequest, clog *models.ChannelLog) (any, error) {
+	switch request.Type {
+	case "text":
+		if request.Text == nil {
+			return nil, fmt.Errorf("unsupported attachment type on message: %s", msg.UUID())
+		}
+		payload := mtTextPayload{recipient: rcpt, Type: "text", PreviewURL: request.Text.PreviewURL}
+		payload.Text.Body = request.Text.Body
+		return payload, nil
+
+	case "image", "audio", "video", "document":
+		var media *whatsapp.Media
+		switch request.Type {
+		case "image":
+			media = request.Image
+		case "audio":
+			media = request.Audio
+		case "video":
+			media = request.Video
+		case "document":
+			media = request.Document
+		}
+
+		mediaID, err := h.fetchMediaID(ctx, msg, media.Link, clog)
+		if err != nil {
+			slog.Error("error while uploading media to whatsapp", "error", err, "channel_uuid", msg.Channel().UUID())
+		}
+		if mediaID == "" {
+			return nil, channels.ErrRetryableWithReason("media_upload_failed", "unable to upload media to WhatsApp")
+		}
+
+		object := &mediaObject{ID: mediaID, Caption: media.Caption, Filename: media.Filename}
+		switch request.Type {
+		case "image":
+			return mtImagePayload{recipient: rcpt, Type: "image", Image: object}, nil
+		case "audio":
+			return mtAudioPayload{recipient: rcpt, Type: "audio", Audio: object}, nil
+		case "video":
+			return mtVideoPayload{recipient: rcpt, Type: "video", Video: object}, nil
+		default:
+			return mtDocumentPayload{recipient: rcpt, Type: "document", Document: object}, nil
+		}
+
+	case "interactive":
+		return mtInteractivePayload{recipient: rcpt, Type: "interactive", Interactive: request.Interactive}, nil
+	}
+
+	return nil, fmt.Errorf("unsupported payload type: %s", request.Type)
 }
 
 // fetchMediaID tries to fetch the id for the uploaded media, setting the result in redis.
@@ -904,7 +634,7 @@ func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.Se
 	}
 	sendURL, _ := url.Parse("/v1/messages")
 
-	requestPayloads, err := buildPayloads(ctx, msg, h, clog)
+	requestPayloads, err := h.buildPayloads(ctx, msg, clog)
 	if err != nil {
 		return err
 	}

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -1327,24 +1327,14 @@ var defaultSendTestCases = []OutgoingTestCase{
 		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "BUTTON1"}},
 		MsgAttachments:  []string{"image/jpeg:https://foo.bar/image2.jpg"},
 		MockResponses: map[string][]*httpx.MockResponse{
-			"https://foo.bar/image2.jpg": {
-				httpx.NewMockResponse(200, nil, []byte(`data`)),
-			},
-			"*/v1/media": {
-				httpx.NewMockResponse(201, nil, []byte(`{ "media" : [{"id": "5f6a7b8c-1283-4b94-988d-7276bdec4de2"}] }`)),
-			},
 			"*/v1/messages": {
-				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
 				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
 			},
 		},
 		ExpectedRequests: []ExpectedRequest{
-			{},
-			{},
-			{Body: `{"to":"250788123123","type":"image","image":{"id":"5f6a7b8c-1283-4b94-988d-7276bdec4de2"}}`},
-			{Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"button","body":{"text":"Interactive Button Msg"},"action":{"buttons":[{"type":"reply","reply":{"id":"0","title":"BUTTON1"}}]}}}`},
+			{Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"button","header":{"type":"image","image":{"link":"https://foo.bar/image2.jpg"}},"body":{"text":"Interactive Button Msg"},"action":{"buttons":[{"type":"reply","reply":{"id":"0","title":"BUTTON1"}}]}}}`},
 		},
-		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
 	{
 		Label:           "Interactive List Message Send with attachment",
@@ -1460,6 +1450,22 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"cta_url","body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Open Link","url":"https://example.com"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with URL button, with attachment used as header",
+		MsgText:         "Interactive URL msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}},
+		MsgAttachments:  []string{"image/jpeg:https://foo.bar/image2.jpg"},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"cta_url","header":{"type":"image","image":{"link":"https://foo.bar/image2.jpg"}},"body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Visit","url":"https://example.com"}}}}`,
 		}},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},


### PR DESCRIPTION
## Summary

The TN handler carried its own copy of the WhatsApp content-message logic (text splitting, quick reply rendering, attachment handling), which had drifted from the shared builder used by the WAC and D3C handlers. This ports it onto `whatsapp.GetMsgPayloads` with a thin conversion to this API's format, deleting ~300 lines of duplication and picking up the behaviors the shared builder already has.

## Changes

- `buildPayloads` now calls `whatsapp.GetMsgPayloads` and converts each Cloud API style request via a new `convertPayload`: media messages swap their `link` for an id from the existing upload-and-cache machinery (`fetchMediaID`, unchanged), and `preview_url` moves to the top level. The template branch is untouched since these templates require a namespace.
- `mtInteractivePayload` embeds the shared `whatsapp.Interactive` struct directly — interactive headers on this API can reference media by link (like template headers already do), so no upload is needed for them. The duplicated `mtSection`/`mtSectionRow`/`mtButton` structs and the two identical interactive-building blocks are deleted.
- The shared builder now logs `media_unsupported` and skips attachments whose content type can't be sent as a media message, instead of emitting a malformed request that the API rejects — this benefits WAC and D3C too, and preserves TN's previous log-and-skip behavior for unsupported media.

## Behavior changes

| Case | Before | After |
|---|---|---|
| image/video/document + button or URL quick replies | attachment and interactive sent as two messages | one interactive message with a media header |
| text > 1024 chars with quick replies or attachments | sent at up to 4096 chars, rejected by the API | split so bodies/captions stay within the 1024 limit |
| more than 10 list rows | sent as-is, rejected by the API | truncated to 10 with a logged channel error |
| list menu button | hardcoded "Menu" | localized to the message locale |
| multi-part text with an attachment | whole text stuffed into the first caption, parts never sent | caption only when a single part and single attachment |
| attachment + quick replies with no text | interactive message with an empty body, rejected by the API | attachment sent as a standalone media message |
| attachment with unsupported MIME type (all WhatsApp handlers) | malformed request rejected by the API | logged as `media_unsupported` and skipped, rest of message sends |

## Review notes

- Interactive media headers referencing attachments by `link` (no `/v1/media` upload) is confirmed supported: the API docs list `link` for interactive header media, and template headers already send media by link on this channel.
- Review surfaced that unsupported attachment types would have failed the whole message without a useful log; fixed at the source in the shared builder.

## Test plan

- Existing TN handler tests pass; only one expectation changed (button + attachment now sends a single header message with no media upload)
- Added tests pinning the new CTA URL + attachment header behavior and the unsupported-attachment log-and-skip behavior
- Full test suite passes