### PR TITLE
Remove orphaned per-channel rate limit checks from queue pop script

### DIFF
--- a/utils/queue/lua/pop.lua
+++ b/utils/queue/lua/pop.lua
@@ -15,21 +15,8 @@ local delim = string.find(queue, "|")
 local tps = 0
 local tpsKey = ""
 
-local queueName = ""
-
 if delim then
-    queueName = string.sub(queue, string.len(KEYS[2])+2, delim-1)
     tps = tonumber(string.sub(queue, delim+1))
-end
-
-if queueName then
-    local rateLimitKey = "rate_limit:" .. queueName
-    local rateLimitEngaged = redis.call("get", rateLimitKey)
-    if rateLimitEngaged then
-        redis.call("zincrby", KEYS[2] .. ":throttled", workers, queue)
-        redis.call("zrem", KEYS[2] .. ":active", queue)
-        return {"retry", ""}
-    end
 end
 
 -- if we have a tps, then check whether we exceed it
@@ -54,14 +41,6 @@ local isFutureResult = result[1] and tonumber(result[2]) > tonumber(KEYS[1])
 
 -- if we didn't find one, try again from our bulk queue
 if not result[1] or isFutureResult then
-    -- check if we are rate limited for bulk queue
-    local rateLimitBulkKey = "rate_limit_bulk:" .. queueName
-    local rateLimitBulk = redis.call("get", rateLimitBulkKey)
-    if rateLimitBulk then
-        return {"retry", ""}
-    end
-
-    -- we are not pause check our bulk queue
     local bulkQueue = queue .. "/0"
     local bulkResult = redis.call("zrangebyscore", bulkQueue, 0, "+inf", "WITHSCORES", "LIMIT", 0, 1)
 

--- a/utils/queue/queue_test.go
+++ b/utils/queue/queue_test.go
@@ -64,19 +64,6 @@ func TestLua(t *testing.T) {
 	delay := time.Second*2 - time.Duration(time.Now().UnixNano()%int64(time.Second)) + time.Millisecond*500
 	time.Sleep(delay)
 
-	// mark chan1 as rate limited
-	rc.Do("SET", "rate_limit_bulk:chan1", "engaged")
-	rc.Do("EXPIRE", "rate_limit_bulk:chan1", 5)
-
-	// popping shouldn't error or return a value
-	q, value, err := queue.PopFromQueue(rc, "msgs")
-	assert.NoError(t, err)
-	assert.Equal(t, "", value)
-	assert.Equal(t, queue.Retry, q)
-
-	// unmark chan1 as rate limited
-	rc.Do("DEL", "rate_limit_bulk:chan1")
-
 	// pop 10 items off
 	for i := 0; i < 10; i++ {
 		q, value, err := queue.PopFromQueue(rc, "msgs")
@@ -86,7 +73,7 @@ func TestLua(t *testing.T) {
 	}
 
 	// next value should be throttled
-	q, value, err = queue.PopFromQueue(rc, "msgs")
+	q, value, err := queue.PopFromQueue(rc, "msgs")
 	assert.NoError(t, err)
 	assert.Equal(t, "", value)
 	assert.Equal(t, queue.Retry, q)
@@ -110,17 +97,10 @@ func TestLua(t *testing.T) {
 	err = queue.PushOntoQueue(rc, "msgs", "chan1", rate, `[{"id":31}]`, queue.HighPriority)
 	assert.NoError(t, err)
 
-	// make sure pause bulk key do not prevent use to get from the high priority queue
-	rc.Do("SET", "rate_limit_bulk:chan1", "engaged")
-	rc.Do("EXPIRE", "rate_limit_bulk:chan1", 5)
-
 	q, value, err = queue.PopFromQueue(rc, "msgs")
 	assert.NoError(t, err)
 	assert.Equal(t, queue.WorkerToken("msgs:chan1|10"), q)
 	assert.Equal(t, `{"id":31}`, value)
-
-	// make sure paused is not present for more tests
-	rc.Do("DEL", "rate_limit_bulk:chan1")
 
 	// should get next five bulk msgs fine
 	for i := 10; i < 15; i++ {
@@ -187,55 +167,6 @@ func TestLua(t *testing.T) {
 	assert.Equal(t, queue.EmptyQueue, q)
 	assert.Empty(t, value)
 
-	err = queue.PushOntoQueue(rc, "msgs", "chan1", rate, `[{"id":34}]`, queue.HighPriority)
-	assert.NoError(t, err)
-
-	// 3 seconds so it's still set when we check at ~2 seconds but reliably expired when we check at ~5 seconds
-	rc.Do("SET", "rate_limit:chan1", "engaged")
-	rc.Do("EXPIRE", "rate_limit:chan1", 3)
-
-	// we have the rate limit set
-	q, value, err = queue.PopFromQueue(rc, "msgs")
-	assert.NoError(t, err)
-	if value != "" && q != queue.EmptyQueue {
-		t.Fatal("Should be throttled")
-	}
-
-	time.Sleep(2 * time.Second)
-
-	q, value, err = queue.PopFromQueue(rc, "msgs")
-	assert.NoError(t, err)
-	assert.Equal(t, "", value)
-	assert.Equal(t, queue.Retry, q)
-
-	assertvk.ZGetAll(t, rc, "msgs:active", map[string]float64{})
-	assertvk.ZGetAll(t, rc, "msgs:throttled", map[string]float64{"msgs:chan1|10": 0})
-	assertvk.ZGetAll(t, rc, "msgs:future", map[string]float64{})
-
-	// but if we wait for the rate limit to expire
-	time.Sleep(3 * time.Second)
-
-	// next should be 34.. tho we poll because we can't rely on the dethrottler having moved the queue back
-	// to active at an exact time
-	for deadline := time.Now().Add(5 * time.Second); ; {
-		q, value, err = queue.PopFromQueue(rc, "msgs")
-		assert.NoError(t, err)
-		if value != "" || time.Now().After(deadline) {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	assert.Equal(t, queue.WorkerToken("msgs:chan1|10"), q)
-	assert.Equal(t, `{"id":34}`, value)
-
-	// nothing should be left
-	q = queue.Retry
-	for q == queue.Retry {
-		q, value, err = queue.PopFromQueue(rc, "msgs")
-	}
-	assert.NoError(t, err)
-	assert.Equal(t, queue.EmptyQueue, q)
-	assert.Empty(t, value)
 }
 
 func TestThrottle(t *testing.T) {


### PR DESCRIPTION
## Summary

The queue's `pop.lua` consulted two valkey keys — `rate_limit:<channel>` and `rate_limit_bulk:<channel>` — to pause a channel's queue when its handler had hit a provider rate limit. Those keys were only ever written by the WhatsApp legacy handler, which has since been removed, so nothing sets them any more. Both checks were dead weight on every pop.

TPS-based throttling is untouched — that's a separate mechanism in the same script, driven by the per-channel TPS baked into the queue key, and it's still live for every channel.

## Changes

**`utils/queue/lua/pop.lua`**

- Dropped the `rate_limit:<channel>` check that moved the queue to the throttled set and returned `retry`.
- Dropped the `rate_limit_bulk:<channel>` check that suppressed the bulk queue.
- Removed the `queueName` local, which existed only to build those two key names.

**`utils/queue/queue_test.go`**

- Removed the three fixtures that set and deleted those keys around pops.
- Removed the trailing section of `TestLua` that pushed a message purely to exercise the rate-limit-then-expire path. The test already asserted an empty queue immediately before it, so nothing else was being covered — and this drops ~5s of sleeps from the suite.

## Behavior examples

Every pop previously issued up to two extra `GET`s against keys that are never set:

| | Before | After |
|---|---|---|
| `GET rate_limit:<channel>` | on every pop | gone |
| `GET rate_limit_bulk:<channel>` | on every pop that falls through to the bulk queue | gone |
| TPS throttling | active | unchanged |
| Dethrottler / `:throttled` set | active | unchanged |

No observable change in queue behavior: with neither key ever set, both branches were always false.

## Test plan

- [x] `go test ./utils/queue/...` — passes, including the TPS throttling and dethrottler timing tests
- [x] `go test ./core/... ./cmd/...` — passes
- [x] Full suite `go test -p=1 ./...` — passes
- [x] Confirmed nothing writes `rate_limit:` or `rate_limit_bulk:` anywhere: the last writer was the WhatsApp legacy handler removed in f7babd35, and no other service sets them