### PR TITLE
Fix pop script to correctly charge tps_cost of queued messages

### DIFF
--- a/utils/queue/lua/pop.lua
+++ b/utils/queue/lua/pop.lua
@@ -78,7 +78,7 @@ if result[1] and not isFutureResult then
     if tps > 0 then
         local tpsCost = 1
         if type(popped) == "table" and type(popped["tps_cost"]) == "number" then
-            tpsCost = math.floor(popped["tps_cost"])
+            tpsCost = math.max(1, math.floor(popped["tps_cost"]))
         end
         redis.call("incrby", tpsKey, tpsCost)
         redis.call("expire", tpsKey, 10)

--- a/utils/queue/lua/pop.lua
+++ b/utils/queue/lua/pop.lua
@@ -70,14 +70,19 @@ if result[1] and not isFutureResult then
 
     -- parse it as JSON to get the first element out
     local valueList = cjson.decode(result[1])
-    local popValue = cjson.encode(valueList[1])
+    local popped = valueList[1]
+    local popValue = cjson.encode(popped)
     table.remove(valueList, 1)
 
     -- increment our tps for this second if we have a limit
-    if tps > 0 then 
-        redis.call("incrby", tpsKey, popValue["tps_cost"] or 1)
+    if tps > 0 then
+        local tpsCost = 1
+        if type(popped) == "table" and type(popped["tps_cost"]) == "number" then
+            tpsCost = math.floor(popped["tps_cost"])
+        end
+        redis.call("incrby", tpsKey, tpsCost)
         redis.call("expire", tpsKey, 10)
-    end 
+    end
 
     -- encode it back if there is anything left
     if table.getn(valueList) > 0 then

--- a/utils/queue/queue_test.go
+++ b/utils/queue/queue_test.go
@@ -169,6 +169,42 @@ func TestLua(t *testing.T) {
 
 }
 
+func TestTPSCost(t *testing.T) {
+	rp := getPool()
+	rc := rp.Get()
+	defer rc.Close()
+
+	rate := 10
+
+	// push a message whose tps_cost consumes the entire rate, followed by a regular message
+	err := queue.PushOntoQueue(rc, "msgs", "chan1", rate, `[{"id":0,"tps_cost":10}]`, queue.HighPriority)
+	require.NoError(t, err)
+	err = queue.PushOntoQueue(rc, "msgs", "chan1", rate, `[{"id":1}]`, queue.HighPriority)
+	require.NoError(t, err)
+
+	// align ourselves to mid-second so our pops and TPS key reads land in the same second
+	delay := time.Second - time.Duration(time.Now().UnixNano()%int64(time.Second)) + time.Millisecond*500
+	time.Sleep(delay)
+
+	q, value, err := queue.PopFromQueue(rc, "msgs")
+	assert.NoError(t, err)
+	assert.Equal(t, queue.WorkerToken("msgs:chan1|10"), q)
+	assert.Equal(t, `{"id":0,"tps_cost":10}`, value)
+
+	// popped message should have been charged its full cost against this second's TPS key
+	tpsUsed, err := redis.Int(rc.Do("GET", fmt.Sprintf("msgs:chan1|10:tps:%d", time.Now().Unix())))
+	assert.NoError(t, err)
+	assert.Equal(t, 10, tpsUsed)
+
+	// so the next pop should be throttled even though only one message was popped
+	q, value, err = queue.PopFromQueue(rc, "msgs")
+	assert.NoError(t, err)
+	assert.Equal(t, queue.Retry, q)
+	assert.Equal(t, "", value)
+
+	assertvk.ZGetAll(t, rc, "msgs:throttled", map[string]float64{"msgs:chan1|10": 1})
+}
+
 func TestThrottle(t *testing.T) {
 	assert := assert.New(t)
 	pool := getPool()


### PR DESCRIPTION
## Summary

The queue pop script was meant to charge each popped message's `tps_cost` (e.g. segment count) against the channel's per-second TPS counter, but it indexed the re-encoded JSON *string* instead of the decoded value — in Lua that lookup returns `nil`, so every message was charged `1` regardless of its actual cost. This has been the behavior since the field was introduced in 2017, meaning TPS limits have effectively been message-per-second limits rather than segment-per-second limits.

## Changes

- `utils/queue/lua/pop.lua`: read `tps_cost` from the decoded first element (captured before it's removed from the batch), guarded so non-table values and missing/non-numeric costs fall back to the previous charge of `1`. The charge is clamped with `math.max(1, math.floor(...))` so a fractional cost can't round down to zero and a negative cost can't decrement the counter — any unexpected value still charges at least `1`, as before.
- `utils/queue/queue_test.go`: new `TestTPSCost` pushes a message whose `tps_cost` equals the channel's TPS limit, asserts the per-second TPS key is incremented by the full cost (previously it would read `1`), and that the next pop is throttled with the queue moved to the throttled set.

## Behavior

| | Before | After |
|---|---|---|
| Message with `tps_cost: 3` popped on a 10 TPS channel | counter +1 | counter +3 |
| Message without `tps_cost` | counter +1 | counter +1 (unchanged) |
| Message with fractional or negative `tps_cost` | counter +1 | counter +1 (clamped) |

Note that since multi-segment messages were previously under-charged, channels with TPS limits and long-message traffic will throttle sooner after this change — that's the intended enforcement, but effective message throughput on such channels will drop to what their configured TPS actually implies.

## Test plan

- [x] New `TestTPSCost` verifies the TPS key increments by the message's `tps_cost` and that throttling kicks in accordingly
- [x] Existing queue tests (`TestLua`, `TestThrottle`) still pass, covering the default charge-of-1 path
- [x] Full test suite passes

## Review notes

- Review flagged that `math.floor` alone would charge `0` for costs in `(0,1)` and pass negative values to `INCRBY` (relaxing throttling) — addressed by clamping the charge to a minimum of `1`.