### PR TITLE
Group the outbound HTTP clients into a single runtime.HTTP

### DIFF
--- a/handlers/base.go
+++ b/handlers/base.go
@@ -111,13 +111,13 @@ func (h *BaseHandler) GetChannel(ctx context.Context, r *http.Request) (*models.
 
 // RequestHTTP does the given request, logging the trace, and returns the response
 func (h *BaseHandler) RequestHTTP(req *http.Request, clog *models.ChannelLog) (*http.Response, []byte, error) {
-	return h.requestHTTP(h.rt.HTTP, req, clog)
+	return h.requestHTTP(h.rt.HTTP.Default, req, clog)
 }
 
 // RequestHTTPProxied is like RequestHTTP but routes through the configured outbound proxy
 // (SendProxyURL) when one is set. Use this for handlers that send to user-configured URLs.
 func (h *BaseHandler) RequestHTTPProxied(req *http.Request, clog *models.ChannelLog) (*http.Response, []byte, error) {
-	return h.requestHTTP(h.rt.HTTPProxied, req, clog)
+	return h.requestHTTP(h.rt.HTTP.Proxied, req, clog)
 }
 
 // requestHTTP does the given request using the given client, logging the trace, and returns the response

--- a/handlers/base_test.go
+++ b/handlers/base_test.go
@@ -33,9 +33,9 @@ func TestRequestHTTP(t *testing.T) {
 	clog := models.NewChannelLogForSend(mm, nil)
 
 	// use a plain client so we can install a mocking transport
-	rt.HTTP = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTPProxied = rt.HTTP
-	rt.HTTP.Transport = httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
+	rt.HTTP.Proxied = rt.HTTP.Default
+	rt.HTTP.Default.Transport = httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"https://api.messages.com/send.json": {
 			httpx.NewMockResponse(200, nil, []byte(`{"status":"success"}`)),
 			httpx.NewMockResponse(400, nil, []byte(`{"status":"error"}`)),

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -1055,7 +1055,7 @@ func TestSendEvent(t *testing.T) {
 	h := newWAHandler(models.ChannelType("D3C"), "360Dialog").(*handler)
 	s.MountHandler(h)
 
-	s.Runtime().HTTP.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://waba-v2.360dialog.io/messages": {
 			httpx.NewMockResponse(200, nil, []byte(`{"success": true}`)),
 			httpx.NewMockResponse(400, nil, []byte(`{"error": {"message": "(#131009) Parameter value is not valid", "code": 131009}}`)),

--- a/handlers/handlertest/handlertest.go
+++ b/handlers/handlertest/handlertest.go
@@ -178,9 +178,9 @@ func RunIncomingTestCases(t *testing.T, chs []*models.Channel, handler channels.
 	// isn't pointed at a test server (e.g. one describing a URN whilst a contact is created) is caught
 	// here rather than calling a real channel API
 	client := &http.Client{Transport: httpx.WithTraces(localOnlyTransport{http.DefaultTransport}), Timeout: 30 * time.Second}
-	rt.HTTP = client
-	rt.HTTPProxied = client
-	rt.HTTPAttachments = client
+	rt.HTTP.Default = client
+	rt.HTTP.Proxied = client
+	rt.HTTP.Attachments = client
 
 	// data: attachments are saved to storage as they're received so ensure the bucket exists
 	rt.S3.Client.CreateBucket(t.Context(), &s3.CreateBucketInput{Bucket: aws.String(rt.Config.S3AttachmentsBucket)})
@@ -455,13 +455,13 @@ func RunOutgoingTestCases(t *testing.T, channel *models.Channel, handler channel
 	testsuite.ResetDB(t, rt)
 	testsuite.ResetValkey(t, rt)
 
-	// use a plain HTTP client so per-case mock transports can be installed, shared by HTTP and HTTPProxied so
-	// installing a mocking transport intercepts every request a handler makes via either client. Tracing stays
+	// use a plain HTTP client so per-case mock transports can be installed, shared by all three clients so
+	// installing a mocking transport intercepts every request a handler makes via any of them. Tracing stays
 	// wrapped around whatever transport a case installs, since that's what produces the channel logs asserted below.
 	client := &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTP = client
-	rt.HTTPProxied = client
-	rt.HTTPAttachments = client
+	rt.HTTP.Default = client
+	rt.HTTP.Proxied = client
+	rt.HTTP.Attachments = client
 
 	if setup != nil {
 		setup(t, rt)
@@ -486,10 +486,10 @@ func RunOutgoingTestCases(t *testing.T, channel *models.Channel, handler channel
 
 			// reset to the default transport each case, then install a mocking transport when the
 			// case provides mocks - always inside tracing, which is what the handler's channel log is built from
-			rt.HTTP.Transport = httpx.WithTraces(nil)
+			rt.HTTP.Default.Transport = httpx.WithTraces(nil)
 			if len(tc.MockResponses) > 0 {
 				mockHTTP = httpx.WithMocks(nil, tc.MockResponses)
-				rt.HTTP.Transport = httpx.WithTraces(mockHTTP)
+				rt.HTTP.Default.Transport = httpx.WithTraces(mockHTTP)
 			}
 
 			clog := models.NewChannelLogForSend(msg, handler.RedactValues(channel))
@@ -500,7 +500,7 @@ func RunOutgoingTestCases(t *testing.T, channel *models.Channel, handler channel
 			externalIDs := res.ExternalIDs()
 
 			if mockHTTP != nil {
-				rt.HTTP.Transport = httpx.WithTraces(nil)
+				rt.HTTP.Default.Transport = httpx.WithTraces(nil)
 
 				actualRequests = mockHTTP.Requests()
 

--- a/handlers/jiochat/handler_test.go
+++ b/handlers/jiochat/handler_test.go
@@ -281,8 +281,8 @@ func TestDescribeURN(t *testing.T) {
 	testsuite.ResetValkey(t, rt)
 
 	// use a plain client so the handler can reach the mock API on localhost
-	rt.HTTP = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTPProxied = rt.HTTP
+	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
+	rt.HTTP.Proxied = rt.HTTP.Default
 
 	// ensure there's a cached access token
 	rc := rt.VK.Get()
@@ -319,11 +319,11 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	// ensure that we start with no cached token
 	testsuite.ResetValkey(t, rt)
 
-	rt.HTTP = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTPProxied = rt.HTTP
+	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
+	rt.HTTP.Proxied = rt.HTTP.Default
 
 	s := web.NewServer(rt)
-	rt.HTTP.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://channels.jiochat.com/auth/token.action": {
 			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"access_token": "SESAME"}`)),
 		},

--- a/handlers/line/handler_test.go
+++ b/handlers/line/handler_test.go
@@ -717,7 +717,7 @@ func TestSendEvent(t *testing.T) {
 	h := newHandler().(*handler)
 	s.MountHandler(h)
 
-	s.Runtime().HTTP.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://api.line.me/v2/bot/chat/loading/start": {
 			httpx.NewMockResponse(202, nil, []byte(`{}`)),
 			httpx.NewMockResponse(400, nil, []byte(`{"message": "The property, 'chatId', in the request body is invalid"}`)),

--- a/handlers/meta/facebook_test.go
+++ b/handlers/meta/facebook_test.go
@@ -611,7 +611,7 @@ func TestFacebookSendEvent(t *testing.T) {
 	h := newHandler("FBA", "Facebook").(*handler)
 	s.MountHandler(h)
 
-	s.Runtime().HTTP.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://graph.facebook.com/v25.0/me/messages*": {
 			httpx.NewMockResponse(200, nil, []byte(`{"recipient_id": "5678"}`)),
 			httpx.NewMockResponse(200, nil, []byte(`{"recipient_id": "5678"}`)),

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -1211,7 +1211,7 @@ func TestWhatsAppSendEvent(t *testing.T) {
 	h := newHandler("WAC", "WhatsApp Cloud").(*handler)
 	s.MountHandler(h)
 
-	s.Runtime().HTTP.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://graph.facebook.com/12345_ID/messages": {
 			httpx.NewMockResponse(200, nil, []byte(`{"success": true}`)),
 			httpx.NewMockResponse(400, nil, []byte(`{"error": {"message": "(#131009) Parameter value is not valid", "code": 131009}}`)),

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -1253,7 +1253,7 @@ func TestSendEvent(t *testing.T) {
 	h := newHandler().(*handler)
 	s.MountHandler(h)
 
-	s.Runtime().HTTP.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://api.telegram.org/botauth_token/sendChatAction": {
 			httpx.NewMockResponse(200, nil, []byte(`{"ok": true, "result": true}`)),
 			httpx.NewMockResponse(400, nil, []byte(`{"ok": false, "error_code": 400, "description": "Bad Request"}`)),

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -1546,7 +1546,7 @@ func TestSendEvent(t *testing.T) {
 	h := newTWIMLHandler("TWA", "Twilio Whatsapp", true).(*handler)
 	s.MountHandler(h)
 
-	s.Runtime().HTTP.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://messaging.twilio.com/v3/Indicators/Typing.json": {
 			httpx.NewMockResponse(200, nil, []byte(`{"success": true}`)),
 			httpx.NewMockResponse(400, nil, []byte(`{"code": 21211, "message": "Invalid message SID"}`)),

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -567,7 +567,7 @@ func (h *handler) downloadMedia(mediaURL string) (io.Reader, error) {
 	}
 
 	// access control is enforced by the client's transport
-	if res, err := h.Runtime().HTTP.Do(req); err == nil {
+	if res, err := h.Runtime().HTTP.Default.Do(req); err == nil {
 		return res.Body, nil
 	} else {
 		return nil, err

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -659,7 +659,7 @@ func TestSendEvent(t *testing.T) {
 	h := newHandler().(*handler)
 	s.MountHandler(h)
 
-	s.Runtime().HTTP.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://api.vk.com/method/messages.setActivity.json*": {
 			httpx.NewMockResponse(200, nil, []byte(`{"response": 1}`)),
 			httpx.NewMockResponse(200, nil, []byte(`{"error": {"error_code": 5, "error_msg": "User authorization failed"}}`)),

--- a/handlers/wechat/handler_test.go
+++ b/handlers/wechat/handler_test.go
@@ -236,8 +236,8 @@ func TestDescribeURN(t *testing.T) {
 	testsuite.ResetValkey(t, rt)
 
 	// use a plain client so the handler can reach the mock API on localhost
-	rt.HTTP = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTPProxied = rt.HTTP
+	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
+	rt.HTTP.Proxied = rt.HTTP.Default
 
 	// ensure there's a cached access token
 	rc := rt.VK.Get()
@@ -274,11 +274,11 @@ func TestBuildAttachmentRequest(t *testing.T) {
 	// ensure that we start with no cached token
 	testsuite.ResetValkey(t, rt)
 
-	rt.HTTP = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTPProxied = rt.HTTP
+	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
+	rt.HTTP.Proxied = rt.HTTP.Default
 
 	s := web.NewServer(rt)
-	rt.HTTP.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://api.weixin.qq.com/cgi-bin/token?appid=app-id&grant_type=client_credential&secret=app-secret123": {
 			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"access_token": "SESAME"}`)),
 		},
@@ -312,11 +312,11 @@ func TestFetchAccessTokenThrottled(t *testing.T) {
 	// ensure that we start with no cached token
 	testsuite.ResetValkey(t, rt)
 
-	rt.HTTP = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTPProxied = rt.HTTP
+	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
+	rt.HTTP.Proxied = rt.HTTP.Default
 
 	s := web.NewServer(rt)
-	rt.HTTP.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://api.weixin.qq.com/cgi-bin/token?appid=app-id&grant_type=client_credential&secret=app-secret123": {
 			httpx.NewMockResponse(429, nil, []byte(`{"errcode": 45009, "errmsg": "reach max api daily quota limit"}`)),
 		},
@@ -450,8 +450,8 @@ func TestSendEvent(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 	testsuite.ResetValkey(t, rt)
 
-	rt.HTTP = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTPProxied = rt.HTTP
+	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
+	rt.HTTP.Proxied = rt.HTTP.Default
 
 	// ensure there's a cached access token
 	rc := rt.VK.Get()
@@ -462,7 +462,7 @@ func TestSendEvent(t *testing.T) {
 	h := newHandler().(*handler)
 	s.MountHandler(h)
 
-	rt.HTTP.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://api.weixin.qq.com/cgi-bin/message/custom/typing*": {
 			httpx.NewMockResponse(200, nil, []byte(`{"errcode": 0, "errmsg": "ok"}`)),
 			httpx.NewMockResponse(200, nil, []byte(`{"errcode": 0, "errmsg": "ok"}`)),

--- a/runtime/http.go
+++ b/runtime/http.go
@@ -1,0 +1,96 @@
+package runtime
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/nyaruka/gocommon/httpx"
+)
+
+// MaxAttachmentBodyBytes bounds how much of an incoming attachment we'll read. Attachments are fetched from URLs
+// chosen by the remote service rather than by us, so the bound is what stops one from being able to make us buffer
+// an arbitrarily large body.
+const MaxAttachmentBodyBytes = 100 * 1024 * 1024
+
+// HTTP holds the http.Clients used for outbound calls. Default is the general purpose one. Proxied is for handlers
+// sending to user-configured URLs, which route through the forward proxy when one is configured. Attachments is for
+// fetching incoming attachments, the only path on which we fetch from a URL chosen by the remote service rather than
+// by us, and so the only one that bounds how much of a response body it will read.
+//
+// Every client's transport captures a trace of any request whose context carries an httpx.TraceCollector, which is
+// how callers get the trace to attach to a channel log. Tests can replace a client's Transport with a mocking
+// transport to intercept its calls - that must be one which keeps the tracing, see test.MockTransport.
+type HTTP struct {
+	Default     *http.Client
+	Proxied     *http.Client
+	Attachments *http.Client
+}
+
+func newHTTP(cfg *Config) (*HTTP, error) {
+	// parse the SSRF blocklist up front so it can be baked into each client's transport via
+	// httpx.WithAccessControl, rather than passed to every request.
+	disallowedIPs, disallowedNets, err := cfg.ParseDisallowedNetworks()
+	if err != nil {
+		return nil, fmt.Errorf("error parsing disallowed networks: %w", err)
+	}
+	access := httpx.NewAccessConfig(10*time.Second, disallowedIPs, disallowedNets)
+
+	transport := newBaseTransport()
+
+	// tracing goes on the outside of each client so that a request denied by access control is still captured as a
+	// trace. It records into whichever httpx.TraceCollector the request's context carries, and costs nothing for a
+	// request made without one, so it belongs here rather than being assembled per call.
+	h := &HTTP{
+		Default: &http.Client{Transport: httpx.WithTraces(httpx.WithAccessControl(transport, access)), Timeout: 30 * time.Second},
+
+		// the attachments client additionally bounds the response body, since it fetches from URLs we didn't
+		// choose. The bound sits inside the tracing so it applies before the body is buffered into the trace;
+		// reading past it fails with httpx.ErrResponseSize.
+		Attachments: &http.Client{
+			Transport: httpx.WithTraces(httpx.WithReadLimit(httpx.WithAccessControl(transport, access), MaxAttachmentBodyBytes)),
+			Timeout:   30 * time.Second,
+		},
+	}
+
+	// build a proxied variant when SendProxyURL is configured; otherwise reuse the default client so handlers can
+	// always go through Proxied without behavior change.
+	//
+	// Note on the SSRF blocklist: the access control wrapped into each transport resolves the destination URL's
+	// host and rejects the request if it maps to a disallowed IP. This check runs regardless of the proxy; when the
+	// proxy is set the request still dials the proxy rather than the destination, so the proxy's own egress rules
+	// govern the actual connection to the destination.
+	proxyURL, err := cfg.ParseSendProxyURL()
+	if err != nil {
+		return nil, fmt.Errorf("error parsing send proxy URL: %w", err)
+	}
+
+	h.Proxied = h.Default
+	if proxyURL != nil {
+		proxiedTransport := transport.Clone()
+		proxiedTransport.Proxy = http.ProxyURL(proxyURL)
+		h.Proxied = &http.Client{Transport: httpx.WithTraces(httpx.WithAccessControl(proxiedTransport, access)), Timeout: 30 * time.Second}
+	}
+
+	return h, nil
+}
+
+// newTestHTTP builds the clients for a test runtime, which don't need access control or the proxy. All three are the
+// same client: they're given a timeout matching the production clients so a test that accidentally lets a request
+// escape its mocking transport fails fast instead of hanging, and the same tracing the production clients carry so
+// code under test produces channel logs the way it does in production.
+func newTestHTTP() *HTTP {
+	client := &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
+
+	return &HTTP{Default: client, Proxied: client, Attachments: client}
+}
+
+// newBaseTransport clones http.DefaultTransport with our connection-pool settings. Callers layer their own concerns
+// (access control, the send proxy, read limits) on top.
+func newBaseTransport() *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.MaxIdleConns = 64
+	t.MaxIdleConnsPerHost = 8
+	t.IdleConnTimeout = 15 * time.Second
+	return t
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -3,23 +3,15 @@ package runtime
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"time"
 
 	"github.com/gomodule/redigo/redis"
 	_ "github.com/lib/pq" // postgres driver
 	"github.com/nyaruka/gocommon/aws/cwatch"
 	"github.com/nyaruka/gocommon/aws/s3x"
 	"github.com/nyaruka/gocommon/centrifugo"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/vkutil"
 	"github.com/vinovest/sqlx"
 )
-
-// MaxAttachmentBodyBytes bounds how much of an incoming attachment we'll read. Attachments are fetched from URLs
-// chosen by the remote service rather than by us, so the bound is what stops one from being able to make us buffer
-// an arbitrarily large body.
-const MaxAttachmentBodyBytes = 100 * 1024 * 1024
 
 type Runtime struct {
 	Config     *Config
@@ -30,20 +22,7 @@ type Runtime struct {
 	CW         *cwatch.Service
 	Centrifugo *centrifugo.Service
 
-	// HTTP is the general purpose client for outbound calls. Its transport captures a trace of any request whose
-	// context carries an httpx.TraceCollector, which is how callers get the trace to attach to a channel log.
-	HTTP *http.Client
-
-	// HTTPProxied is the HTTP client used by handlers that send to user-configured URLs. When
-	// SendProxyURL is set, it routes through that forward proxy. Otherwise it's the same as HTTP.
-	HTTPProxied *http.Client
-
-	// HTTPAttachments is the client used to fetch incoming attachments. It is the only path on which we fetch from
-	// a URL chosen by the remote service rather than by us, so it bounds how much of a response body it will read;
-	// reading past that fails with httpx.ErrResponseSize. The bound sits inside the tracing so it applies before the
-	// body is buffered into the trace.
-	HTTPAttachments *http.Client
-
+	HTTP  *HTTP
 	Stats *StatsCollector
 }
 
@@ -85,46 +64,9 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 
 	rt.Centrifugo = centrifugo.NewService(centrifugo.NewClient(cfg.CentrifugoEndpoint, cfg.CentrifugoKey), rt.VK)
 
-	// parse the SSRF blocklist up front so it can be baked into each HTTP client's transport via
-	// httpx.WithAccessControl, rather than passed to every request.
-	disallowedIPs, disallowedNets, err := cfg.ParseDisallowedNetworks()
+	rt.HTTP, err = newHTTP(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing disallowed networks: %w", err)
-	}
-	httpAccess := httpx.NewAccessConfig(10*time.Second, disallowedIPs, disallowedNets)
-
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.MaxIdleConns = 64
-	transport.MaxIdleConnsPerHost = 8
-	transport.IdleConnTimeout = 15 * time.Second
-
-	// tracing goes on the outside of each client so that a request denied by access control is still captured as a
-	// trace. It records into whichever httpx.TraceCollector the request's context carries, and costs nothing for a
-	// request made without one, so it belongs here rather than being assembled per call.
-	rt.HTTP = &http.Client{Transport: httpx.WithTraces(httpx.WithAccessControl(transport, httpAccess)), Timeout: 30 * time.Second}
-
-	// the attachments client additionally bounds the response body, since it fetches from URLs we didn't choose
-	rt.HTTPAttachments = &http.Client{
-		Transport: httpx.WithTraces(httpx.WithReadLimit(httpx.WithAccessControl(transport, httpAccess), MaxAttachmentBodyBytes)),
-		Timeout:   30 * time.Second,
-	}
-
-	// build a proxied variant when SendProxyURL is configured; otherwise reuse the regular client
-	// so handlers can always go through HTTPProxied without behavior change.
-	//
-	// Note on the SSRF blocklist: the access control wrapped into each transport resolves the
-	// destination URL's host and rejects the request if it maps to a disallowed IP. This check runs
-	// regardless of the proxy; when the proxy is set the request still dials the proxy rather than the
-	// destination, so the proxy's own egress rules govern the actual connection to the destination.
-	proxyURL, err := cfg.ParseSendProxyURL()
-	if err != nil {
-		return nil, fmt.Errorf("error parsing send proxy URL: %w", err)
-	}
-	rt.HTTPProxied = rt.HTTP
-	if proxyURL != nil {
-		proxiedTransport := transport.Clone()
-		proxiedTransport.Proxy = http.ProxyURL(proxyURL)
-		rt.HTTPProxied = &http.Client{Transport: httpx.WithTraces(httpx.WithAccessControl(proxiedTransport, httpAccess)), Timeout: 30 * time.Second}
+		return nil, err
 	}
 
 	rt.Stats = NewStatsCollector()
@@ -133,19 +75,13 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 }
 
 // NewTestRuntime returns a minimal Runtime wrapping the given config, suitable for tests that need a
-// Runtime but don't bring up real backing services. It populates HTTP (shared by HTTPProxied) with a
-// dedicated client so code paths that issue outbound HTTP requests work against test servers, and so
-// tests can install a mocking transport via httpx.WithMocks without mutating http.DefaultClient.
+// Runtime but don't bring up real backing services. It populates HTTP with dedicated clients so code paths
+// that issue outbound HTTP requests work against test servers, and so tests can install a mocking transport
+// via httpx.WithMocks without mutating http.DefaultClient.
 func NewTestRuntime(cfg *Config) *Runtime {
-	// give the client a timeout matching the production clients so a test that accidentally lets a
-	// request escape its mocking transport fails fast instead of hanging, and the same tracing the
-	// production clients carry so code under test produces channel logs the way it does in production
-	client := &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
 	return &Runtime{
-		Config:          cfg,
-		HTTP:            client,
-		HTTPProxied:     client,
-		HTTPAttachments: client,
+		Config: cfg,
+		HTTP:   newTestHTTP(),
 		// note the nil valkey pool: publishing requires a subscriber presence lookup, so tests that
 		// exercise a publish path need a runtime with a real pool (i.e. testsuite.Runtime)
 		Centrifugo: centrifugo.NewService(centrifugo.NewMockClient(), nil),

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -14,13 +14,13 @@ func TestHTTPProxied(t *testing.T) {
 	// the default config uses virtual-host style S3 URLs, which require a resolvable region
 	t.Setenv("AWS_REGION", "us-east-1")
 
-	// without SendProxyURL configured, HTTPProxied is the same client as HTTP
+	// without SendProxyURL configured, HTTP.Proxied is the same client as HTTP.Default
 	cfg := runtime.NewDefaultConfig()
 	require.NoError(t, cfg.Validate())
 
 	rt, err := newRuntimeForHTTPTest(cfg)
 	require.NoError(t, err)
-	assert.Same(t, rt.HTTP, rt.HTTPProxied)
+	assert.Same(t, rt.HTTP.Default, rt.HTTP.Proxied)
 
 	// stand up a stub forward proxy; a forward-proxied http:// request arrives here carrying the
 	// target's host, which lets us confirm the proxied client actually routes through it. The access
@@ -33,7 +33,7 @@ func TestHTTPProxied(t *testing.T) {
 	}))
 	defer proxy.Close()
 
-	// with SendProxyURL configured, HTTPProxied is a distinct client that routes through the proxy.
+	// with SendProxyURL configured, HTTP.Proxied is a distinct client that routes through the proxy.
 	// clear the SSRF blocklist so the IP-literal target below (never actually dialed) isn't rejected
 	// by access control before it can be proxied.
 	cfg = runtime.NewDefaultConfig()
@@ -43,16 +43,16 @@ func TestHTTPProxied(t *testing.T) {
 
 	rt, err = newRuntimeForHTTPTest(cfg)
 	require.NoError(t, err)
-	require.NotSame(t, rt.HTTP, rt.HTTPProxied)
+	require.NotSame(t, rt.HTTP.Default, rt.HTTP.Proxied)
 
-	resp, err := rt.HTTPProxied.Get("http://93.184.216.34/hook")
+	resp, err := rt.HTTP.Proxied.Get("http://93.184.216.34/hook")
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, "93.184.216.34", proxiedHost, "proxied client should route through the configured proxy")
 }
 
-// newRuntimeForHTTPTest constructs a Runtime by calling NewRuntime, which builds the HTTP and HTTPProxied
-// clients we want to assert on. NewRuntime also tries to open a DB pool etc., but those don't dial
+// newRuntimeForHTTPTest constructs a Runtime by calling NewRuntime, which builds the HTTP clients we want
+// to assert on. NewRuntime also tries to open a DB pool etc., but those don't dial
 // until used, so this is safe for unit tests focused on the HTTP plumbing.
 func newRuntimeForHTTPTest(cfg *runtime.Config) (*runtime.Runtime, error) {
 	return runtime.NewRuntime(cfg)

--- a/test/handler.go
+++ b/test/handler.go
@@ -51,7 +51,7 @@ func (h *mockHandler) Send(ctx context.Context, msg *models.MsgOut, res *channel
 	// log a request that contains a header value that should be redacted; goes through the runtime's
 	// HTTP client so tests can intercept it with a mocking transport
 	req, _ := httpx.NewRequest(ctx, "GET", "http://mock.com/send", nil, map[string]string{"Authorization": "Token sesame"})
-	trace, resp, err := utils.DoTraced(h.rt.HTTP, req)
+	trace, resp, err := utils.DoTraced(h.rt.HTTP.Default, req)
 	if trace != nil {
 		clog.HTTP(trace)
 	}
@@ -77,7 +77,7 @@ func (h *mockHandler) Send(ctx context.Context, msg *models.MsgOut, res *channel
 // SendEvent sends the given event, logging any HTTP calls or errors
 func (h *mockHandler) SendEvent(ctx context.Context, ch *models.Channel, event events.Event, clog *models.ChannelLog) error {
 	req, _ := httpx.NewRequest(ctx, "POST", "http://mock.com/action", nil, nil)
-	trace, resp, err := utils.DoTraced(h.rt.HTTP, req)
+	trace, resp, err := utils.DoTraced(h.rt.HTTP.Default, req)
 	if trace != nil {
 		clog.HTTP(trace)
 	}

--- a/web/attachments.go
+++ b/web/attachments.go
@@ -93,11 +93,11 @@ func FetchAndStoreAttachment(ctx context.Context, rt *runtime.Runtime, channel *
 		return nil, fmt.Errorf("unable to create attachment request: %w", err)
 	}
 
-	// attachment URLs are untrusted, so this goes through rt.HTTPAttachments, whose transport bounds the body read
+	// attachment URLs are untrusted, so this goes through rt.HTTP.Attachments, whose transport bounds the body read
 	// at runtime.MaxAttachmentBodyBytes and enforces access control (the SSRF blocklist) — a denied request comes
 	// back as an error with a nil response. DoTraced drains the body, which is what turns an oversized attachment
 	// into the ErrResponseSize checked below rather than a silently truncated file.
-	trace, resp, err := utils.DoTraced(rt.HTTPAttachments, attRequest)
+	trace, resp, err := utils.DoTraced(rt.HTTP.Attachments, attRequest)
 	if trace != nil {
 		clog.HTTP(trace)
 	}

--- a/web/attachments_test.go
+++ b/web/attachments_test.go
@@ -30,7 +30,7 @@ func TestFetchAndStoreAttachment(t *testing.T) {
 	rt := testsuite.NewRuntime(t)
 	rt.S3.Client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("test-attachments")})
 
-	rt.HTTPAttachments = &http.Client{Transport: httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+	rt.HTTP.Attachments = &http.Client{Transport: httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"http://mock.com/media/hello.jpg": {
 			httpx.NewMockResponse(200, nil, testJPG),
 		},
@@ -122,7 +122,7 @@ func TestFetchAndStoreAttachmentAccessDenied(t *testing.T) {
 	// rejected before any connection is made; the mocking transport underneath has no entries and so
 	// would panic if a request ever reached it, guarding against the access check silently passing
 	access := httpx.NewAccessConfig(time.Second, []net.IP{net.ParseIP("127.0.0.1")}, nil)
-	rt.HTTPAttachments = &http.Client{Transport: httpx.WithTraces(httpx.WithAccessControl(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{}), access))}
+	rt.HTTP.Attachments = &http.Client{Transport: httpx.WithTraces(httpx.WithAccessControl(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{}), access))}
 
 	mockChannel := test.NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230", "MCK", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{})
 
@@ -152,7 +152,7 @@ func TestFetchAndStoreAttachmentOversized(t *testing.T) {
 	// response is cheap to produce. The limit goes inside the tracing, exactly as the runtime composes it, so
 	// that it applies before the body is buffered into the trace.
 	const limit = 64
-	rt.HTTPAttachments = &http.Client{Transport: httpx.WithTraces(httpx.WithReadLimit(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+	rt.HTTP.Attachments = &http.Client{Transport: httpx.WithTraces(httpx.WithReadLimit(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"http://mock.com/media/huge.jpg": {
 			httpx.NewMockResponse(200, nil, bytes.Repeat([]byte("x"), limit*10)),
 		},

--- a/web/events_test.go
+++ b/web/events_test.go
@@ -51,7 +51,7 @@ func TestSendEvent(t *testing.T) {
 	rt.Config.InternalPort = 8181
 
 	server := web.NewServer(rt)
-	server.Runtime().HTTP.Transport = httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+	server.Runtime().HTTP.Default.Transport = httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"http://mock.com/action": {
 			httpx.NewMockResponse(200, nil, []byte(`OK`)),
 			httpx.NewMockResponse(502, nil, []byte(`bad gateway`)),

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -85,7 +85,7 @@ func TestOutgoing(t *testing.T) {
 	dyntest.Truncate(t, rt.Dynamo.Main.Client(), rt.Dynamo.Main.Table())
 
 	s := web.NewServer(rt)
-	rt.HTTP.Transport = httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+	rt.HTTP.Default.Transport = httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		"http://mock.com/send": {
 			httpx.NewMockResponse(200, nil, []byte(`SENT`)),
 			httpx.MockConnectionError,
@@ -231,7 +231,7 @@ func TestFetchAttachment(t *testing.T) {
 	server := web.NewServer(rt)
 
 	// attachments are fetched through the dedicated bounded client, so that's where the mocks go
-	server.Runtime().HTTPAttachments.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+	server.Runtime().HTTP.Attachments.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"http://mock.com/media/hello.jpg": {
 			httpx.NewMockResponse(200, nil, testJPG),
 		},


### PR DESCRIPTION
## Summary

The runtime carried three loose `*http.Client` fields, and `NewRuntime` carried the ~40 lines that built them — SSRF blocklist parsing, the base transport clone, three client constructions and the forward-proxy branch. That was the largest block in a function otherwise made up of one-line "connect to a service" calls.

This groups the clients into a `runtime.HTTP` and moves their assembly into `runtime/http.go`, alongside the `MaxAttachmentBodyBytes` bound that one of them enforces. The three are genuinely purpose-distinct, so they're named for what they're for:

- `Default` — general purpose outbound calls
- `Proxied` — handler sends to user-configured URLs, routed through the forward proxy when one is configured
- `Attachments` — fetching incoming attachments, the only path where the URL is chosen by the remote service rather than by us, and so the only one that bounds how much of a body it reads

## Changes

- New `runtime/http.go` holding `HTTP{Default, Proxied, Attachments}`, `newHTTP`, `newTestHTTP` and a `newBaseTransport` helper, plus the `MaxAttachmentBodyBytes` const.
- `Runtime` loses `HTTP`, `HTTPProxied` and `HTTPAttachments` for a single `HTTP *HTTP`; `NewRuntime` loses the assembly and two imports.
- `NewTestRuntime`'s three-fields-one-client block becomes `newTestHTTP()`, keeping the note on why test clients carry a production-matching timeout and the same tracing.
- Call sites updated across 21 files — `rt.HTTP` → `rt.HTTP.Default`, `rt.HTTPProxied` → `rt.HTTP.Proxied`, `rt.HTTPAttachments` → `rt.HTTP.Attachments`. Almost all are one-line mock-transport assignments in handler tests.

## Behavior

None. Every client is built from the same pieces in the same order as before, including the layering that matters: tracing on the outside so a request denied by access control is still captured, and the attachments read limit inside the tracing so it applies before a body is buffered into the trace.

## Test plan

- Full suite green (`go test -p=1 ./...`)
- `gofmt` and `go vet` clean