### PR TITLE
Write msgs_msg.folder when creating incoming messages and updating outgoing statuses

### DIFF
--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -160,12 +160,14 @@ type dbMsgIn struct {
 	LogUUIDs           pq.StringArray `db:"log_uuids"`
 }
 
+// incoming messages are created pending (folder 'P') - mailroom moves them to the inbox or handled folder when it
+// handles them, and courier never writes those folders itself
 const sqlInsertIncomingMsg = `
 INSERT INTO
 	msgs_msg(org_id, uuid, direction, text, attachments, msg_type, msg_count, error_count, high_priority, status, is_android,
-             visibility, external_identifier, channel_id, contact_id, contact_urn_id, created_on, modified_on, sent_on, log_uuids)
+             visibility, folder, external_identifier, channel_id, contact_id, contact_urn_id, created_on, modified_on, sent_on, log_uuids)
     VALUES(:org_id, :uuid, 'I', :text, :attachments, 'T', 1, 0, FALSE, 'P', FALSE,
-             'V', :external_identifier, :channel_id, :contact_id, :contact_urn_id, :created_on, :created_on, :sent_on, :log_uuids)`
+             'V', 'P', :external_identifier, :channel_id, :contact_id, :contact_urn_id, :created_on, :created_on, :sent_on, :log_uuids)`
 
 // InsertIncomingMsg inserts the passed in incoming message into the database
 func InsertIncomingMsg(ctx context.Context, db *sqlx.DB, m *MsgIn, contact *Contact) error {

--- a/core/models/status.go
+++ b/core/models/status.go
@@ -303,7 +303,9 @@ const sqlNewMsgStatus = `CASE
 		ELSE s.status 
 		END`
 
-// the craziness below lets us update our status to 'F' and schedule retries without knowing anything about the message
+// the craziness below lets us update our status to 'F' and schedule retries without knowing anything about the message.
+// the folder derivation assumes the message is visible, which holds because nothing makes an outgoing message
+// non-visible - if that ever changes, a deleted message needs its own folder rather than one derived from status.
 var sqlUpdateMsgByUUID = fmt.Sprintf(`
 UPDATE msgs_msg SET 
 	status = %[1]s,

--- a/core/models/status.go
+++ b/core/models/status.go
@@ -294,13 +294,23 @@ func resolveStatusUpdateByExternalIdentifier(ctx context.Context, rt *runtime.Ru
 	return rows.Err()
 }
 
-// the craziness below lets us update our status to 'F' and schedule retries without knowing anything about the message
-const sqlUpdateMsgByUUID = `
-UPDATE msgs_msg SET 
-	status = CASE 
+// the expression which computes the new status of a message, referenced twice in the update statement below - once to
+// write the status itself, and once to derive the folder that status puts the message in. it lives here as a single
+// constant so that the two can't drift apart.
+const sqlNewMsgStatus = `CASE 
 		WHEN s.status = 'E' 
 		THEN CASE WHEN error_count >= 2 OR msgs_msg.status = 'F' THEN 'F' ELSE 'E' END 
 		ELSE s.status 
+		END`
+
+// the craziness below lets us update our status to 'F' and schedule retries without knowing anything about the message
+var sqlUpdateMsgByUUID = fmt.Sprintf(`
+UPDATE msgs_msg SET 
+	status = %[1]s,
+	folder = CASE (%[1]s)::varchar(1) 
+		WHEN 'W' THEN 'S' WHEN 'S' THEN 'S' WHEN 'D' THEN 'S' WHEN 'R' THEN 'S' 
+		WHEN 'F' THEN 'X' 
+		ELSE 'O' -- initializing, queued or errored 
 		END,
 	error_count = CASE WHEN s.status = 'E' THEN error_count + 1 ELSE error_count END,
 	next_attempt = CASE WHEN s.status = 'E' THEN NOW() + (5 * (error_count+1) * interval '1 minutes') ELSE next_attempt END,
@@ -313,7 +323,7 @@ UPDATE msgs_msg SET
         (VALUES(:msg_uuid::uuid, :channel_id::int, :status, :external_identifier, :log_uuid::uuid)) AS s(msg_uuid, channel_id, status, external_identifier, log_uuid),
         contacts_contact c
     WHERE msgs_msg.uuid = s.msg_uuid AND msgs_msg.channel_id = s.channel_id AND msgs_msg.direction = 'O' AND c.id = msgs_msg.contact_id
-RETURNING msgs_msg.uuid AS msg_uuid, msgs_msg.status AS msg_status, msgs_msg.failed_reason, c.uuid AS contact_uuid, msgs_msg.org_id`
+RETURNING msgs_msg.uuid AS msg_uuid, msgs_msg.status AS msg_status, msgs_msg.failed_reason, c.uuid AS contact_uuid, msgs_msg.org_id`, sqlNewMsgStatus)
 
 func WriteStatusUpdates(ctx context.Context, rt *runtime.Runtime, statuses []*StatusUpdate) ([]*StatusChange, error) {
 	// rewrite query as a bulk operation

--- a/core/models/status_test.go
+++ b/core/models/status_test.go
@@ -79,6 +79,16 @@ func TestWriteStatusUpdates(t *testing.T) {
 		"019bb29e-b2c6-7e5f-b980-ccb3e9e21fbc": "S",
 	})
 
+	// folder is written in step with status - sent messages in the sent folder, errored ones back in the outbox, and
+	// the incoming messages left alone in pending
+	assertdb.Query(t, rt.DB, `SELECT uuid, folder FROM msgs_msg`).Map(map[string]any{
+		"0199df0f-9f82-7689-b02d-f34105991321": "S",
+		"0199df10-10dc-7e6e-834b-3d959ece93b2": "O",
+		"0199df10-9519-7fe2-a29c-c890d1713673": "P",
+		"019bb1ca-a92d-78f5-ba61-06aa62f2b41a": "P",
+		"019bb29e-b2c6-7e5f-b980-ccb3e9e21fbc": "S",
+	})
+
 	assertdb.Query(t, rt.DB, `SELECT uuid::text, status, external_identifier FROM msgs_msg WHERE uuid= '0199df0f-9f82-7689-b02d-f34105991321'`).
 		Columns(map[string]any{
 			"uuid":                "0199df0f-9f82-7689-b02d-f34105991321",
@@ -124,6 +134,10 @@ func TestWriteStatusUpdates(t *testing.T) {
 		assert.Equal(t, "", string(changes[0].FailedReason))
 	}
 
+	// still errored so still in the outbox
+	assertdb.Query(t, rt.DB, `SELECT status, folder FROM msgs_msg WHERE uuid = '0199df10-10dc-7e6e-834b-3d959ece93b2'`).
+		Columns(map[string]any{"status": "E", "folder": "O"})
+
 	// write yet another errored status for message 2 - this should flip it to failed
 	changes, err = models.WriteStatusUpdates(ctx, rt, []*models.StatusUpdate{
 		{
@@ -140,6 +154,28 @@ func TestWriteStatusUpdates(t *testing.T) {
 		assert.Equal(t, models.MsgStatus("F"), changes[0].MsgStatus)
 		assert.Equal(t, "E", string(changes[0].FailedReason))
 	}
+
+	// the errored status flipped the message to failed so its folder has to have followed it there
+	assertdb.Query(t, rt.DB, `SELECT status, folder FROM msgs_msg WHERE uuid = '0199df10-10dc-7e6e-834b-3d959ece93b2'`).
+		Columns(map[string]any{"status": "F", "folder": "X"})
+
+	// and an update on an already failed message keeps it failed and in the failed folder
+	_, err = models.WriteStatusUpdates(ctx, rt, []*models.StatusUpdate{
+		{
+			ChannelUUID_: "dbc126ed-66bc-4e28-b67b-81dc3327c95d",
+			ChannelID_:   10,
+			MsgUUID_:     "0199df10-10dc-7e6e-834b-3d959ece93b2",
+			Status_:      models.MsgStatusErrored,
+			LogUUID:      "019a6e53-e1e8-7df7-a264-ce2372824e1d",
+		},
+	})
+	assert.NoError(t, err)
+
+	assertdb.Query(t, rt.DB, `SELECT status, folder FROM msgs_msg WHERE uuid = '0199df10-10dc-7e6e-834b-3d959ece93b2'`).
+		Columns(map[string]any{"status": "F", "folder": "X"})
+
+	// courier never writes a NULL folder for a message it touches
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM msgs_msg WHERE folder IS NULL`).Returns(0)
 }
 
 func TestStatusChanges(t *testing.T) {

--- a/core/models/suite_test.go
+++ b/core/models/suite_test.go
@@ -385,6 +385,7 @@ func (ts *ModelsTestSuite) TestMsgStatus() {
 
 	m := testsuite.ReadDBMsg(ts.T(), ts.rt, "0199df10-10dc-7e6e-834b-3d959ece93b2")
 	ts.Equal(models.MsgStatusWired, m.Status)
+	ts.Equal(null.String("S"), m.Folder)
 	ts.Equal(null.String("ext0"), m.ExternalIdentifier)
 	ts.True(m.ModifiedOn.After(now))
 	ts.True(m.SentOn.After(now))
@@ -404,6 +405,7 @@ func (ts *ModelsTestSuite) TestMsgStatus() {
 
 	m = testsuite.ReadDBMsg(ts.T(), ts.rt, "0199df10-10dc-7e6e-834b-3d959ece93b2")
 	ts.Equal(models.MsgStatusSent, m.Status)
+	ts.Equal(null.String("S"), m.Folder)
 	ts.Equal(null.String("ext0"), m.ExternalIdentifier) // no change
 	ts.True(m.ModifiedOn.After(now))
 	ts.True(m.SentOn.Equal(sentOn)) // no change
@@ -420,6 +422,7 @@ func (ts *ModelsTestSuite) TestMsgStatus() {
 
 	m = testsuite.ReadDBMsg(ts.T(), ts.rt, "0199df10-10dc-7e6e-834b-3d959ece93b2")
 	ts.Equal(m.Status, models.MsgStatusDelivered)
+	ts.Equal(null.String("S"), m.Folder)
 	ts.True(m.ModifiedOn.After(now))
 	ts.True(m.SentOn.Equal(sentOn))                     // no change
 	ts.Equal(null.String("ext0"), m.ExternalIdentifier) // no change
@@ -436,6 +439,7 @@ func (ts *ModelsTestSuite) TestMsgStatus() {
 
 	m = testsuite.ReadDBMsg(ts.T(), ts.rt, "0199df10-10dc-7e6e-834b-3d959ece93b2")
 	ts.Equal(m.Status, models.MsgStatusRead)
+	ts.Equal(null.String("S"), m.Folder)
 	ts.True(m.ModifiedOn.After(now))
 	ts.True(m.SentOn.Equal(sentOn)) // no change
 	ts.Equal([]string{string(clog1.UUID), string(clog2.UUID), string(clog3.UUID), string(clog4.UUID)}, []string(m.LogUUIDs))
@@ -451,6 +455,7 @@ func (ts *ModelsTestSuite) TestMsgStatus() {
 
 	m = testsuite.ReadDBMsg(ts.T(), ts.rt, "0199df10-9519-7fe2-a29c-c890d1713673")
 	ts.Equal(models.MsgStatusPending, m.Status)
+	ts.Equal(null.String("P"), m.Folder) // unchanged - courier never moves an incoming message out of pending
 	ts.Equal(m.ExternalIdentifier, null.String("ext2"))
 	ts.Equal([]string(nil), []string(m.LogUUIDs))
 
@@ -459,6 +464,7 @@ func (ts *ModelsTestSuite) TestMsgStatus() {
 
 	m = testsuite.ReadDBMsg(ts.T(), ts.rt, "0199df0f-9f82-7689-b02d-f34105991321")
 	ts.Equal(models.MsgStatusFailed, m.Status)
+	ts.Equal(null.String("X"), m.Folder)
 	ts.True(m.ModifiedOn.After(now))
 	ts.Nil(m.SentOn)
 	ts.Equal([]string{string(clog5.UUID)}, []string(m.LogUUIDs))
@@ -518,6 +524,7 @@ func (ts *ModelsTestSuite) TestMsgStatus() {
 
 	m = testsuite.ReadDBMsg(ts.T(), ts.rt, "0199df0f-9f82-7689-b02d-f34105991321")
 	ts.Equal(m.Status, models.MsgStatusErrored)
+	ts.Equal(null.String("O"), m.Folder) // errored messages go back to the outbox
 	ts.Equal(m.ErrorCount, 1)
 	ts.True(m.ModifiedOn.After(now))
 	ts.True(m.NextAttempt.After(now))
@@ -529,6 +536,7 @@ func (ts *ModelsTestSuite) TestMsgStatus() {
 
 	m = testsuite.ReadDBMsg(ts.T(), ts.rt, "0199df0f-9f82-7689-b02d-f34105991321")
 	ts.Equal(m.Status, models.MsgStatusErrored)
+	ts.Equal(null.String("O"), m.Folder)
 	ts.Equal(m.ErrorCount, 2)
 	ts.Equal(null.NullString, m.FailedReason)
 
@@ -537,6 +545,7 @@ func (ts *ModelsTestSuite) TestMsgStatus() {
 
 	m = testsuite.ReadDBMsg(ts.T(), ts.rt, "0199df0f-9f82-7689-b02d-f34105991321")
 	ts.Equal(m.Status, models.MsgStatusFailed)
+	ts.Equal(null.String("X"), m.Folder) // erroring past the retry limit fails the message into the failed folder
 	ts.Equal(m.ErrorCount, 3)
 	ts.Equal(null.String("E"), m.FailedReason)
 
@@ -1075,6 +1084,8 @@ func (ts *ModelsTestSuite) TestWriteMsg() {
 	ts.Equal(contactURN.ID, m.ContactURNID)
 	ts.Equal("ext123", string(m.ExternalIdentifier))
 	ts.Equal("test-write", m.Text)
+	ts.Equal(models.MsgStatusPending, m.Status)
+	ts.Equal(null.String("P"), m.Folder) // incoming messages start in the pending folder
 	ts.Equal(0, len(m.Attachments))
 	ts.Equal(now, m.SentOn.In(time.UTC))
 	ts.NotNil(m.CreatedOn)

--- a/testsuite/database.go
+++ b/testsuite/database.go
@@ -37,6 +37,7 @@ type DBMsg struct {
 	Status             models.MsgStatus     `db:"status"`
 	MsgType            string               `db:"msg_type"`
 	Visibility         models.MsgVisibility `db:"visibility"`
+	Folder             null.String          `db:"folder"`
 	HighPriority       bool                 `db:"high_priority"`
 	IsAndroid          bool                 `db:"is_android"`
 	Text               string               `db:"text"`

--- a/testsuite/testdata/data.sql
+++ b/testsuite/testdata/data.sql
@@ -46,29 +46,29 @@ INSERT INTO contacts_contacturn("id", "identity", "path", "scheme", "priority", 
 
 /** Msg with id 10000 */
 DELETE FROM msgs_msg;
-INSERT INTO msgs_msg("id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "direction", "status", "visibility", "msg_type", "is_android",
+INSERT INTO msgs_msg("id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "direction", "status", "visibility", "folder", "msg_type", "is_android",
                         "msg_count", "error_count", "next_attempt", "external_identifier", "channel_id", "contact_id", "contact_urn_id", "org_id")
-              VALUES(10000, '0199df0f-9f82-7689-b02d-f34105991321', 'test message', True, now(), now(), now(), 'O', 'W', 'V', 'T', FALSE,
+              VALUES(10000, '0199df0f-9f82-7689-b02d-f34105991321', 'test message', True, now(), now(), now(), 'O', 'W', 'V', 'S', 'T', FALSE,
                      1, 0, now(), 'ext1', 10, 100, 1000, 1);
 
-INSERT INTO msgs_msg("id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "direction", "status", "visibility", "msg_type", "is_android",
+INSERT INTO msgs_msg("id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "direction", "status", "visibility", "folder", "msg_type", "is_android",
                         "msg_count", "error_count", "next_attempt", "external_identifier", "channel_id", "contact_id", "contact_urn_id", "org_id")
-              VALUES(10001, '0199df10-10dc-7e6e-834b-3d959ece93b2', 'test message without external', True, now(), now(), now(), 'O', 'W', 'V', 'T', FALSE,
+              VALUES(10001, '0199df10-10dc-7e6e-834b-3d959ece93b2', 'test message without external', True, now(), now(), now(), 'O', 'W', 'V', 'S', 'T', FALSE,
                      1, 0, now(), '', 10, 100, 1000, 1);
 
-INSERT INTO msgs_msg("id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "direction", "status", "visibility", "msg_type", "is_android",
+INSERT INTO msgs_msg("id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "direction", "status", "visibility", "folder", "msg_type", "is_android",
                         "msg_count", "error_count", "next_attempt", "external_identifier", "channel_id", "contact_id", "contact_urn_id", "org_id")
-              VALUES(10002, '0199df10-9519-7fe2-a29c-c890d1713673', 'test message incoming', True, now(), now(), now(), 'I', 'P', 'V', 'T', FALSE,
+              VALUES(10002, '0199df10-9519-7fe2-a29c-c890d1713673', 'test message incoming', True, now(), now(), now(), 'I', 'P', 'V', 'P', 'T', FALSE,
                      1, 0, now(), 'ext2', 10, 100, 1000, 1);
 
-INSERT INTO msgs_msg("id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "direction", "status", "visibility", "msg_type", "is_android",
+INSERT INTO msgs_msg("id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "direction", "status", "visibility", "folder", "msg_type", "is_android",
                         "msg_count", "error_count", "next_attempt", "external_identifier", "channel_id", "contact_id", "contact_urn_id", "org_id")
-              VALUES(10003, '019bb1ca-a92d-78f5-ba61-06aa62f2b41a', 'test message incoming', True, now(), now(), now(), 'I', 'P', 'V', 'T', FALSE,
+              VALUES(10003, '019bb1ca-a92d-78f5-ba61-06aa62f2b41a', 'test message incoming', True, now(), now(), now(), 'I', 'P', 'V', 'P', 'T', FALSE,
                      1, 0, now(), 'ext3', 10, 100, 1000, 1);
 
-INSERT INTO msgs_msg("id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "direction", "status", "visibility", "msg_type", "is_android",
+INSERT INTO msgs_msg("id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "direction", "status", "visibility", "folder", "msg_type", "is_android",
                         "msg_count", "error_count", "next_attempt", "external_identifier", "channel_id", "contact_id", "contact_urn_id", "org_id")
-              VALUES(10005, '019bb29e-b2c6-7e5f-b980-ccb3e9e21fbc', 'test message outgoing', True, now(), now(), now(), 'O', 'W', 'V', 'T', FALSE,
+              VALUES(10005, '019bb29e-b2c6-7e5f-b980-ccb3e9e21fbc', 'test message outgoing', True, now(), now(), now(), 'O', 'W', 'V', 'S', 'T', FALSE,
                      1, 0, now(), 'ext4', 10, 100, 1000, 1);
 
 INSERT INTO msgs_media("id", "uuid", "org_id", "content_type", "url", "path", "size", "duration", "width", "height", "original_id")

--- a/testsuite/testdata/schema.sql
+++ b/testsuite/testdata/schema.sql
@@ -91,6 +91,7 @@ CREATE TABLE msgs_msg (
     direction character varying(1) NOT NULL,
     status character varying(1) NOT NULL,
     visibility character varying(1) NOT NULL,
+    folder character varying(1) NULL,
     is_android boolean NOT NULL,
     msg_count integer NOT NULL,
     high_priority boolean NULL,


### PR DESCRIPTION
## Summary

Populates the new nullable `msgs_msg.folder` column at the two places courier writes to `msgs_msg`. The column denormalizes the message folder that is currently derived from a combination of `direction`, `visibility`, `status` and `flow` predicates, so that folder listings can eventually be served by a single index. Nothing reads the column yet — this is the write side only.

Courier writes four of the eight folder codes; the rest (inbox, handled, archived, deleted) belong to message handling, archiving and deletion, which courier doesn't do.

| code | folder | written when |
|---|---|---|
| `P` | Pending | an incoming message is created |
| `O` | Outbox | an outgoing message is initializing, queued or errored |
| `S` | Sent | an outgoing message is wired, sent, delivered or read |
| `X` | Failed | an outgoing message has failed |

## Changes

**`core/models/msg.go`** — `sqlInsertIncomingMsg` writes a literal `'P'` alongside the existing hardcoded direction, status and visibility. An incoming message is pending until it is handled.

**`core/models/status.go`** — the bulk status update computes the message's new status in SQL, so folder can't be a bound parameter; it has to be derived from the same expression. The status expression is extracted into a `sqlNewMsgStatus` constant and interpolated into the statement twice — once to write `status`, once as the subject of the `CASE` that maps it to a folder — so the two cannot drift apart when the retry/fail logic is next edited.

Deriving the status once in a `LATERAL` in the `FROM` clause would be tidier, but Postgres rejects references to the `UPDATE` target from a `FROM`-list subquery (`invalid reference to FROM-clause entry`), so the single-source guarantee is provided in Go instead.

The statement derives folder from status alone and ignores `visibility`; a comment on the statement records that this holds only because nothing makes an outgoing message non-visible, so the constraint travels with the code.

**`testsuite/`** — the hand-maintained test schema gains a nullable `folder character varying(1)`; fixtures carry the folder value their status implies, and the `DBMsg` test helper gained the field.

## Behavior examples

For an outgoing message that errors repeatedly, folder tracks the status the same statement computes:

| update | resulting status | folder |
|---|---|---|
| errored, `error_count` 0 | `E` | `O` |
| errored, `error_count` 1 | `E` | `O` |
| errored, `error_count` 2 | `F` | `X` |
| wired / sent / delivered / read | `W`/`S`/`D`/`R` | `S` |

A status update for an incoming message is a no-op as before, so such a message keeps the `P` it was created with.

## Test plan

- [x] `go test -p=1 ./...` passes locally and in CI
- [x] Folder asserted at every status transition — wired, sent, delivered, read, failed, and each step of the errored-to-failed ladder, which is where status and folder are most likely to diverge
- [x] Folder asserted on the incoming insert path
- [x] Asserted that an update against an already-failed message leaves it in the failed folder
- [x] Asserted that no message touched by these paths is left with a NULL folder

## Notes

Both statements now name `folder` unconditionally, so the schema migration that adds the column has to be in place before this version runs.