### PR TITLE
Bring TN handler to parity with other WhatsApp handlers

### DIFF
--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -225,7 +225,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 
 		text := ""
 		mediaURL := ""
-		var payload json.RawMessage
+		var msgPayload json.RawMessage
 		supported := true
 
 		if msg.Type == "text" {
@@ -249,7 +249,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 			// attach the response JSON as the msg payload if it's a valid JSON object
 			raw := strings.TrimSpace(msg.Interactive.NFMReply.ResponseJSON)
 			if strings.HasPrefix(raw, "{") && json.Valid([]byte(raw)) {
-				payload = json.RawMessage(raw)
+				msgPayload = json.RawMessage(raw)
 			} else if msg.Interactive.NFMReply.ResponseJSON != "" {
 				channels.LogRequestError(r, channel, errors.New("nfm_reply response_json is not a valid JSON object"))
 			}
@@ -281,8 +281,8 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 			event.WithAttachment(mediaURL)
 		}
 
-		if payload != nil {
-			event.WithPayload(payload)
+		if msgPayload != nil {
+			event.WithPayload(msgPayload)
 		}
 
 		// if we have a from_bsuid, add it as a secondary whatsapp URN (unless it's already the primary URN)

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/buger/jsonparser"
@@ -132,8 +133,13 @@ type eventsPayload struct {
 				Title       string `json:"title"`
 				Description string `json:"description"`
 			} `json:"list_reply"`
+			NFMReply *struct {
+				Name         string `json:"name"`
+				Body         string `json:"body"`
+				ResponseJSON string `json:"response_json"`
+			} `json:"nfm_reply"`
 			Type string `json:"type"`
-		}
+		} `json:"interactive"`
 		Location *struct {
 			Address   string  `json:"address"   validate:"required"`
 			Latitude  float32 `json:"latitude"  validate:"required"`
@@ -155,11 +161,13 @@ type eventsPayload struct {
 			MimeType string `json:"mime_type" validate:"required"`
 			Sha256   string `json:"sha256"    validate:"required"`
 		} `json:"voice"`
+		Errors []whatsapp.WAError `json:"errors"`
 	} `json:"messages"`
 	Statuses []struct {
-		ID        string `json:"id"           validate:"required"`
-		Timestamp string `json:"timestamp"    validate:"required"`
-		Status    string `json:"status"       validate:"required"`
+		ID        string             `json:"id"           validate:"required"`
+		Timestamp string             `json:"timestamp"    validate:"required"`
+		Status    string             `json:"status"       validate:"required"`
+		Errors    []whatsapp.WAError `json:"errors"`
 	} `json:"statuses"`
 }
 
@@ -211,8 +219,14 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 			return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, errors.New("invalid whatsapp id"))
 		}
 
+		for _, msgError := range msg.Errors {
+			msgError.ErrorChannelLog(clog)
+		}
+
 		text := ""
 		mediaURL := ""
+		var payload json.RawMessage
+		supported := true
 
 		if msg.Type == "text" {
 			text = msg.Text.Body
@@ -226,11 +240,18 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 		} else if msg.Type == "image" && msg.Image != nil {
 			text = msg.Image.Caption
 			mediaURL, err = resolveMediaURL(channel, msg.Image.ID)
-		} else if msg.Type == "interactive" && msg.Interactive != nil {
-			if msg.Interactive.Type == "button_reply" && msg.Interactive.ButtonReply != nil {
-				text = msg.Interactive.ButtonReply.Title
-			} else if msg.Interactive.Type == "list_reply" && msg.Interactive.ListReply != nil {
-				text = msg.Interactive.ListReply.Title
+		} else if msg.Type == "interactive" && msg.Interactive != nil && msg.Interactive.Type == "button_reply" && msg.Interactive.ButtonReply != nil {
+			text = msg.Interactive.ButtonReply.Title
+		} else if msg.Type == "interactive" && msg.Interactive != nil && msg.Interactive.Type == "list_reply" && msg.Interactive.ListReply != nil {
+			text = msg.Interactive.ListReply.Title
+		} else if msg.Type == "interactive" && msg.Interactive != nil && msg.Interactive.Type == "nfm_reply" && msg.Interactive.NFMReply != nil {
+			text = msg.Interactive.NFMReply.Body
+			// attach the response JSON as the msg payload if it's a valid JSON object
+			raw := strings.TrimSpace(msg.Interactive.NFMReply.ResponseJSON)
+			if strings.HasPrefix(raw, "{") && json.Valid([]byte(raw)) {
+				payload = json.RawMessage(raw)
+			} else if msg.Interactive.NFMReply.ResponseJSON != "" {
+				channels.LogRequestError(r, channel, errors.New("nfm_reply response_json is not a valid JSON object"))
 			}
 		} else if msg.Type == "location" && msg.Location != nil {
 			mediaURL = fmt.Sprintf("geo:%f,%f", msg.Location.Latitude, msg.Location.Longitude)
@@ -239,8 +260,13 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 		} else if msg.Type == "voice" && msg.Voice != nil {
 			mediaURL, err = resolveMediaURL(channel, msg.Voice.ID)
 		} else {
-			// we received a message type we do not support.
+			supported = false
+		}
+
+		// we received a message type we do not support - don't create an empty message for it
+		if !supported {
 			channels.LogRequestError(r, channel, fmt.Errorf("unsupported message type %s", msg.Type))
+			continue
 		}
 
 		// create our message
@@ -253,6 +279,10 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 
 		if mediaURL != "" {
 			event.WithAttachment(mediaURL)
+		}
+
+		if payload != nil {
+			event.WithPayload(payload)
 		}
 
 		// if we have a from_bsuid, add it as a secondary whatsapp URN (unless it's already the primary URN)
@@ -284,9 +314,13 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 			if turnWaIgnoreStatuses[status.Status] {
 				data = append(data, channels.NewInfoData(fmt.Sprintf("ignoring status: %s", status.Status)))
 			} else {
-				handlers.WriteAndLogRequestError(ctx, h, channel, w, r, fmt.Errorf("unknown status: %s", status.Status))
+				handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, fmt.Sprintf("unknown status: %s", status.Status))
 			}
 			continue
+		}
+
+		for _, statusError := range status.Errors {
+			statusError.ErrorChannelLog(clog)
 		}
 
 		event := models.NewStatusUpdateByExternalID(channel, status.ID, msgStatus, clog)
@@ -451,7 +485,8 @@ func (h *handler) buildPayloads(ctx context.Context, msg *models.MsgOut, clog *m
 	// attach preview media and button quick-replies on the same message; those must not be
 	// turned into separate image/interactive sends.
 	if msg.Templating() != nil {
-		langCode := getSupportedLanguage(msg.Locale())
+		// prefer the language mailroom resolved for the template, falling back to deriving one from the msg locale
+		langCode := cmp.Or(msg.Templating().Language, getSupportedLanguage(msg.Locale()))
 		namespace := msg.Templating().Namespace
 		if namespace == "" {
 			namespace = msg.Channel().StringConfigForKey(configNamespace, "")

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -390,6 +390,70 @@ var ignoreStatus = `
 }
 `
 
+var nfmReplyMsg = `{
+	"messages": [{
+		"from": "250788123123",
+		"id": "41",
+		"interactive": {
+			"nfm_reply": {
+				"name": "flow",
+				"body": "Sent",
+				"response_json": "{\"flow_token\": \"fl0w+t0k3n\", \"age\": \"32\"}"
+			},
+			"type": "nfm_reply"
+		},
+		"timestamp": "1454119029",
+		"type": "interactive"
+	}]
+}`
+
+var nfmReplyMsgNonObject = `{
+	"messages": [{
+		"from": "250788123123",
+		"id": "41",
+		"interactive": {
+			"nfm_reply": {
+				"name": "flow",
+				"body": "Sent",
+				"response_json": "[1, 2]"
+			},
+			"type": "nfm_reply"
+		},
+		"timestamp": "1454119029",
+		"type": "interactive"
+	}]
+}`
+
+var unsupportedTypeMsg = `{
+	"messages": [{
+		"from": "250788123123",
+		"id": "41",
+		"timestamp": "1454119029",
+		"type": "order"
+	}]
+}`
+
+var errorMsg = `{
+	"messages": [{
+		"from": "250788123123",
+		"id": "41",
+		"timestamp": "1454119029",
+		"type": "unsupported",
+		"errors": [{"code": 131051, "title": "Unsupported message type"}]
+	}]
+}`
+
+var errorStatus = `
+{
+  "statuses": [{
+    "id": "9712A34B4A8B6AD50F",
+    "status": "failed",
+    "timestamp": "1518694700",
+    "errors": [{"code": 131014, "title": "Request for url https://URL.jpg failed with error: 404 (Not Found)"}]
+  }]
+}
+`
+
 var turnWhatsappReceiveURL = "/c/trn/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive"
 
 var testCasesTurn = []IncomingTestCase{
@@ -548,6 +612,44 @@ var testCasesTurn = []IncomingTestCase{
 		ExpectedDate:         time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
 	},
 	{
+		Label:                "Receive valid interactive flow reply message",
+		URL:                  turnWhatsappReceiveURL,
+		Data:                 nfmReplyMsg,
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: `"type":"msg"`,
+		ExpectedMsgText:      Sp("Sent"),
+		ExpectedPayload:      `{"flow_token": "fl0w+t0k3n", "age": "32"}`,
+		ExpectedURN:          "whatsapp:250788123123",
+		ExpectedExternalID:   "41",
+		ExpectedDate:         time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
+	},
+	{
+		Label:                "Receive interactive flow reply message with non-object response JSON",
+		URL:                  turnWhatsappReceiveURL,
+		Data:                 nfmReplyMsgNonObject,
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: `"type":"msg"`,
+		ExpectedMsgText:      Sp("Sent"),
+		ExpectedURN:          "whatsapp:250788123123",
+		ExpectedExternalID:   "41",
+		ExpectedDate:         time.Date(2016, 1, 30, 1, 57, 9, 0, time.UTC),
+	},
+	{
+		Label:                "Receive unsupported message type, no message written",
+		URL:                  turnWhatsappReceiveURL,
+		Data:                 unsupportedTypeMsg,
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: "Events Handled",
+	},
+	{
+		Label:                "Receive message with errors, logged and no message written",
+		URL:                  turnWhatsappReceiveURL,
+		Data:                 errorMsg,
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: "Events Handled",
+		ExpectedErrors:       []*svclogs.Error{models.ErrorExternal("131051", "Unsupported message type")},
+	},
+	{
 		Label:                "Receive valid location message",
 		URL:                  turnWhatsappReceiveURL,
 		Data:                 locationMsg,
@@ -642,10 +744,23 @@ var testCasesTurn = []IncomingTestCase{
 		ExpectedBodyContains: "unable to parse",
 	},
 	{
+		Label:                "Receive failed status with error message",
+		URL:                  turnWhatsappReceiveURL,
+		Data:                 errorStatus,
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: `"type":"status"`,
+		ExpectedStatuses: []ExpectedStatus{
+			{ExternalID: "9712A34B4A8B6AD50F", Status: models.MsgStatusFailed},
+		},
+		ExpectedErrors: []*svclogs.Error{
+			models.ErrorExternal("131014", "Request for url https://URL.jpg failed with error: 404 (Not Found)"),
+		},
+	},
+	{
 		Label:                "Receive invalid status",
 		URL:                  turnWhatsappReceiveURL,
 		Data:                 invalidStatus,
-		ExpectedRespStatus:   400,
+		ExpectedRespStatus:   200,
 		ExpectedBodyContains: `"unknown status: in_orbit"`,
 	},
 	{
@@ -944,7 +1059,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Path: "/v1/messages",
-			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en_US"},"components":[{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
 		}},
 
 		ExpectedExtIDs: []string{"157b5e14568e8"},
@@ -965,7 +1080,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Path: "/v1/messages",
-			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"}}}`,
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en_US"}}}`,
 		}},
 
 		ExpectedExtIDs: []string{"157b5e14568e8"},
@@ -1076,7 +1191,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Path: "/v1/messages",
-			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"image","image":{"link":"https://foo.bar/image.jpg"}}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en_US"},"components":[{"type":"header","parameters":[{"type":"image","image":{"link":"https://foo.bar/image.jpg"}}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
 		}},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
@@ -1105,7 +1220,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Path: "/v1/messages",
-			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"video","video":{"link":"https://foo.bar/video.mp4"}}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en_US"},"components":[{"type":"header","parameters":[{"type":"video","video":{"link":"https://foo.bar/video.mp4"}}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
 		}},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
@@ -1134,7 +1249,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Path: "/v1/messages",
-			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"document","document":{"link":"https://foo.bar/doc.pdf","filename":"doc.pdf"}}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en_US"},"components":[{"type":"header","parameters":[{"type":"document","document":{"link":"https://foo.bar/doc.pdf","filename":"doc.pdf"}}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
 		}},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
@@ -1162,7 +1277,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Path: "/v1/messages",
-			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"image","image":{"link":"https://foo.bar/image.jpg"}}]},{"type":"body","parameters":null}]}}`,
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en_US"},"components":[{"type":"header","parameters":[{"type":"image","image":{"link":"https://foo.bar/image.jpg"}}]},{"type":"body","parameters":null}]}}`,
 		}},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
@@ -1191,7 +1306,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Path: "/v1/messages",
-			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"text","text":"Welcome"}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en_US"},"components":[{"type":"header","parameters":[{"type":"text","text":"Welcome"}]},{"type":"body","parameters":[{"type":"text","text":"Chef"},{"type":"text","text":"tomorrow"}]}]}}`,
 		}},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},
@@ -1224,7 +1339,7 @@ var defaultSendTestCases = []OutgoingTestCase{
 		},
 		ExpectedRequests: []ExpectedRequest{{
 			Path: "/v1/messages",
-			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en"},"components":[{"type":"header","parameters":[{"type":"image","image":{"link":"https://foo.bar/image.jpg"}}]},{"type":"body","parameters":[{"type":"text","text":"Ryan Lewis"},{"type":"text","text":"niño"}]},{"type":"button","sub_type":"quick_reply","index":"0","parameters":[{"type":"payload","payload":"Sip"}]},{"type":"button","sub_type":"url","index":"1","parameters":[{"type":"text","text":"id00231"}]}]}}`,
+			Body: `{"to":"250788123123","type":"template","template":{"namespace":"waba_namespace","name":"revive_issue","language":{"policy":"deterministic","code":"en_US"},"components":[{"type":"header","parameters":[{"type":"image","image":{"link":"https://foo.bar/image.jpg"}}]},{"type":"body","parameters":[{"type":"text","text":"Ryan Lewis"},{"type":"text","text":"niño"}]},{"type":"button","sub_type":"quick_reply","index":"0","parameters":[{"type":"payload","payload":"Sip"}]},{"type":"button","sub_type":"url","index":"1","parameters":[{"type":"text","text":"id00231"}]}]}}`,
 		}},
 		ExpectedExtIDs: []string{"157b5e14568e8"},
 	},


### PR DESCRIPTION
## Summary

An audit comparing the three WhatsApp handlers found that the TN handler's incoming path and template handling had drifted from WAC/D3C in ways that lose data or misbehave. This fixes the five substantive gaps; wire formats for supported message types are unchanged.

## Changes

- **Template language**: the handler derived the template language from the message locale, discarding the language the templating info supplied. WhatsApp resolves templates by name *and* language, so a locale that maps to a different code than the registered translation (e.g. `en` vs `en_US`) failed the send with error 132001. The supplied language now wins, with the locale-derived code kept as fallback when templating carries none - matching WAC/D3C.
- **Unsupported incoming types are skipped**: previously a sticker/reaction/order/etc. webhook logged "unsupported message type" but still wrote an empty message (no text, no attachments) that entered flow handling. Now skipped, matching WAC/D3C.
- **Flow replies (`nfm_reply`) are handled**: previously they fell through silently as empty messages. Now the reply body becomes the message text and the response JSON, when it's a valid JSON object, is attached as the message payload - same as WAC/D3C, including the log error for non-object response JSON.
- **Errors on messages and statuses are logged**: `errors[]` on incoming messages and on failed statuses now produce channel log errors (reusing the shared `whatsapp.WAError`), so failed sends have diagnostics.
- **Unknown status returns 200**: previously a status value we don't map returned HTTP 400, making the server redeliver the whole webhook batch (and statuses have no dedup). Now logged as ignored with a 200. WAC and D3C both already respond 200 in this case (WAC via its `WriteRequestError` override), so all three handlers now agree.

## Test plan

- New incoming tests: flow reply (with payload), flow reply with non-object JSON, unsupported type writes no message, message errors logged, failed status with error logged
- Existing template tests updated to expect the supplied language; the no-language and invalid-locale fallback tests unchanged
- Unknown-status test updated to expect 200
- Full handler test suite passes