### PR TITLE
Log WhatsApp quick replies that are dropped instead of discarding them silently

### DIFF
--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -835,7 +835,8 @@ var SendTestCasesD3C = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{{
 			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"location_request_message","body":{"text":"Interactive send location"},"action":{"name":"send_location"}}}`,
 		}},
-		ExpectedExtIDs: []string{"157b5e14568e8"},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "quick reply of type text can't be combined with a location quick reply and won't be sent"}},
 	},
 	{
 		Label:           "Interactive with location request, with attachment",
@@ -853,7 +854,8 @@ var SendTestCasesD3C = []OutgoingTestCase{
 			{Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"image","image":{"link":"https://foo.bar/image.jpg"}}`},
 			{Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"location_request_message","body":{"text":"Interactive send location"},"action":{"name":"send_location"}}}`},
 		},
-		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
+		ExpectedExtIDs:    []string{"157b5e14568e8", "157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "quick reply of type text can't be combined with a location quick reply and won't be sent"}},
 	},
 	{
 		Label:           "Interactive with form",

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -893,7 +893,8 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{{
 			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"location_request_message","body":{"text":"Interactive send location"},"action":{"name":"send_location"}}}`,
 		}},
-		ExpectedExtIDs: []string{"157b5e14568e8"},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "quick reply of type text can't be combined with a location quick reply and won't be sent"}},
 	},
 	{
 		Label:           "Interactive with location request, with attachment",
@@ -941,7 +942,8 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{{
 			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Open Form"}}}}`,
 		}},
-		ExpectedExtIDs: []string{"157b5e14568e8"},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "quick reply of type text can't be combined with a form quick reply and won't be sent"}},
 	},
 	{
 		Label:           "Interactive with form, with attachment",
@@ -1005,7 +1007,8 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{{
 			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"cta_url","body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Open Link","url":"https://example.com"}}}}`,
 		}},
-		ExpectedExtIDs: []string{"157b5e14568e8"},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "quick reply of type text can't be combined with a url quick reply and won't be sent"}},
 	},
 	{
 		Label:           "Interactive with URL button, with attachment",

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -75,8 +75,8 @@ func buildContentPayloads(msg *models.MsgOut, maxMsgLength int, clog *models.Cha
 
 	qrsAsList := shouldUseList(qrs)
 
-	// truncate quick replies to max 10
-	if len(qrs) > 10 {
+	// truncate quick replies to max 10 - only relevant if text quick replies are what will be rendered
+	if len(locationQRs) == 0 && len(formQRs) == 0 && len(urlQRs) == 0 && len(qrs) > 10 {
 		clog.Error(&svclogs.Error{Message: "too many quick replies WhatsApp supports only up to 10 quick replies"})
 		qrs = qrs[:10]
 	}

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -3,6 +3,7 @@ package whatsapp
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/nyaruka/courier/v26/core/models"
@@ -61,6 +62,16 @@ func buildContentPayloads(msg *models.MsgOut, maxMsgLength int, clog *models.Cha
 	}
 
 	msgParts := splitText(msg, maxMsgLength)
+
+	// log any quick replies that will be dropped - because interactive messages require body text, or because a
+	// different kind of quick reply takes precedence on this message
+	if len(sqrs) > 0 && len(msgParts) == 0 {
+		for _, qr := range sqrs {
+			clog.Error(&svclogs.Error{Message: fmt.Sprintf("quick reply of type %s can't be sent on a message with no text", qr.Type)})
+		}
+	} else {
+		logDroppedQuickReplies(clog, locationQRs, formQRs, urlQRs, qrs)
+	}
 
 	qrsAsList := shouldUseList(qrs)
 
@@ -151,6 +162,36 @@ func buildContentPayloads(msg *models.MsgOut, maxMsgLength int, clog *models.Cha
 		}
 	}
 	return payloads, nil
+}
+
+// logDroppedQuickReplies logs a channel error for each quick reply that won't be sent because a message can only
+// render one kind of quick reply - location, form, url or text in order of precedence - and at most one form or
+// url button. Extra location quick replies aren't logged since they all collapse into the same location request.
+func logDroppedQuickReplies(clog *models.ChannelLog, locationQRs, formQRs, urlQRs, textQRs []models.QuickReply) {
+	var winning string
+	var dropped []models.QuickReply
+
+	switch {
+	case len(locationQRs) > 0:
+		winning = models.QuickReplyTypeLocation
+		dropped = slices.Concat(formQRs, urlQRs, textQRs)
+	case len(formQRs) > 0:
+		winning = models.QuickReplyTypeForm
+		dropped = slices.Concat(formQRs[1:], urlQRs, textQRs)
+	case len(urlQRs) > 0:
+		winning = models.QuickReplyTypeURL
+		dropped = slices.Concat(urlQRs[1:], textQRs)
+	default:
+		return
+	}
+
+	for _, qr := range dropped {
+		if qr.Type == winning {
+			clog.Error(&svclogs.Error{Message: fmt.Sprintf("only one quick reply of type %s can be sent per message", qr.Type)})
+		} else {
+			clog.Error(&svclogs.Error{Message: fmt.Sprintf("quick reply of type %s can't be combined with a %s quick reply and won't be sent", qr.Type, winning)})
+		}
+	}
 }
 
 func splitText(msg *models.MsgOut, maxMsgLength int) []string {

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -406,6 +406,36 @@ func TestGetMsgPayloads(t *testing.T) {
 			},
 		},
 		{
+			label:                 "Two form QRs - only first sent, second logged as dropped",
+			text:                  "Book an appointment",
+			quickReplies:          []models.QuickReply{{Type: "form", Text: "Book now", Extra: "111"}, {Type: "form", Text: "Book later", Extra: "222"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, "flow", payloads[0].Interactive.Type)
+				assert.Equal(t, "111", payloads[0].Interactive.Action.Parameters.FlowID)
+				assert.Len(t, clog.Errors, 1)
+				assert.Equal(t, "only one quick reply of type form can be sent per message", clog.Errors[0].Message)
+			},
+		},
+		{
+			label:                 "Mixed QRs with attachment but no text - all QRs logged as dropped",
+			text:                  "",
+			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},
+			quickReplies:          []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}, {Type: "text", Text: "Yes"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "image",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Len(t, clog.Errors, 2)
+				assert.Equal(t, "quick reply of type url can't be sent on a message with no text", clog.Errors[0].Message)
+				assert.Equal(t, "quick reply of type text can't be sent on a message with no text", clog.Errors[1].Message)
+			},
+		},
+		{
 			label:                 "URL QR with image attachment - should use image as header of cta_url",
 			text:                  "Check out our site",
 			attachments:           []string{"image/jpeg:https://example.com/image.jpg"},

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -386,6 +386,23 @@ func TestGetMsgPayloads(t *testing.T) {
 				assert.Equal(t, "Check out our site", payloads[0].Interactive.Body.Text)
 				assert.Equal(t, "cta_url", payloads[0].Interactive.Action.Name)
 				assert.Equal(t, &whatsapp.ActionParameters{DisplayText: "Visit", URL: "https://example.com"}, payloads[0].Interactive.Action.Parameters)
+				// dropped text QR should be logged
+				assert.Len(t, clog.Errors, 1)
+				assert.Equal(t, "quick reply of type text can't be combined with a url quick reply and won't be sent", clog.Errors[0].Message)
+			},
+		},
+		{
+			label:                 "Two URL QRs - only first sent, second logged as dropped",
+			text:                  "Check out our sites",
+			quickReplies:          []models.QuickReply{{Type: "url", Text: "Visit", Extra: "https://example.com"}, {Type: "url", Text: "Docs", Extra: "https://docs.example.com"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, 1, len(payloads))
+				assert.Equal(t, &whatsapp.ActionParameters{DisplayText: "Visit", URL: "https://example.com"}, payloads[0].Interactive.Action.Parameters)
+				assert.Len(t, clog.Errors, 1)
+				assert.Equal(t, "only one quick reply of type url can be sent per message", clog.Errors[0].Message)
 			},
 		},
 		{
@@ -458,6 +475,8 @@ func TestGetMsgPayloads(t *testing.T) {
 				assert.Equal(t, 1, len(payloads))
 				assert.Equal(t, "image", payloads[0].Type)
 				assert.Equal(t, "https://example.com/image.jpg", payloads[0].Image.Link)
+				assert.Len(t, clog.Errors, 1)
+				assert.Equal(t, "quick reply of type url can't be sent on a message with no text", clog.Errors[0].Message)
 			},
 		},
 		{

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -1406,7 +1406,8 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{{
 			Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Open Form"}}}}`,
 		}},
-		ExpectedExtIDs: []string{"157b5e14568e8"},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "quick reply of type text can't be combined with a form quick reply and won't be sent"}},
 	},
 	{
 		Label:           "Interactive with form missing form ID, sent as text",
@@ -1452,7 +1453,8 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedRequests: []ExpectedRequest{{
 			Body: `{"to":"250788123123","type":"interactive","interactive":{"type":"cta_url","body":{"text":"Interactive URL msg"},"action":{"name":"cta_url","parameters":{"display_text":"Open Link","url":"https://example.com"}}}}`,
 		}},
-		ExpectedExtIDs: []string{"157b5e14568e8"},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "quick reply of type text can't be combined with a url quick reply and won't be sent"}},
 	},
 	{
 		Label:           "Interactive with URL button, with attachment used as header",


### PR DESCRIPTION
## Summary

WhatsApp has no interactive message type that combines different kinds of quick replies, so the payload builder picks one kind by precedence (location > form > url > text) and allows at most one form or url button - and interactive messages require body text, so a message with no text can't render quick replies at all. Quick replies dropped for any of these reasons were discarded silently, unlike unsupported types, missing extras and list truncation which all log channel errors. Now every dropped quick reply is logged, so operators can see why buttons vanished from a message. Wire behavior is unchanged.

## Changes

- `buildContentPayloads` logs a channel error for each quick reply dropped because a different kind takes precedence, because it's a second form/url button, or because the message has no text. Extra location quick replies aren't logged since they all collapse into the same location request.
- The "too many quick replies" truncation log now only fires when text quick replies are the winning kind, so text quick replies dropped by precedence get exactly one log line instead of a contradictory pair.
- Existing handler tests for mixed quick replies (WAC, D3C, TN) now assert the logged errors; payload tests added for the second-url, second-form and no-text cases.

## Behavior examples

| Message | Sent (unchanged) | Channel log (new) |
|---|---|---|
| url QR + text QRs | CTA URL message | `quick reply of type text can't be combined with a url quick reply and won't be sent` |
| two url QRs | CTA URL message with the first | `only one quick reply of type url can be sent per message` |
| attachment + QRs, no text | standalone media message | `quick reply of type url can't be sent on a message with no text` |

## Test plan

- Updated the seven affected handler test cases across WAC, D3C and TN to expect the new log errors
- Added payload tests asserting the dropped-QR messages for url, form and no-text variants
- Full handler test suite passes