### PR TITLE
Truncate WhatsApp quick reply texts that exceed their character limits

### DIFF
--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -50,7 +50,8 @@ const maxCaptionAndBodyLength = 1024
 
 // character limits for quick reply texts rendered in interactive messages
 const (
-	maxButtonTextLength   = 20 // reply button titles, CTA URL and flow button text
+	maxButtonTextLength   = 20 // reply button titles and CTA URL display text
+	maxFlowCTALength      = 30 // flow button text
 	maxListRowTitleLength = 24
 	maxListRowDescLength  = 72
 )
@@ -286,7 +287,7 @@ func buildFlowPayload(msg *models.MsgOut, body string, qr models.QuickReply, clo
 	}{Text: body}}
 	interactive.Action = &Action{
 		Name:       "flow",
-		Parameters: &ActionParameters{FlowMessageVersion: "3", FlowID: qr.Extra, FlowCTA: truncateQuickReplyText(clog, qr.GetText(), maxButtonTextLength)},
+		Parameters: &ActionParameters{FlowMessageVersion: "3", FlowID: qr.Extra, FlowCTA: truncateQuickReplyText(clog, qr.GetText(), maxFlowCTALength)},
 	}
 	p.Interactive = &interactive
 	return p

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/utils"
+	"github.com/nyaruka/gocommon/stringsx"
 	"github.com/nyaruka/gocommon/svclogs"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -46,6 +47,23 @@ func (p SendRequest) withTemplate(templating *models.Templating) SendRequest {
 // maxCaptionAndBodyLength is the limit for media captions and interactive message bodies, which is lower than the
 // limit for plain text bodies
 const maxCaptionAndBodyLength = 1024
+
+// character limits for quick reply texts rendered in interactive messages
+const (
+	maxButtonTextLength   = 20 // reply button titles, CTA URL and flow button text
+	maxListRowTitleLength = 24
+	maxListRowDescLength  = 72
+)
+
+// truncateQuickReplyText truncates the given quick reply text to the given character limit, logging a channel
+// error if it was too long to be sent as is.
+func truncateQuickReplyText(clog *models.ChannelLog, text string, limit int) string {
+	truncated := stringsx.TruncateEllipsis(text, limit)
+	if truncated != text {
+		clog.Error(&svclogs.Error{Message: fmt.Sprintf("quick reply text '%s' exceeds the %d character limit and will be truncated", text, limit)})
+	}
+	return truncated
+}
 
 // buildContentPayloads constructs payloads for a non-template message with text, attachments, and quick replies.
 func buildContentPayloads(msg *models.MsgOut, maxMsgLength int, clog *models.ChannelLog) ([]SendRequest, error) {
@@ -138,24 +156,24 @@ func buildContentPayloads(msg *models.MsgOut, maxMsgLength int, clog *models.Cha
 			payloads = append(payloads, buildLocationRequestPayload(msg, part))
 
 		case isLastPart && len(formQRs) > 0:
-			payloads = append(payloads, buildFlowPayload(msg, part, formQRs[0]))
+			payloads = append(payloads, buildFlowPayload(msg, part, formQRs[0], clog))
 
 		case isLastPart && len(urlQRs) > 0:
-			p, err := buildCTAURLPayload(msg, part, urlQRs[0], hasHeaderAttachment)
+			p, err := buildCTAURLPayload(msg, part, urlQRs[0], hasHeaderAttachment, clog)
 			if err != nil {
 				return nil, err
 			}
 			payloads = append(payloads, p)
 
 		case isLastPart && len(qrs) > 0 && !qrsAsList:
-			p, err := buildButtonPayload(msg, part, qrs, hasHeaderAttachment)
+			p, err := buildButtonPayload(msg, part, qrs, hasHeaderAttachment, clog)
 			if err != nil {
 				return nil, err
 			}
 			payloads = append(payloads, p)
 
 		case isLastPart && len(qrs) > 0 && qrsAsList:
-			payloads = append(payloads, buildListPayload(msg, part, qrs, menuButton))
+			payloads = append(payloads, buildListPayload(msg, part, qrs, menuButton, clog))
 
 		default:
 			payloads = append(payloads, buildTextPayload(msg, part))
@@ -260,7 +278,7 @@ func buildLocationRequestPayload(msg *models.MsgOut, body string) SendRequest {
 	return p
 }
 
-func buildFlowPayload(msg *models.MsgOut, body string, qr models.QuickReply) SendRequest {
+func buildFlowPayload(msg *models.MsgOut, body string, qr models.QuickReply, clog *models.ChannelLog) SendRequest {
 	p := newBasePayload(msg)
 	p.Type = "interactive"
 	interactive := Interactive{Type: "flow", Body: struct {
@@ -268,13 +286,13 @@ func buildFlowPayload(msg *models.MsgOut, body string, qr models.QuickReply) Sen
 	}{Text: body}}
 	interactive.Action = &Action{
 		Name:       "flow",
-		Parameters: &ActionParameters{FlowMessageVersion: "3", FlowID: qr.Extra, FlowCTA: qr.GetText()},
+		Parameters: &ActionParameters{FlowMessageVersion: "3", FlowID: qr.Extra, FlowCTA: truncateQuickReplyText(clog, qr.GetText(), maxButtonTextLength)},
 	}
 	p.Interactive = &interactive
 	return p
 }
 
-func buildCTAURLPayload(msg *models.MsgOut, body string, qr models.QuickReply, useAttachmentHeader bool) (SendRequest, error) {
+func buildCTAURLPayload(msg *models.MsgOut, body string, qr models.QuickReply, useAttachmentHeader bool, clog *models.ChannelLog) (SendRequest, error) {
 	p := newBasePayload(msg)
 	p.Type = "interactive"
 	interactive := Interactive{Type: "cta_url", Body: struct {
@@ -291,23 +309,23 @@ func buildCTAURLPayload(msg *models.MsgOut, body string, qr models.QuickReply, u
 
 	interactive.Action = &Action{
 		Name:       "cta_url",
-		Parameters: &ActionParameters{DisplayText: qr.GetText(), URL: qr.Extra},
+		Parameters: &ActionParameters{DisplayText: truncateQuickReplyText(clog, qr.GetText(), maxButtonTextLength), URL: qr.Extra},
 	}
 	p.Interactive = &interactive
 	return p, nil
 }
 
-func buildButtons(qrs []models.QuickReply) []Button {
+func buildButtons(qrs []models.QuickReply, clog *models.ChannelLog) []Button {
 	btns := make([]Button, len(qrs))
 	for i, qr := range qrs {
 		btns[i] = Button{Type: "reply"}
 		btns[i].Reply.ID = fmt.Sprint(i)
-		btns[i].Reply.Title = qr.Text
+		btns[i].Reply.Title = truncateQuickReplyText(clog, qr.Text, maxButtonTextLength)
 	}
 	return btns
 }
 
-func buildButtonPayload(msg *models.MsgOut, body string, qrs []models.QuickReply, useAttachmentHeader bool) (SendRequest, error) {
+func buildButtonPayload(msg *models.MsgOut, body string, qrs []models.QuickReply, useAttachmentHeader bool, clog *models.ChannelLog) (SendRequest, error) {
 	p := newBasePayload(msg)
 	p.Type = "interactive"
 
@@ -323,7 +341,7 @@ func buildButtonPayload(msg *models.MsgOut, body string, qrs []models.QuickReply
 		interactive.Header = header
 	}
 
-	interactive.Action = &Action{Buttons: buildButtons(qrs)}
+	interactive.Action = &Action{Buttons: buildButtons(qrs, clog)}
 	p.Interactive = &interactive
 	return p, nil
 }
@@ -351,7 +369,7 @@ func buildAttachmentHeader(msg *models.MsgOut) (*Header, error) {
 	return nil, nil
 }
 
-func buildListPayload(msg *models.MsgOut, body string, qrs []models.QuickReply, menuButton string) SendRequest {
+func buildListPayload(msg *models.MsgOut, body string, qrs []models.QuickReply, menuButton string, clog *models.ChannelLog) SendRequest {
 	p := newBasePayload(msg)
 	p.Type = "interactive"
 
@@ -363,8 +381,8 @@ func buildListPayload(msg *models.MsgOut, body string, qrs []models.QuickReply, 
 	for i, qr := range qrs {
 		section.Rows[i] = SectionRow{
 			ID:          fmt.Sprint(i),
-			Title:       qr.Text,
-			Description: qr.Extra,
+			Title:       truncateQuickReplyText(clog, qr.Text, maxListRowTitleLength),
+			Description: truncateQuickReplyText(clog, qr.Extra, maxListRowDescLength),
 		}
 	}
 

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -553,6 +553,63 @@ func TestGetMsgPayloads(t *testing.T) {
 			},
 		},
 		{
+			label:                 "Button title over 20 characters - should be truncated and logged",
+			text:                  "Pick one",
+			quickReplies:          []models.QuickReply{{Type: "text", Text: "This is a very long button title"}, {Type: "text", Text: "Short"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, "button", payloads[0].Interactive.Type)
+				assert.Equal(t, "This is a very lo...", payloads[0].Interactive.Action.Buttons[0].Reply.Title)
+				assert.Equal(t, "Short", payloads[0].Interactive.Action.Buttons[1].Reply.Title)
+				assert.Len(t, clog.Errors, 1)
+				assert.Equal(t, "quick reply text 'This is a very long button title' exceeds the 20 character limit and will be truncated", clog.Errors[0].Message)
+			},
+		},
+		{
+			label:                 "List row title and description over limits - should be truncated and logged",
+			text:                  "Pick one",
+			quickReplies:          []models.QuickReply{{Type: "text", Text: "Option with a very long title", Extra: strings.Repeat("x", 80)}, {Type: "text", Text: "Short", Extra: "ok"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, "list", payloads[0].Interactive.Type)
+				rows := payloads[0].Interactive.Action.Sections[0].Rows
+				assert.Equal(t, "Option with a very lo...", rows[0].Title)
+				assert.Equal(t, strings.Repeat("x", 69)+"...", rows[0].Description)
+				assert.Equal(t, "Short", rows[1].Title)
+				assert.Len(t, clog.Errors, 2)
+			},
+		},
+		{
+			label:                 "Flow CTA over 20 characters - should be truncated and logged",
+			text:                  "Book an appointment",
+			quickReplies:          []models.QuickReply{{Type: "form", Text: "Book your appointment now please", Extra: "123456"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, "flow", payloads[0].Interactive.Type)
+				assert.Equal(t, "Book your appoint...", payloads[0].Interactive.Action.Parameters.FlowCTA)
+				assert.Len(t, clog.Errors, 1)
+			},
+		},
+		{
+			label:                 "URL button display text over 20 characters - should be truncated and logged",
+			text:                  "Check out our site",
+			quickReplies:          []models.QuickReply{{Type: "url", Text: "Visit our brand new website", Extra: "https://example.com"}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				assert.Equal(t, "cta_url", payloads[0].Interactive.Type)
+				assert.Equal(t, "Visit our brand n...", payloads[0].Interactive.Action.Parameters.DisplayText)
+				assert.Len(t, clog.Errors, 1)
+			},
+		},
+		{
 			label:                 "Text between 1024 and 4096 without attachments or QRs - should be a single text message",
 			text:                  strings.Repeat("x", 2000),
 			urn:                   "whatsapp:250788123123",

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -584,7 +584,7 @@ func TestGetMsgPayloads(t *testing.T) {
 			},
 		},
 		{
-			label:                 "Flow CTA over 20 characters - should be truncated and logged",
+			label:                 "Flow CTA over 30 characters - should be truncated and logged",
 			text:                  "Book an appointment",
 			quickReplies:          []models.QuickReply{{Type: "form", Text: "Book your appointment now please", Extra: "123456"}},
 			urn:                   "whatsapp:250788123123",
@@ -592,7 +592,23 @@ func TestGetMsgPayloads(t *testing.T) {
 			expectedType:          "interactive",
 			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
 				assert.Equal(t, "flow", payloads[0].Interactive.Type)
-				assert.Equal(t, "Book your appoint...", payloads[0].Interactive.Action.Parameters.FlowCTA)
+				assert.Equal(t, "Book your appointment now p...", payloads[0].Interactive.Action.Parameters.FlowCTA)
+				assert.Len(t, clog.Errors, 1)
+				assert.Equal(t, "quick reply text 'Book your appointment now please' exceeds the 30 character limit and will be truncated", clog.Errors[0].Message)
+			},
+		},
+		{
+			label:                 "Button titles at exactly the limit or with multibyte characters - correct truncation",
+			text:                  "Pick one",
+			quickReplies:          []models.QuickReply{{Type: "text", Text: "Exactly twenty chars"}, {Type: "text", Text: strings.Repeat("é", 22)}},
+			urn:                   "whatsapp:250788123123",
+			expectedPayloadsCount: 1,
+			expectedType:          "interactive",
+			checkFunc: func(t *testing.T, payloads []whatsapp.SendRequest, clog *models.ChannelLog) {
+				// exactly at the limit is left unchanged and not logged
+				assert.Equal(t, "Exactly twenty chars", payloads[0].Interactive.Action.Buttons[0].Reply.Title)
+				// multibyte text is truncated by runes, not bytes
+				assert.Equal(t, strings.Repeat("é", 17)+"...", payloads[0].Interactive.Action.Buttons[1].Reply.Title)
 				assert.Len(t, clog.Errors, 1)
 			},
 		},


### PR DESCRIPTION
## Summary

WhatsApp enforces character limits on interactive message elements: reply button titles and CTA URL display text are capped at 20 characters, flow button text at 30, list row titles at 24 and row descriptions at 72. Quick reply texts over those limits made the API reject the whole message, so a single over-long label meant non-delivery. Now such texts are truncated with an ellipsis and each truncation is logged as a channel error, matching how the existing 10-row list cap is handled. Applies to all channel types using the shared payload builder (WAC, D3C, TN).

## Changes

- New `truncateQuickReplyText` helper (rune-safe, via `stringsx.TruncateEllipsis`) applied wherever quick reply text lands in an interactive payload: button titles, list row titles and descriptions, CTA URL display text and flow CTA text.
- Per-element limits: 20 for reply buttons and CTA URL display text (documented hard limits), 30 for flow CTA text (the documented advisory limit), 24/72 for list row titles/descriptions.
- Each truncation logs a channel error naming the original text and the limit.

## Behavior examples

| Quick reply | Before | After |
|---|---|---|
| button "This is a very long button title" | API rejects the message | button "This is a very lo..." + channel log error |
| list row description over 72 chars | API rejects the message | description truncated + channel log error |

Note: a flow that routes on the exact reply text of an over-limit quick reply will receive the truncated title back. Since such messages previously didn't send at all, this is still a strict improvement, and the log entry points at the fix (shorter labels).

## Review notes

- Review flagged that a single 20-char constant drove reply buttons, CTA URL and flow text; re-checked the docs and flow CTA allows 30, so it now has its own limit.
- Added boundary (exactly at the limit) and multibyte truncation tests.

## Test plan

- Payload tests cover truncation and logging for button titles, list row titles/descriptions, flow CTA and CTA URL display text, plus boundary and multibyte cases
- Full handler test suite passes