### PR TITLE
Tidy TN incoming message parsing

### DIFF
--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -96,32 +96,18 @@ type eventsPayload struct {
 			Body string `json:"body"`
 		} `json:"text"`
 		Audio *struct {
-			File     string `json:"file"      validate:"required"`
-			ID       string `json:"id"        validate:"required"`
-			Link     string `json:"link"`
-			MimeType string `json:"mime_type" validate:"required"`
-			Sha256   string `json:"sha256"    validate:"required"`
+			ID string `json:"id"`
 		} `json:"audio"`
 		Button *struct {
-			Payload string `json:"payload"`
-			Text    string `json:"text"    validate:"required"`
+			Text string `json:"text"`
 		} `json:"button"`
 		Document *struct {
-			File     string `json:"file"      validate:"required"`
-			ID       string `json:"id"        validate:"required"`
-			Link     string `json:"link"`
-			MimeType string `json:"mime_type" validate:"required"`
-			Sha256   string `json:"sha256"    validate:"required"`
-			Caption  string `json:"caption"`
-			Filename string `json:"filename"`
+			ID      string `json:"id"`
+			Caption string `json:"caption"`
 		} `json:"document"`
 		Image *struct {
-			File     string `json:"file"      validate:"required"`
-			ID       string `json:"id"        validate:"required"`
-			Link     string `json:"link"`
-			MimeType string `json:"mime_type" validate:"required"`
-			Sha256   string `json:"sha256"    validate:"required"`
-			Caption  string `json:"caption"`
+			ID      string `json:"id"`
+			Caption string `json:"caption"`
 		} `json:"image"`
 		Interactive *struct {
 			ButtonReply *struct {
@@ -141,25 +127,15 @@ type eventsPayload struct {
 			Type string `json:"type"`
 		} `json:"interactive"`
 		Location *struct {
-			Address   string  `json:"address"   validate:"required"`
-			Latitude  float32 `json:"latitude"  validate:"required"`
-			Longitude float32 `json:"longitude" validate:"required"`
-			Name      string  `json:"name"      validate:"required"`
-			URL       string  `json:"url"       validate:"required"`
+			Latitude  float64 `json:"latitude"`
+			Longitude float64 `json:"longitude"`
 		} `json:"location"`
 		Video *struct {
-			File     string `json:"file"      validate:"required"`
-			ID       string `json:"id"        validate:"required"`
-			Link     string `json:"link"`
-			MimeType string `json:"mime_type" validate:"required"`
-			Sha256   string `json:"sha256"    validate:"required"`
+			ID      string `json:"id"`
+			Caption string `json:"caption"`
 		} `json:"video"`
 		Voice *struct {
-			File     string `json:"file"      validate:"required"`
-			ID       string `json:"id"        validate:"required"`
-			Link     string `json:"link"`
-			MimeType string `json:"mime_type" validate:"required"`
-			Sha256   string `json:"sha256"    validate:"required"`
+			ID string `json:"id"`
 		} `json:"voice"`
 		Errors []whatsapp.WAError `json:"errors"`
 	} `json:"messages"`
@@ -256,6 +232,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 		} else if msg.Type == "location" && msg.Location != nil {
 			mediaURL = fmt.Sprintf("geo:%f,%f", msg.Location.Latitude, msg.Location.Longitude)
 		} else if msg.Type == "video" && msg.Video != nil {
+			text = msg.Video.Caption
 			mediaURL, err = resolveMediaURL(channel, msg.Video.ID)
 		} else if msg.Type == "voice" && msg.Voice != nil {
 			mediaURL, err = resolveMediaURL(channel, msg.Voice.ID)

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -296,7 +296,8 @@ var videoMsg = `{
 			"id": "41",
 			"link": "https://example.org/v1/media/41",
 			"mime_type": "text/plain",
-			"sha256": "the-sha-signature"
+			"sha256": "the-sha-signature",
+			"caption": "the caption"
 		}
 	}]
 }`
@@ -667,7 +668,7 @@ var testCasesTurn = []IncomingTestCase{
 		Data:                 videoMsg,
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: `"type":"msg"`,
-		ExpectedMsgText:      Sp(""),
+		ExpectedMsgText:      Sp("the caption"),
 		ExpectedAttachments:  []string{"https://foo.bar/v1/media/41"},
 		ExpectedURN:          "whatsapp:250788123123",
 		ExpectedExternalID:   "41",


### PR DESCRIPTION
## Summary

Small cleanups to the TN handler's incoming path, following the parity fixes: video captions were the one media caption type not extracted as message text; location coordinates were parsed as `float32` (slightly lossy vs the `float64` other handlers use); and the webhook payload structs carried many fields that were parsed but never read.

## Changes

- Incoming video captions become the message text, matching image and document handling.
- Location latitude/longitude parsed as `float64`.
- Dead struct fields removed (media `file`/`link`/`mime_type`/`sha256`, document `filename`, button `payload`, location `address`/`name`/`url`), along with their `validate` tags — which were demonstrably never enforced on these nested structs (existing tests pass payloads with "required" fields missing or zero).

## Test plan

- Video message test now asserts the caption is extracted
- Existing location/document/audio/voice tests pass unchanged, confirming parsing and geo formatting are unaffected
- Full turn handler test suite passes