### PR TITLE
Support flow_action, flow_action_payload and flow_token when sending WhatsApp Flows

### DIFF
--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -1102,6 +1102,54 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedLogErrors: []*svclogs.Error{{Message: "form quick reply extra '123456/BOOKING?name=50%' is malformed (invalid query: invalid URL escape \"%\") and flow will be sent with default action parameters"}},
 	},
 	{
+		Label:           "Interactive with form, with data not allowed with data exchange",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "dx:123456?name=Bob"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now"}}}}`,
+		}},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "form quick reply extra 'dx:123456?name=Bob' is malformed (data values can't be specified with data_exchange) and flow will be sent with default action parameters"}},
+	},
+	{
+		Label:           "Interactive with form, with missing screen ID",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456/"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now"}}}}`,
+		}},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "form quick reply extra '123456/' is malformed (missing screen id) and flow will be sent with default action parameters"}},
+	},
+	{
+		Label:           "Interactive with form, with missing flow ID",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "?token=98765"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"?token=98765","flow_cta":"Book now"}}}}`,
+		}},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "form quick reply extra '?token=98765' is malformed (missing flow id) and flow will be sent with default action parameters"}},
+	},
+	{
 		Label:           "Interactive with form missing form ID, sent as text",
 		MsgText:         "Interactive form msg",
 		MsgURN:          "whatsapp:250788123123",

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -964,6 +964,144 @@ var whatsappOutgoingTests = []OutgoingTestCase{
 		ExpectedExtIDs: []string{"157b5e14568e8", "157b5e14568e8"},
 	},
 	{
+		Label:           "Interactive with form, with entry screen and data",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456/BOOKING?name=Bob&age=32"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now","flow_action":"navigate","flow_action_payload":{"screen":"BOOKING","data":{"age":"32","name":"Bob"}}}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with form, with entry screen, url-encoded data and token",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456/BOOKING?name=Bob%20%26%20Ann&token=session%3D123"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now","flow_action":"navigate","flow_action_payload":{"screen":"BOOKING","data":{"name":"Bob & Ann"}},"flow_token":"session=123"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with form, with entry screen only",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456/BOOKING"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now","flow_action":"navigate","flow_action_payload":{"screen":"BOOKING"}}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with form, with token only",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456?token=98765"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now","flow_token":"98765"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with form, with data exchange and token",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "dx:123456?token=b2fdc934"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now","flow_action":"data_exchange","flow_token":"b2fdc934"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with form, with data exchange and no token",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "dx:123456"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now","flow_action":"data_exchange"}}}}`,
+		}},
+		ExpectedExtIDs: []string{"157b5e14568e8"},
+	},
+	{
+		Label:           "Interactive with form, with screen not allowed with data exchange",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "dx:123456/BOOKING?token=98765"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now"}}}}`,
+		}},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "form quick reply extra 'dx:123456/BOOKING?token=98765' is malformed (screen can't be specified with data_exchange) and flow will be sent with default action parameters"}},
+	},
+	{
+		Label:           "Interactive with form, with data not allowed without screen",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456?name=Bob"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now"}}}}`,
+		}},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "form quick reply extra '123456?name=Bob' is malformed (data values require a screen) and flow will be sent with default action parameters"}},
+	},
+	{
+		Label:           "Interactive with form, with invalid query encoding",
+		MsgText:         "Interactive form msg",
+		MsgURN:          "whatsapp:250788123123",
+		MsgQuickReplies: []models.QuickReply{{Type: "form", Text: "Book now", Extra: "123456/BOOKING?name=50%"}},
+		MockResponses: map[string][]*httpx.MockResponse{
+			"*/12345_ID/messages": {
+				httpx.NewMockResponse(201, nil, []byte(`{ "messages": [{"id": "157b5e14568e8"}] }`)),
+			},
+		},
+		ExpectedRequests: []ExpectedRequest{{
+			Body: `{"messaging_product":"whatsapp","recipient_type":"individual","to":"250788123123","type":"interactive","interactive":{"type":"flow","body":{"text":"Interactive form msg"},"action":{"name":"flow","parameters":{"flow_message_version":"3","flow_id":"123456","flow_cta":"Book now"}}}}`,
+		}},
+		ExpectedExtIDs:    []string{"157b5e14568e8"},
+		ExpectedLogErrors: []*svclogs.Error{{Message: "form quick reply extra '123456/BOOKING?name=50%' is malformed (invalid query: invalid URL escape \"%\") and flow will be sent with default action parameters"}},
+	},
+	{
 		Label:           "Interactive with form missing form ID, sent as text",
 		MsgText:         "Interactive form msg",
 		MsgURN:          "whatsapp:250788123123",

--- a/handlers/meta/whatsapp/api.go
+++ b/handlers/meta/whatsapp/api.go
@@ -323,14 +323,23 @@ type Template struct {
 	Components []*Component `json:"components,omitempty"`
 }
 
+// payload of a navigate flow action, specifying the entry screen and optionally its initial data
+type FlowActionPayload struct {
+	Screen string            `json:"screen"`
+	Data   map[string]string `json:"data,omitempty"`
+}
+
 // parameters for flow actions (https://developers.facebook.com/docs/whatsapp/flows/gettingstarted/sendingaflow)
 // and cta_url actions (https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-cta-url-messages)
 type ActionParameters struct {
-	FlowMessageVersion string `json:"flow_message_version,omitempty"`
-	FlowID             string `json:"flow_id,omitempty"`
-	FlowCTA            string `json:"flow_cta,omitempty"`
-	DisplayText        string `json:"display_text,omitempty"`
-	URL                string `json:"url,omitempty"`
+	FlowMessageVersion string             `json:"flow_message_version,omitempty"`
+	FlowID             string             `json:"flow_id,omitempty"`
+	FlowCTA            string             `json:"flow_cta,omitempty"`
+	FlowAction         string             `json:"flow_action,omitempty"`
+	FlowActionPayload  *FlowActionPayload `json:"flow_action_payload,omitempty"`
+	FlowToken          string             `json:"flow_token,omitempty"`
+	DisplayText        string             `json:"display_text,omitempty"`
+	URL                string             `json:"url,omitempty"`
 }
 
 type Header struct {

--- a/handlers/meta/whatsapp/payloads.go
+++ b/handlers/meta/whatsapp/payloads.go
@@ -1,7 +1,9 @@
 package whatsapp
 
 import (
+	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -278,16 +280,92 @@ func buildLocationRequestPayload(msg *models.MsgOut, body string) SendRequest {
 	return p
 }
 
+// flowParams are the optional flow action parameters parsed from a form quick reply's extra value
+type flowParams struct {
+	action string
+	screen string
+	data   map[string]string
+	token  string
+}
+
+// parseFormExtra parses the extra value of a form quick reply, which has the syntax
+//
+//	[dx:]<flow_id>[/<screen>][?<key>=<value>&...]
+//
+// where the dx: prefix selects the data_exchange flow action, and token is a reserved query key that sets
+// flow_token. The flow id is returned even when parsing fails so callers can still fall back to a plain
+// flow message.
+func parseFormExtra(extra string) (string, *flowParams, error) {
+	rest, isDX := strings.CutPrefix(extra, "dx:")
+	base, query, hasQuery := strings.Cut(rest, "?")
+	id, screen, hasScreen := strings.Cut(base, "/")
+
+	params := &flowParams{}
+	if isDX {
+		params.action = "data_exchange"
+	}
+
+	if id == "" {
+		return "", nil, errors.New("missing flow id")
+	}
+	if hasScreen {
+		if isDX {
+			return id, nil, errors.New("screen can't be specified with data_exchange")
+		}
+		if screen == "" {
+			return id, nil, errors.New("missing screen id")
+		}
+		params.action = "navigate"
+		params.screen = screen
+	}
+	if hasQuery {
+		values, err := url.ParseQuery(query)
+		if err != nil {
+			return id, nil, fmt.Errorf("invalid query: %s", err)
+		}
+		params.token = values.Get("token")
+		values.Del("token")
+		if len(values) > 0 {
+			if isDX {
+				return id, nil, errors.New("data values can't be specified with data_exchange")
+			}
+			if !hasScreen {
+				return id, nil, errors.New("data values require a screen")
+			}
+			params.data = make(map[string]string, len(values))
+			for key, vals := range values {
+				params.data[key] = vals[0]
+			}
+		}
+	}
+	return id, params, nil
+}
+
 func buildFlowPayload(msg *models.MsgOut, body string, qr models.QuickReply, clog *models.ChannelLog) SendRequest {
 	p := newBasePayload(msg)
 	p.Type = "interactive"
 	interactive := Interactive{Type: "flow", Body: struct {
 		Text string `json:"text"`
 	}{Text: body}}
-	interactive.Action = &Action{
-		Name:       "flow",
-		Parameters: &ActionParameters{FlowMessageVersion: "3", FlowID: qr.Extra, FlowCTA: truncateQuickReplyText(clog, qr.GetText(), maxFlowCTALength)},
+
+	actionParams := &ActionParameters{FlowMessageVersion: "3", FlowID: qr.Extra, FlowCTA: truncateQuickReplyText(clog, qr.GetText(), maxFlowCTALength)}
+
+	id, flow, err := parseFormExtra(qr.Extra)
+	if err != nil {
+		clog.Error(&svclogs.Error{Message: fmt.Sprintf("form quick reply extra '%s' is malformed (%s) and flow will be sent with default action parameters", qr.Extra, err)})
+		if id != "" {
+			actionParams.FlowID = id
+		}
+	} else {
+		actionParams.FlowID = id
+		actionParams.FlowAction = flow.action
+		actionParams.FlowToken = flow.token
+		if flow.screen != "" {
+			actionParams.FlowActionPayload = &FlowActionPayload{Screen: flow.screen, Data: flow.data}
+		}
 	}
+
+	interactive.Action = &Action{Name: "flow", Parameters: actionParams}
 	p.Interactive = &interactive
 	return p
 }


### PR DESCRIPTION
## Summary

Extends the `extra` syntax of form quick replies on WhatsApp channels to support the full set of flow action parameters on interactive flow messages, so flows can be launched with an entry screen and initial data, as endpoint-backed (`data_exchange`) flows, and with a `flow_token`. Closes #1134.

## Changes

* `handlers/meta/whatsapp/api.go` — adds `FlowAction`, `FlowActionPayload` and `FlowToken` fields to `ActionParameters`, and a new `FlowActionPayload` struct (`screen` plus optional string-valued `data`).
* `handlers/meta/whatsapp/payloads.go` — new `parseFormExtra` parses the extra value as `[dx:]<flow_id>[/<screen>][?<key>=<value>&...]`:
  * a `<screen>` slot selects `flow_action: navigate` with a `flow_action_payload` carrying the screen and url-decoded query values as string data
  * the `dx:` prefix selects `flow_action: data_exchange`, on which no screen or data keys are permitted since the API rejects `flow_action_payload` there
  * `token=` is a reserved query key on both forms and sets `flow_token`; when unset it is omitted so Meta's default of `"unused"` applies
  * malformed extras (screen or data with `dx:`, data without a screen, invalid url-encoding, missing flow or screen id) are logged to the channel log and the flow is sent with default action parameters rather than failing the send

## Behavior examples

| extra | action parameters sent (in addition to `flow_message_version`, `flow_id`, `flow_cta`) |
|---|---|
| `123456` | *(none — unchanged)* |
| `123456/BOOKING?name=Bob&age=32` | `"flow_action":"navigate","flow_action_payload":{"screen":"BOOKING","data":{"age":"32","name":"Bob"}}` |
| `123456?token=98765` | `"flow_token":"98765"` |
| `dx:123456?token=b2fdc934` | `"flow_action":"data_exchange","flow_token":"b2fdc934"` |
| `dx:123456/BOOKING` | *(none — malformed, channel log error, sent as plain flow message)* |

## Test plan

- [x] New outgoing test cases covering navigate with screen and data, url-encoded values, screen only, token only, and `data_exchange` with and without token
- [x] Every malformed-extra error branch has a case asserting its channel log error and fallback payload: screen with `dx:`, data with `dx:`, data without a screen, missing screen id, missing flow id, invalid url-encoding
- [x] Existing form quick reply cases unchanged, confirming the bare flow-id syntax produces the same payload as before
- [x] Full test suite passes

## Review notes

* Added regression tests for the three initially-uncovered parse error branches (data with `dx:`, missing screen id, missing flow id) per review.
* A suggestion to redact the raw extra from the malformed-extra channel log error was declined: channel logs already carry the outgoing request body (including `flow_token`) verbatim, and hiding the extra would obscure the malformed value from the flow author.