### PR TITLE
Consolidate WhatsApp send response parsing into a shared helper

### DIFF
--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -291,7 +290,7 @@ func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.Se
 	}
 	sendURL, _ := url.Parse("/messages")
 
-	requestPayloads, err := whatsapp.GetMsgPayloads(ctx, msg, maxMsgLength, clog)
+	requestPayloads, err := whatsapp.GetMsgPayloads(msg, maxMsgLength, clog)
 	if err != nil {
 		return err
 	}
@@ -398,27 +397,13 @@ func (h *handler) requestD3C(payload whatsapp.SendRequest, accessToken string, r
 		return "", channels.ErrConnectionThrottled
 	}
 
-	respPayload := &whatsapp.SendResponse{}
-	err = json.Unmarshal(respBody, respPayload)
+	respPayload, err := whatsapp.ParseSendResponse(respBody)
 	if err != nil {
-		return "", channels.ErrResponseUnparseable
+		return "", err
 	}
 
-	if slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Error.Code) {
-		return "", channels.ErrConnectionThrottled
+	if id := respPayload.ExternalID(); id != "" {
+		res.AddExternalID(id)
 	}
-
-	if slices.Contains(whatsapp.WACRetryableErrorCodes, respPayload.Error.Code) {
-		return "", channels.ErrRetryableWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
-	}
-
-	if respPayload.Error.Code != 0 || respPayload.Error.Message != "" {
-		return "", channels.ErrFailedWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
-	}
-
-	if len(respPayload.Messages) > 0 && respPayload.Messages[0].ID != "" {
-		res.AddExternalID(respPayload.Messages[0].ID)
-	}
-
 	return respPayload.UserID(), nil
 }

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -700,7 +699,7 @@ func (h *handler) sendWhatsAppMsg(ctx context.Context, msg *models.MsgOut, res *
 	path, _ := url.Parse(fmt.Sprintf("/%s/messages", msg.Channel().Address()))
 	wacPhoneURL := base.ResolveReference(path)
 
-	requestPayloads, err := whatsapp.GetMsgPayloads(ctx, msg, maxMsgLengthWAC, clog)
+	requestPayloads, err := whatsapp.GetMsgPayloads(msg, maxMsgLengthWAC, clog)
 	if err != nil {
 		return err
 	}
@@ -876,26 +875,13 @@ func (h *handler) requestWAC(payload whatsapp.SendRequest, accessToken string, r
 		return "", channels.ErrConnectionThrottled
 	}
 
-	respPayload := &whatsapp.SendResponse{}
-	err = json.Unmarshal(respBody, respPayload)
+	respPayload, err := whatsapp.ParseSendResponse(respBody)
 	if err != nil {
-		return "", channels.ErrResponseUnparseable
+		return "", err
 	}
 
-	if slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Error.Code) {
-		return "", channels.ErrConnectionThrottled
-	}
-
-	if slices.Contains(whatsapp.WACRetryableErrorCodes, respPayload.Error.Code) {
-		return "", channels.ErrRetryableWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
-	}
-
-	if respPayload.Error.Code != 0 || respPayload.Error.Message != "" {
-		return "", channels.ErrFailedWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
-	}
-
-	if len(respPayload.Messages) > 0 && respPayload.Messages[0].ID != "" {
-		res.AddExternalID(respPayload.Messages[0].ID)
+	if id := respPayload.ExternalID(); id != "" {
+		res.AddExternalID(id)
 	}
 	return respPayload.UserID(), nil
 }

--- a/handlers/meta/whatsapp/api.go
+++ b/handlers/meta/whatsapp/api.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -418,8 +420,45 @@ func NewTypingRequest(msgID string) *TypingRequest {
 
 // UserID returns the user_id from the first contact in the response if present.
 func (r *SendResponse) UserID() string {
-	if len(r.Contacts) > 0 && r.Contacts[0].UserID != "" {
+	if len(r.Contacts) > 0 && r.Contacts[0] != nil {
 		return r.Contacts[0].UserID
 	}
 	return ""
+}
+
+// ExternalID returns the ID of the first message in the response if present.
+func (r *SendResponse) ExternalID() string {
+	if len(r.Messages) > 0 && r.Messages[0] != nil {
+		return r.Messages[0].ID
+	}
+	return ""
+}
+
+// Err returns the appropriate send error if this response contains an error, or nil if it doesn't.
+func (r *SendResponse) Err() error {
+	if r.Error.Code != 0 || r.Error.Message != "" {
+		return SendErrorFromCode(r.Error.Code, r.Error.Message)
+	}
+	return nil
+}
+
+// ParseSendResponse parses the given response body from a send request, returning the parsed response and the
+// appropriate send error if it indicates the message couldn't be sent.
+func ParseSendResponse(respBody []byte) (*SendResponse, error) {
+	respPayload := &SendResponse{}
+	if err := json.Unmarshal(respBody, respPayload); err != nil {
+		return nil, channels.ErrResponseUnparseable
+	}
+	return respPayload, respPayload.Err()
+}
+
+// SendErrorFromCode maps an error code and message in a send response to the appropriate send error.
+func SendErrorFromCode(code int, message string) error {
+	if code == 429 || slices.Contains(WACThrottlingErrorCodes, code) {
+		return channels.ErrConnectionThrottled
+	}
+	if slices.Contains(WACRetryableErrorCodes, code) {
+		return channels.ErrRetryableWithReason(strconv.Itoa(code), message)
+	}
+	return channels.ErrFailedWithReason(strconv.Itoa(code), message)
 }

--- a/handlers/meta/whatsapp/api_test.go
+++ b/handlers/meta/whatsapp/api_test.go
@@ -1,0 +1,45 @@
+package whatsapp_test
+
+import (
+	"testing"
+
+	"github.com/nyaruka/courier/v26/core/channels"
+	"github.com/nyaruka/courier/v26/handlers/meta/whatsapp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSendResponse(t *testing.T) {
+	// valid response with a sent message
+	resp, err := whatsapp.ParseSendResponse([]byte(`{"messages":[{"id":"wamid.123"}],"contacts":[{"wa_id":"5678","user_id":"US.999"}]}`))
+	assert.NoError(t, err)
+	assert.Equal(t, "wamid.123", resp.ExternalID())
+	assert.Equal(t, "US.999", resp.UserID())
+
+	// null elements in the arrays shouldn't panic
+	resp, err = whatsapp.ParseSendResponse([]byte(`{"messages":[null],"contacts":[null]}`))
+	assert.NoError(t, err)
+	assert.Equal(t, "", resp.ExternalID())
+	assert.Equal(t, "", resp.UserID())
+
+	// empty response
+	resp, err = whatsapp.ParseSendResponse([]byte(`{}`))
+	assert.NoError(t, err)
+	assert.Equal(t, "", resp.ExternalID())
+	assert.Equal(t, "", resp.UserID())
+
+	// unparseable response
+	_, err = whatsapp.ParseSendResponse([]byte(`not json`))
+	assert.Equal(t, channels.ErrResponseUnparseable, err)
+
+	// error object responses map to the appropriate send error
+	_, err = whatsapp.ParseSendResponse([]byte(`{"error":{"code":130429,"message":"Rate limit hit"}}`))
+	assert.Equal(t, channels.ErrConnectionThrottled, err)
+
+	_, err = whatsapp.ParseSendResponse([]byte(`{"error":{"code":131053,"message":"Media upload error"}}`))
+	require.Error(t, err)
+	assert.Equal(t, channels.ErrRetryableWithReason("131053", "Media upload error"), err)
+
+	_, err = whatsapp.ParseSendResponse([]byte(`{"error":{"code":100,"message":"Invalid parameter"}}`))
+	assert.Equal(t, channels.ErrFailedWithReason("100", "Invalid parameter"), err)
+}

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -1,7 +1,6 @@
 package whatsapp
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -14,7 +13,7 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 )
 
-func GetMsgPayloads(ctx context.Context, msg *models.MsgOut, maxMsgLength int, clog *models.ChannelLog) ([]SendRequest, error) {
+func GetMsgPayloads(msg *models.MsgOut, maxMsgLength int, clog *models.ChannelLog) ([]SendRequest, error) {
 	if msg.Templating() != nil {
 		return []SendRequest{newBasePayload(msg).withTemplate(msg.Templating())}, nil
 	}

--- a/handlers/meta/whatsapp/payloads_test.go
+++ b/handlers/meta/whatsapp/payloads_test.go
@@ -1,7 +1,6 @@
 package whatsapp_test
 
 import (
-	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -34,7 +33,6 @@ func TestRecipientFields(t *testing.T) {
 }
 
 func TestGetMsgPayloads(t *testing.T) {
-	ctx := context.Background()
 	maxMsgLength := 4096
 
 	// Create a mock channel
@@ -680,7 +678,7 @@ func TestGetMsgPayloads(t *testing.T) {
 			clog := models.NewChannelLogForSend(msg, nil)
 
 			// Call GetMsgPayloads
-			payloads, err := whatsapp.GetMsgPayloads(ctx, msg, maxMsgLength, clog)
+			payloads, err := whatsapp.GetMsgPayloads(msg, maxMsgLength, clog)
 
 			// Assert no error
 			require.NoError(t, err)

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -486,7 +485,7 @@ func (h *handler) buildPayloads(ctx context.Context, msg *models.MsgOut, clog *m
 		return []any{payload}, nil
 	}
 
-	requests, err := whatsapp.GetMsgPayloads(ctx, msg, maxMsgLength, clog)
+	requests, err := whatsapp.GetMsgPayloads(msg, maxMsgLength, clog)
 	if err != nil {
 		return nil, err
 	}
@@ -665,18 +664,13 @@ func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.Se
 // https://developers.facebook.com/documentation/business-messaging/whatsapp/support/error-codes
 // the struct below captures both errors array and error object
 type mtResponsePayload struct {
+	whatsapp.SendResponse
+
 	Errors []struct {
 		Code    int    `json:"code"`
 		Title   string `json:"title"`
 		Details string `json:"details"`
 	} `json:"errors"`
-	Messages []*struct {
-		ID string `json:"id"`
-	} `json:"messages"`
-	Error struct {
-		Message string `json:"message"`
-		Code    int    `json:"code"`
-	} `json:"error"`
 }
 
 func (h *handler) makeAPIRequest(payload any, accessToken string, res *channels.SendResult, wacPhoneURL *url.URL, clog *models.ChannelLog) error {
@@ -703,40 +697,26 @@ func (h *handler) makeAPIRequest(payload any, accessToken string, res *channels.
 	}
 
 	respPayload := &mtResponsePayload{}
-	err = json.Unmarshal(respBody, respPayload)
-	if err != nil {
+	if err := json.Unmarshal(respBody, respPayload); err != nil {
 		return channels.ErrResponseUnparseable
 	}
-
-	if respPayload.Error.Code == 429 || slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Error.Code) {
-		return channels.ErrConnectionThrottled
+	if err := respPayload.Err(); err != nil {
+		return err
 	}
 
-	if slices.Contains(whatsapp.WACRetryableErrorCodes, respPayload.Error.Code) {
-		return channels.ErrRetryableWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
-	}
-
-	if respPayload.Error.Code != 0 || respPayload.Error.Message != "" {
-		return channels.ErrFailedWithReason(strconv.Itoa(respPayload.Error.Code), respPayload.Error.Message)
-	}
-
+	// errors can also come as an errors array using the same Meta error codes
 	if len(respPayload.Errors) > 0 {
-		if respPayload.Errors[0].Code == 429 || slices.Contains(whatsapp.WACThrottlingErrorCodes, respPayload.Errors[0].Code) {
-			return channels.ErrConnectionThrottled
+		e := respPayload.Errors[0]
+		message := e.Title
+		if e.Details != "" {
+			message += ": " + e.Details
 		}
-		if slices.Contains(whatsapp.WACRetryableErrorCodes, respPayload.Errors[0].Code) {
-			return channels.ErrRetryableWithReason(strconv.Itoa(respPayload.Errors[0].Code), respPayload.Errors[0].Title)
-		}
-		return channels.ErrFailedWithReason(strconv.Itoa(respPayload.Errors[0].Code), respPayload.Errors[0].Title)
+		return whatsapp.SendErrorFromCode(e.Code, message)
 	}
 
-	if len(respPayload.Messages) > 0 {
-		externalID := respPayload.Messages[0].ID
-		if externalID != "" {
-			res.AddExternalID(externalID)
-		}
+	if id := respPayload.ExternalID(); id != "" {
+		res.AddExternalID(id)
 	}
-
 	return nil
 }
 

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -885,6 +885,21 @@ var defaultSendTestCases = []OutgoingTestCase{
 		ExpectedError: channels.ErrFailedWithReason("232", "Error Sending"),
 	},
 	{
+		Label:   "Error Field with details",
+		MsgText: "Error",
+		MsgURN:  "whatsapp:250788123123",
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/v1/messages": {
+				httpx.NewMockResponse(400, nil, []byte(`{ "errors": [{"code": -1, "title": "Bad Request", "details": "Could not be parsed, invalid key"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Path: "/v1/messages",
+			Body: `{"to":"250788123123","type":"text","text":{"body":"Error"}}`,
+		}},
+		ExpectedError: channels.ErrFailedWithReason("-1", "Bad Request: Could not be parsed, invalid key"),
+	},
+	{
 		Label:   "Error Field Retryable",
 		MsgText: "Error",
 		MsgURN:  "whatsapp:250788123123",


### PR DESCRIPTION
## Summary

The three WhatsApp handlers (WAC, D3C, TN) each carried a near-identical ~25 line copy of send-response parsing and error-code mapping - which is exactly how they drifted apart in the past. This consolidates the parsing into the shared `whatsapp` package so future changes land in one place.

## Changes

- New `whatsapp.ParseSendResponse` (unmarshal + error mapping) and `whatsapp.SendErrorFromCode` (throttling/retryable/failed classification), plus `SendResponse.ExternalID()` / `.Err()` helpers. WAC and D3C now call these directly; TN embeds `whatsapp.SendResponse` in its response payload and layers its `errors[]`-array handling on top with the same shared code mapping.
- TN failure reasons now include the `details` field it parses but previously never reported (e.g. `Bad Request: Could not be parsed, invalid key` instead of just `Bad Request`).
- A body error code of `429` is now treated as throttling in all three handlers (previously only TN checked it; the HTTP-status 429 check was already uniform).
- Null elements in response `messages[]` / `contacts[]` arrays no longer panic - the helpers guard before dereferencing.
- Dropped the unused `context.Context` parameter from `GetMsgPayloads`.

## Test plan

- New unit tests on `ParseSendResponse` cover the null-element guards, error-code mapping (throttled/retryable/failed) and unparseable bodies
- New TN send test asserts the failure reason includes error `details`
- No wire-format or happy-path behavior changes; existing send tests for all three handlers pass unchanged
- Full handler test suite passes