### PR TITLE
Allow application attachments as WhatsApp interactive message headers

### DIFF
--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -80,8 +80,8 @@ func buildContentPayloads(msg *models.MsgOut, maxMsgLength int, clog *models.Cha
 	if len(msg.Attachments()) > 0 && len(msgParts) > 0 && headerCapable && len(locationQRs) == 0 && len(formQRs) == 0 {
 		attType, _ := handlers.SplitAttachment(msg.Attachments()[0])
 		attType = strings.Split(attType, "/")[0]
-		// only certain media types can be used as an interactive header
-		if attType == "image" || attType == "video" || attType == "document" {
+		// only certain media types can be used as an interactive header (application/* is sent as a document)
+		if attType == "image" || attType == "video" || attType == "document" || attType == "application" {
 			hasHeaderAttachment = true
 		}
 	}

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -147,7 +147,7 @@ func TestGetMsgPayloads(t *testing.T) {
 		{
 			label:                 "1 QR with document attachment - should use document as header",
 			text:                  "Review this",
-			attachments:           []string{"document/pdf:https://example.com/document.pdf"},
+			attachments:           []string{"application/pdf:https://example.com/document.pdf"},
 			quickReplies:          []models.QuickReply{{Type: "text", Text: "Approve"}},
 			urn:                   "whatsapp:250788123123",
 			expectedPayloadsCount: 1,
@@ -407,6 +407,25 @@ func TestGetMsgPayloads(t *testing.T) {
 				assert.NotNil(t, payloads[0].Interactive.Header.Image)
 				assert.Equal(t, "https://example.com/image.jpg", payloads[0].Interactive.Header.Image.Link)
 				assert.Equal(t, &whatsapp.ActionParameters{DisplayText: "Visit", URL: "https://example.com"}, payloads[0].Interactive.Action.Parameters)
+			},
+		},
+		{
+			label:                 "URL QR with application attachment - should use document as header of cta_url",
+			text:                  "Review this",
+			attachments:           []string{"application/pdf:https://example.com/document.pdf"},
+			quickReplies:          []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "cta_url", payloads[0].Interactive.Type)
+				// Check header
+				assert.NotNil(t, payloads[0].Interactive.Header)
+				assert.Equal(t, "document", payloads[0].Interactive.Header.Type)
+				assert.NotNil(t, payloads[0].Interactive.Header.Document)
+				assert.Equal(t, "https://example.com/document.pdf", payloads[0].Interactive.Header.Document.Link)
+				assert.Equal(t, "document.pdf", payloads[0].Interactive.Header.Document.Filename)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

The interactive-header eligibility check in the shared WhatsApp payload builder only accepted raw `image`/`video`/`document` content-type prefixes, but real document attachments carry `application/*` types (e.g. `application/pdf`). The header builder already maps `application` to a document header - the eligibility check just never let it get there, so a document + quick replies always went out as two messages while an image went out as one. This affects all three channel types using the shared builder (WAC, D3C, TN).

## Changes

- Accept `application` in the header-eligibility check in `buildContentPayloads`.
- Switched the document-header payload test from the synthetic `document/pdf` type (which masked this gap) to `application/pdf`, and added a case covering an `application/*` attachment as the header of a CTA URL message.

## Behavior examples

| Case | Before | After |
|---|---|---|
| `application/pdf` attachment + button or URL quick replies | PDF sent as standalone media message, then a separate interactive message | one interactive message with a document header |

## Test plan

- New and updated payload tests cover document headers via `application/*` for both button and CTA URL messages
- Full handler test suite passes