### PR TITLE
Rate limit webchat chat starts per IP per channel

### DIFF
--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -3,8 +3,11 @@ package webchat
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"net"
 	"net/http"
 
+	"github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
@@ -20,6 +23,11 @@ const (
 
 	// the type of the event published to a conversation's chat socket for each outgoing message
 	eventTypeMsgOut = "msg_out"
+
+	// how many chats a single IP can start on a channel per window - generous for a real visitor (who starts
+	// one chat, ever) while capping how fast anyone can mint contacts
+	startLimit       = 10
+	startLimitWindow = 60 // seconds
 )
 
 var chatIDChars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
@@ -81,8 +89,18 @@ type startResponse struct {
 }
 
 // start is our HTTP handler for a visitor opening a chat for the first time: it mints them a new chat ID and
-// creates the contact behind it
+// creates the contact behind it.
+//
+// It's necessarily unauthenticated - it's what hands a brand new visitor their credential, and the channel UUID
+// it's addressed by is public in the widget's JS - so each request creating a contact is an abuse surface. The
+// per-IP throttle below caps how fast a single caller can mint contacts; a distributed flood is left to
+// edge-level protection like any other unauthenticated endpoint.
 func (h *handler) start(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
+	if !h.allowStart(channel, r) {
+		channels.LogRequestError(r, channel, fmt.Errorf("rate limit exceeded"))
+		return nil, channels.WriteError(w, http.StatusTooManyRequests, fmt.Errorf("rate limit exceeded"))
+	}
+
 	// a chat ID is a bearer credential - possession is the only thing that identifies a webchat visitor - so it
 	// comes from a CSPRNG (24 chars of [a-zA-Z0-9] is ~143 bits of entropy)
 	chatID := random.SecureString(chatIDLength, chatIDChars)
@@ -99,6 +117,36 @@ func (h *handler) start(ctx context.Context, channel *models.Channel, w http.Res
 	w.WriteHeader(http.StatusOK)
 	w.Write(jsonx.MustMarshal(&startResponse{ChatID: chatID}))
 	return nil, nil
+}
+
+// allowStart checks the requesting IP against the channel's start rate limit, counting requests in fixed windows
+// with a valkey key that expires with the window
+func (h *handler) allowStart(channel *models.Channel, r *http.Request) bool {
+	// the server's RealIP middleware has already resolved forwarded headers into RemoteAddr, which may or may
+	// not still carry a port
+	ip := r.RemoteAddr
+	if host, _, err := net.SplitHostPort(ip); err == nil {
+		ip = host
+	}
+
+	key := fmt.Sprintf("chat-starts:%s|%s", channel.UUID(), ip)
+
+	rc := h.Runtime().VK.Get()
+	defer rc.Close()
+
+	count, err := redis.Int(rc.Do("INCR", key))
+	if err != nil {
+		// a valkey problem shouldn't stop visitors starting chats so proceed unthrottled
+		slog.Error("error checking chat start rate limit", "error", err, "key", key)
+		return true
+	}
+	if count == 1 {
+		if _, err := rc.Do("EXPIRE", key, startLimitWindow); err != nil {
+			slog.Error("error setting chat start rate limit expiry", "error", err, "key", key)
+		}
+	}
+
+	return count <= startLimit
 }
 
 type receivePayload struct {

--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -93,7 +93,9 @@ type startResponse struct {
 //
 // It's necessarily unauthenticated - it's what hands a brand new visitor their credential, and the channel UUID
 // it's addressed by is public in the widget's JS - so each request creating a contact is an abuse surface. The
-// per-IP throttle below caps how fast a single caller can mint contacts; a distributed flood is left to
+// per-IP throttle below caps how fast a single caller can mint contacts - but only if the IP is trustworthy:
+// the server's RealIP middleware takes it from forwarded headers without a trusted-proxy allowlist, so this
+// relies on the edge overwriting client-supplied headers. Spoofed-header and distributed floods are left to
 // edge-level protection like any other unauthenticated endpoint.
 func (h *handler) start(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
 	if !h.allowStart(channel, r) {
@@ -119,8 +121,8 @@ func (h *handler) start(ctx context.Context, channel *models.Channel, w http.Res
 	return nil, nil
 }
 
-// allowStart checks the requesting IP against the channel's start rate limit, counting requests in fixed windows
-// with a valkey key that expires with the window
+// allowStart checks the requesting IP against the channel's start rate limit, counting requests in a valkey key
+// whose TTL slides with each request and expires one window after the last
 func (h *handler) allowStart(channel *models.Channel, r *http.Request) bool {
 	// the server's RealIP middleware has already resolved forwarded headers into RemoteAddr, which may or may
 	// not still carry a port
@@ -140,10 +142,11 @@ func (h *handler) allowStart(channel *models.Channel, r *http.Request) bool {
 		slog.Error("error checking chat start rate limit", "error", err, "key", key)
 		return true
 	}
-	if count == 1 {
-		if _, err := rc.Do("EXPIRE", key, startLimitWindow); err != nil {
-			slog.Error("error setting chat start rate limit expiry", "error", err, "key", key)
-		}
+	// re-arm the TTL on every request rather than only the first: INCR + EXPIRE isn't atomic, and a key left
+	// behind by a lost EXPIRE would otherwise count forever and permanently block the IP. The result is a
+	// sliding window - continuous callers stay throttled, which is fine for a start-flood cap.
+	if _, err := rc.Do("EXPIRE", key, startLimitWindow); err != nil {
+		slog.Error("error setting chat start rate limit expiry", "error", err, "key", key)
 	}
 
 	return count <= startLimit

--- a/handlers/webchat/handler_test.go
+++ b/handlers/webchat/handler_test.go
@@ -90,17 +90,21 @@ func TestStartRateLimit(t *testing.T) {
 	testsuite.ResetDB(t, rt)
 	testsuite.ResetValkey(t, rt)
 
+	const otherChannelUUID = "b81c3f45-2d6e-4a1f-9c72-8e5d0a4b6f13"
+
 	s := web.NewServer(rt)
 	testsuite.InsertChannel(t, rt, testChannels[0])
+	testsuite.InsertChannel(t, rt, test.NewMockChannel(otherChannelUUID, "WCH", "", "", []string{urns.WebChat.Prefix}, nil))
 	require.NoError(t, s.MountHandler(newHandler()))
 
-	start := func(ip string) *httptest.ResponseRecorder {
-		req, _ := http.NewRequest(http.MethodPost, "https://localhost"+startURL, strings.NewReader(`{}`))
+	startOn := func(chURL, ip string) *httptest.ResponseRecorder {
+		req, _ := http.NewRequest(http.MethodPost, "https://localhost"+chURL, strings.NewReader(`{}`))
 		req.RemoteAddr = ip
 		rr := httptest.NewRecorder()
 		s.Router().ServeHTTP(rr, req)
 		return rr
 	}
+	start := func(ip string) *httptest.ResponseRecorder { return startOn(startURL, ip) }
 
 	// an IP can start up to the limit of chats within the window...
 	for i := range startLimit {
@@ -120,6 +124,9 @@ func TestStartRateLimit(t *testing.T) {
 
 	// but other IPs aren't affected
 	assert.Equal(t, 200, start("41.23.45.68:1234").Code)
+
+	// nor is the same IP on a different channel - the limit is scoped per channel
+	assert.Equal(t, 200, startOn("/c/wch/"+otherChannelUUID+"/start", "41.23.45.67:1234").Code)
 
 	// and the count expires with the window
 	vc := rt.VK.Get()

--- a/handlers/webchat/handler_test.go
+++ b/handlers/webchat/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
@@ -82,6 +83,51 @@ func TestIncoming(t *testing.T) {
 	defer random.SetSecureSource(random.DefaultSecureSource)
 
 	RunIncomingTestCases(t, testChannels, newHandler(), incomingCases)
+}
+
+func TestStartRateLimit(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+	testsuite.ResetDB(t, rt)
+	testsuite.ResetValkey(t, rt)
+
+	s := web.NewServer(rt)
+	testsuite.InsertChannel(t, rt, testChannels[0])
+	require.NoError(t, s.MountHandler(newHandler()))
+
+	start := func(ip string) *httptest.ResponseRecorder {
+		req, _ := http.NewRequest(http.MethodPost, "https://localhost"+startURL, strings.NewReader(`{}`))
+		req.RemoteAddr = ip
+		rr := httptest.NewRecorder()
+		s.Router().ServeHTTP(rr, req)
+		return rr
+	}
+
+	// an IP can start up to the limit of chats within the window...
+	for i := range startLimit {
+		assert.Equal(t, 200, start("41.23.45.67:1234").Code, "start %d", i)
+	}
+
+	// ...then gets throttled, with the CORS header still on the error so the widget can read it
+	rr := start("41.23.45.67:1234")
+	assert.Equal(t, 429, rr.Code)
+	assert.Contains(t, rr.Body.String(), "rate limit exceeded")
+	assert.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"))
+
+	// without a contact being created
+	var contacts int
+	require.NoError(t, rt.DB.Get(&contacts, `SELECT count(*) FROM contacts_contact WHERE uuid != 'a984069d-0008-4d8c-a772-b14a8a6acccc'`))
+	assert.Equal(t, startLimit, contacts)
+
+	// but other IPs aren't affected
+	assert.Equal(t, 200, start("41.23.45.68:1234").Code)
+
+	// and the count expires with the window
+	vc := rt.VK.Get()
+	defer vc.Close()
+	ttl, err := redis.Int(vc.Do("TTL", "chat-starts:"+channelUUID+"|41.23.45.67"))
+	require.NoError(t, err)
+	assert.Greater(t, ttl, 0)
+	assert.LessOrEqual(t, ttl, startLimitWindow)
 }
 
 // the framework can't assert response headers or make OPTIONS requests, so CORS support is tested directly


### PR DESCRIPTION
Follow-up to #1140. The WebChat `start` endpoint is necessarily unauthenticated — it's what hands a brand new visitor their chat ID, and the channel UUID it's addressed by is public in the widget's JS — so each request creating a contact + URN made it an open contact-flooding vector.

### Changes

- `start` now enforces a per-IP, per-channel limit of 10 starts per 60s, counted in a valkey key (same style as the event-send throttle). The key's TTL is re-armed on every request — `INCR` + `EXPIRE` isn't atomic, so a first-request-only `EXPIRE` could leave a lost key counting forever and permanently block the IP; the sliding window self-heals and keeps continuous abuse throttled.
- Over the limit returns `429` with the CORS header intact (so the widget can read it) without creating anything; a valkey error proceeds unthrottled rather than blocking real visitors.
- The handler documents the load-bearing assumptions: the client IP comes from forwarded headers via the `RealIP` middleware with no trusted-proxy allowlist, so the throttle relies on the edge overwriting client-supplied headers — spoofed-header and distributed floods remain edge-level protection's job, like any other unauthenticated endpoint.

### Test plan

`TestStartRateLimit` covers the limit boundary, the 429 response (body + CORS header), that no contact is created when throttled, per-IP and per-channel scoping of the limit, and the key's TTL bounds. Full handler suite green.