### PR TITLE
Parse derived config values once in Config.Parse rather than at each use site

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -132,7 +132,9 @@ func (c *Config) Parse() error {
 	}
 	c.DisallowedIPs, c.DisallowedNets = ips, nets
 
-	// the validator has already enforced that this is an http(s) URL if set
+	// the validator has already enforced that this is an http(s) URL if set. Cleared rather than left alone when
+	// unset, so that parsing twice can't leave a stale URL behind - same as the networks above.
+	c.SendProxyURLParsed = nil
 	if c.SendProxyURL != "" {
 		u, err := url.Parse(c.SendProxyURL)
 		if err != nil {

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -55,6 +55,11 @@ type Config struct {
 
 	// ExcludeChannels is the list of channels to exclude, empty means exclude none
 	ExcludeChannels []string
+
+	// parsed values that can't be set directly
+	DisallowedIPs      []net.IP
+	DisallowedNets     []*net.IPNet
+	SendProxyURLParsed *url.URL
 }
 
 // NewDefaultConfig returns a new default configuration object
@@ -105,38 +110,36 @@ func LoadConfig(cfg *Config, args ...string) (*Config, error) {
 		return nil, err
 	}
 
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.Parse(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
 	return cfg, nil
 }
 
-// Validate validates the config
-func (c *Config) Validate() error {
+// Parse validates the config and fills in the values which can't be used in the form they're configured in. It's
+// called by LoadConfig, and a config built by other means (e.g. NewDefaultConfig in a test) must be parsed before
+// being handed to NewRuntime - the values it fills in have no meaningful zero value, so skipping it would silently
+// leave the SSRF blocklist empty rather than fail.
+func (c *Config) Parse() error {
 	if err := utils.Validate(c); err != nil {
 		return err
 	}
 
-	if _, _, err := c.ParseDisallowedNetworks(); err != nil {
+	ips, nets, err := httpx.ParseNetworks(c.DisallowedNetworks...)
+	if err != nil {
 		return fmt.Errorf("unable to parse 'DisallowedNetworks': %w", err)
 	}
+	c.DisallowedIPs, c.DisallowedNets = ips, nets
 
-	if _, err := c.ParseSendProxyURL(); err != nil {
-		return fmt.Errorf("unable to parse 'SendProxyURL': %w", err)
+	// the validator has already enforced that this is an http(s) URL if set
+	if c.SendProxyURL != "" {
+		u, err := url.Parse(c.SendProxyURL)
+		if err != nil {
+			return fmt.Errorf("unable to parse 'SendProxyURL': %w", err)
+		}
+		c.SendProxyURLParsed = u
 	}
+
 	return nil
-}
-
-// ParseDisallowedNetworks parses the list of IPs and IP networks (written in CIDR notation)
-func (c *Config) ParseDisallowedNetworks() ([]net.IP, []*net.IPNet, error) {
-	return httpx.ParseNetworks(c.DisallowedNetworks...)
-}
-
-// ParseSendProxyURL parses SendProxyURL. Returns (nil, nil) when SendProxyURL is empty.
-func (c *Config) ParseSendProxyURL() (*url.URL, error) {
-	if c.SendProxyURL == "" {
-		return nil, nil
-	}
-	return url.Parse(c.SendProxyURL)
 }

--- a/runtime/config_test.go
+++ b/runtime/config_test.go
@@ -69,6 +69,11 @@ func TestConfigParse(t *testing.T) {
 	assert.Equal(t, []net.IP{net.ParseIP("::1")}, cfg.DisallowedIPs)
 	assert.Len(t, cfg.DisallowedNets, 9)
 
+	// parsing again with the proxy removed clears the parsed URL rather than leaving the previous one behind
+	cfg.SendProxyURL = ""
+	require.NoError(t, cfg.Parse())
+	assert.Nil(t, cfg.SendProxyURLParsed)
+
 	// with no proxy configured the parsed URL stays nil, which is how newHTTP knows not to build a proxied client
 	cfg = runtime.NewDefaultConfig()
 	require.NoError(t, cfg.Parse())

--- a/runtime/config_test.go
+++ b/runtime/config_test.go
@@ -2,6 +2,7 @@ package runtime_test
 
 import (
 	"log/slog"
+	"net"
 	"testing"
 
 	"github.com/nyaruka/courier/v26/runtime"
@@ -47,30 +48,29 @@ func TestLoadConfig(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestConfigValidate(t *testing.T) {
+func TestConfigParse(t *testing.T) {
 	for _, tc := range invalidConfigTestCases {
-		err := tc.config.Validate()
+		err := tc.config.Parse()
 		if assert.Error(t, err, "expected error for config %v", tc.config) {
 			assert.Contains(t, err.Error(), tc.expectedError, "error mismatch for config %v", tc.config)
 		}
 	}
-}
 
-func TestParseSendProxyURL(t *testing.T) {
+	// parsing a valid config fills in the values which can't be used in their configured form
 	cfg := runtime.NewDefaultConfig()
 	cfg.SendProxyURL = "http://proxy.example.com:3128"
-	require.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Parse())
 
-	u, err := cfg.ParseSendProxyURL()
-	require.NoError(t, err)
-	require.NotNil(t, u)
-	assert.Equal(t, "proxy.example.com:3128", u.Host)
-	assert.Equal(t, "http", u.Scheme)
+	require.NotNil(t, cfg.SendProxyURLParsed)
+	assert.Equal(t, "proxy.example.com:3128", cfg.SendProxyURLParsed.Host)
+	assert.Equal(t, "http", cfg.SendProxyURLParsed.Scheme)
 
-	// empty SendProxyURL returns (nil, nil)
+	// the disallowed networks are split into bare IPs and CIDR networks
+	assert.Equal(t, []net.IP{net.ParseIP("::1")}, cfg.DisallowedIPs)
+	assert.Len(t, cfg.DisallowedNets, 9)
+
+	// with no proxy configured the parsed URL stays nil, which is how newHTTP knows not to build a proxied client
 	cfg = runtime.NewDefaultConfig()
-	require.NoError(t, cfg.Validate())
-	u, err = cfg.ParseSendProxyURL()
-	require.NoError(t, err)
-	assert.Nil(t, u)
+	require.NoError(t, cfg.Parse())
+	assert.Nil(t, cfg.SendProxyURLParsed)
 }

--- a/runtime/http.go
+++ b/runtime/http.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -27,14 +26,10 @@ type HTTP struct {
 	Attachments *http.Client
 }
 
-func newHTTP(cfg *Config) (*HTTP, error) {
-	// parse the SSRF blocklist up front so it can be baked into each client's transport via
-	// httpx.WithAccessControl, rather than passed to every request.
-	disallowedIPs, disallowedNets, err := cfg.ParseDisallowedNetworks()
-	if err != nil {
-		return nil, fmt.Errorf("error parsing disallowed networks: %w", err)
-	}
-	access := httpx.NewAccessConfig(10*time.Second, disallowedIPs, disallowedNets)
+func newHTTP(cfg *Config) *HTTP {
+	// the SSRF blocklist is baked into each client's transport via httpx.WithAccessControl, rather than passed to
+	// every request. Config.Parse turned the configured networks into the IPs and nets this needs.
+	access := httpx.NewAccessConfig(10*time.Second, cfg.DisallowedIPs, cfg.DisallowedNets)
 
 	transport := newBaseTransport()
 
@@ -60,19 +55,14 @@ func newHTTP(cfg *Config) (*HTTP, error) {
 	// host and rejects the request if it maps to a disallowed IP. This check runs regardless of the proxy; when the
 	// proxy is set the request still dials the proxy rather than the destination, so the proxy's own egress rules
 	// govern the actual connection to the destination.
-	proxyURL, err := cfg.ParseSendProxyURL()
-	if err != nil {
-		return nil, fmt.Errorf("error parsing send proxy URL: %w", err)
-	}
-
 	h.Proxied = h.Default
-	if proxyURL != nil {
+	if cfg.SendProxyURLParsed != nil {
 		proxiedTransport := transport.Clone()
-		proxiedTransport.Proxy = http.ProxyURL(proxyURL)
+		proxiedTransport.Proxy = http.ProxyURL(cfg.SendProxyURLParsed)
 		h.Proxied = &http.Client{Transport: httpx.WithTraces(httpx.WithAccessControl(proxiedTransport, access)), Timeout: 30 * time.Second}
 	}
 
-	return h, nil
+	return h
 }
 
 // newTestHTTP builds the clients for a test runtime, which don't need access control or the proxy. All three are the

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -64,11 +64,7 @@ func NewRuntime(cfg *Config) (*Runtime, error) {
 
 	rt.Centrifugo = centrifugo.NewService(centrifugo.NewClient(cfg.CentrifugoEndpoint, cfg.CentrifugoKey), rt.VK)
 
-	rt.HTTP, err = newHTTP(cfg)
-	if err != nil {
-		return nil, err
-	}
-
+	rt.HTTP = newHTTP(cfg)
 	rt.Stats = NewStatsCollector()
 
 	return rt, nil

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/gocommon/httpx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,11 +17,17 @@ func TestHTTPProxied(t *testing.T) {
 
 	// without SendProxyURL configured, HTTP.Proxied is the same client as HTTP.Default
 	cfg := runtime.NewDefaultConfig()
-	require.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Parse())
 
 	rt, err := newRuntimeForHTTPTest(cfg)
 	require.NoError(t, err)
 	assert.Same(t, rt.HTTP.Default, rt.HTTP.Proxied)
+
+	// the blocklist Config.Parse built is baked into the client's transport, so a request to a disallowed address
+	// is rejected without dialing. This is the assertion that fails if a runtime is ever built from a config that
+	// wasn't parsed, since an unparsed config yields an empty blocklist rather than an error.
+	_, err = rt.HTTP.Default.Get("http://127.0.0.1:1/")
+	assert.ErrorIs(t, err, httpx.ErrAccessConfig)
 
 	// stand up a stub forward proxy; a forward-proxied http:// request arrives here carrying the
 	// target's host, which lets us confirm the proxied client actually routes through it. The access
@@ -39,7 +46,7 @@ func TestHTTPProxied(t *testing.T) {
 	cfg = runtime.NewDefaultConfig()
 	cfg.DisallowedNetworks = nil
 	cfg.SendProxyURL = proxy.URL
-	require.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.Parse())
 
 	rt, err = newRuntimeForHTTPTest(cfg)
 	require.NoError(t, err)

--- a/testsuite/runtime.go
+++ b/testsuite/runtime.go
@@ -65,6 +65,9 @@ func NewRuntime(t *testing.T) *runtime.Runtime {
 	// items spooled by a previous test run would be replayed into this run's reset database
 	require.NoError(t, os.RemoveAll(cfg.SpoolDir))
 
+	// tests get the same SSRF blocklist as production, which NewRuntime reads from the parsed config
+	require.NoError(t, cfg.Parse())
+
 	rt, err := runtime.NewRuntime(cfg)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Two config values can't be used in the form they're configured in — the disallowed networks (a list of strings, needed as IPs and CIDR nets) and the send proxy URL (a string, needed as a `*url.URL`). They were being parsed twice: `Config.Validate` parsed both purely to check them and threw the results away, then `newHTTP` parsed them again to actually use them.

`Validate` becomes `Parse`, which validates and keeps what it parsed on the config. `newHTTP` reads the fields, and since it can no longer fail it drops its error return.

## Changes

- `Config` gains a `// parsed values that can't be set directly` block: `DisallowedIPs`, `DisallowedNets`, `SendProxyURLParsed`.
- `Config.Validate` → `Config.Parse`, which fills those in. `ParseDisallowedNetworks` and `ParseSendProxyURL` are removed.
- `newHTTP(cfg) *HTTP` — no parsing, no error return, so `NewRuntime` loses another error branch.
- `testsuite.NewRuntime` now calls `cfg.Parse()`. It previously called neither `Validate` nor `Parse`, which was harmless when parsing happened at the use site but would otherwise have left every test runtime with an empty SSRF blocklist.
- `TestConfigValidate` and `TestParseSendProxyURL` merge into `TestConfigParse`, which also asserts the configured networks split into the expected bare IPs and CIDR nets.

## Behavior

None in production — `LoadConfig` called `Validate` and now calls `Parse`, and the clients are built from the same values.

There is a new failure mode worth knowing about, which is inherent to storing parsed values on the config: a `Config` that is never parsed has an *empty* blocklist rather than an error, so a runtime built from one would make outbound requests with no SSRF protection. Two things guard it:

- The only two ways to get a config — `LoadConfig` and the test suite — both parse.
- `TestHTTPProxied` asserts the default client rejects `http://127.0.0.1:1/` with `httpx.ErrAccessConfig`. Verified this fails if the `Parse` call is removed, so a future call site that skips it gets caught:

```
--- FAIL: TestHTTPProxied (0.00s)
    Error Trace:  runtime/runtime_test.go:29
    Error:        Target error should be in err chain:
```

## Test plan

- Full suite green (`go test -p=1 ./...`)
- New assertion verified to fail without the `Parse` call, as above
- `gofmt` and `go vet` clean