### PR TITLE
Fix log type of Kannel status report logs

### DIFF
--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -45,7 +45,7 @@ func newHandler() channels.Handler {
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.Add(h, http.MethodGet, "status", models.ChannelLogTypeMsgReceive, h.receiveStatus)
+	r.Add(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Kannel's delivery status route was registered with channel log type `msg_receive` instead of `msg_status`, so channel logs for incoming status reports on Kannel channels were mislabeled. This was a copy-paste slip dating back to when per-route log types were introduced (c8e241be) — every other handler's status route got `msg_status`.

## Changes

- `handlers/kannel/handler.go`: register the `status` route with `ChannelLogTypeMsgStatus` instead of `ChannelLogTypeMsgReceive`.

## Behavior

| | Before | After |
|---|---|---|
| Log type of a Kannel DLR request | `msg_receive` | `msg_status` |

## Test plan

- [x] `go test -p=1 ./...` passes