### PR TITLE
Enforce allowed domains for webchat channels

### DIFF
--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -83,10 +83,12 @@ func withCORS(fn channels.HandleFunc) channels.HandleFunc {
 		domains := allowedDomains(channel)
 		origin := r.Header.Get("Origin")
 
-		if len(domains) > 0 && origin != "" {
-			// this response depends on the request's origin so caches must vary on it too
+		if len(domains) > 0 {
+			// every branch below picks the allow-origin value from the request's origin so caches must vary on it
 			w.Header().Add("Vary", "Origin")
+		}
 
+		if len(domains) > 0 && origin != "" {
 			if !originAllowed(origin, domains) {
 				// deliberately no allow-origin header on this response, so the embedding page's browser also
 				// blocks it from reading the error

--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -6,6 +6,9 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
+	"slices"
+	"strings"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/courier/v26/core/channels"
@@ -20,6 +23,10 @@ import (
 
 const (
 	chatIDLength = 24
+
+	// optional channel config: the host[:port] values (no scheme) of the sites the widget may be embedded on -
+	// empty or absent means unrestricted
+	configAllowedDomains = "allowed_domains"
 
 	// the type of the event published to a conversation's chat socket for each outgoing message
 	eventTypeMsgOut = "msg_out"
@@ -64,17 +71,65 @@ func (h *handler) GetChannel(ctx context.Context, r *http.Request) (*models.Chan
 	return h.BaseHandler.GetChannel(ctx, r)
 }
 
-// withCORS wraps a handler function to set the CORS header that all responses on our public endpoints need -
-// error responses included, or the widget's browser couldn't read them - because the widget calls from
-// third-party origins
+// withCORS wraps a handler function to enforce the channel's allowed domains and set the CORS header that all
+// responses on our public endpoints need - error responses included, or the widget's browser couldn't read
+// them - because the widget calls from third-party origins.
+//
+// Allowed domains are an anti-embedding control for real browsers, which send a genuine Origin header - not an
+// anti-abuse control, since scripted clients can spoof or omit Origin freely (the start rate limit and edge
+// protection cover those) - so a request without an Origin header always passes.
 func withCORS(fn channels.HandleFunc) channels.HandleFunc {
 	return func(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		domains := allowedDomains(channel)
+		origin := r.Header.Get("Origin")
+
+		if len(domains) > 0 && origin != "" {
+			// this response depends on the request's origin so caches must vary on it too
+			w.Header().Add("Vary", "Origin")
+
+			if !originAllowed(origin, domains) {
+				// deliberately no allow-origin header on this response, so the embedding page's browser also
+				// blocks it from reading the error
+				channels.LogRequestError(r, channel, fmt.Errorf("origin not allowed: %s", origin))
+				return nil, channels.WriteError(w, http.StatusForbidden, fmt.Errorf("origin not allowed"))
+			}
+
+			// reflect the specific origin instead of * so only pages on allowed domains get readable responses
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+		} else {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+		}
+
 		return fn(ctx, channel, w, r, clog)
 	}
 }
 
-// preflight is our HTTP handler for CORS preflight requests to the start and receive endpoints
+// allowedDomains reads the channel's allowed_domains config as a list of host[:port] strings
+func allowedDomains(channel *models.Channel) []string {
+	vals, _ := channel.ConfigForKey(configAllowedDomains, nil).([]any)
+	domains := make([]string, 0, len(vals))
+	for _, val := range vals {
+		if s, ok := val.(string); ok {
+			domains = append(domains, s)
+		}
+	}
+	return domains
+}
+
+// originAllowed parses an Origin header value (scheme://host[:port]) and checks whether its host[:port]
+// matches one of the configured domains, case-insensitively
+func originAllowed(origin string, domains []string) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return slices.ContainsFunc(domains, func(d string) bool { return strings.EqualFold(d, u.Host) })
+}
+
+// preflight is our HTTP handler for CORS preflight requests to the start and receive endpoints. The channel
+// deliberately isn't loaded here (see GetChannel) so preflights can't check allowed domains and stay
+// permissive - that's fine because the browser is gated by the allow-origin header on the actual POST
+// response, which does check them.
 func (h *handler) preflight(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")

--- a/handlers/webchat/handler_test.go
+++ b/handlers/webchat/handler_test.go
@@ -236,9 +236,11 @@ func TestAllowedDomains(t *testing.T) {
 	require.NoError(t, rt.DB.Get(&contacts, `SELECT count(*) FROM contacts_contact WHERE uuid != 'a984069d-0008-4d8c-a772-b14a8a6acccc'`))
 	assert.Equal(t, 4, contacts)
 
-	// but a request with no Origin header (a non-browser client) passes
+	// but a request with no Origin header (a non-browser client) passes, still marked as varying on origin
 	rr = request(cfgStartURL, "")
 	assert.Equal(t, 200, rr.Code)
+	assert.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "Origin", rr.Header().Get("Vary"))
 
 	// and preflights stay permissive - the channel isn't loaded for them, and the POST response is what gates
 	// the browser

--- a/handlers/webchat/handler_test.go
+++ b/handlers/webchat/handler_test.go
@@ -173,6 +173,83 @@ func TestCORS(t *testing.T) {
 	assert.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"))
 }
 
+func TestAllowedDomains(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+	testsuite.ResetDB(t, rt)
+	testsuite.ResetValkey(t, rt)
+
+	const cfgChannelUUID = "7d3fb8a2-5c1e-4b9f-a6d4-2e8c0f7b5a19"
+	cfgStartURL := "/c/wch/" + cfgChannelUUID + "/start"
+	cfgReceiveURL := "/c/wch/" + cfgChannelUUID + "/receive"
+
+	s := web.NewServer(rt)
+	testsuite.InsertChannel(t, rt, testChannels[0])
+	testsuite.InsertChannel(t, rt, test.NewMockChannel(cfgChannelUUID, "WCH", "", "", []string{urns.WebChat.Prefix},
+		map[string]any{"allowed_domains": []string{"example.com", "localhost:3000"}},
+	))
+	require.NoError(t, s.MountHandler(newHandler()))
+
+	request := func(path, origin string) *httptest.ResponseRecorder {
+		req, _ := http.NewRequest(http.MethodPost, "https://localhost"+path, strings.NewReader(`{}`))
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		rr := httptest.NewRecorder()
+		s.Router().ServeHTTP(rr, req)
+		return rr
+	}
+
+	// a channel without allowed_domains ignores the origin and keeps the wildcard header
+	rr := request(startURL, "https://anywhere.com")
+	assert.Equal(t, 200, rr.Code)
+	assert.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"))
+
+	// an allowed origin gets itself reflected back instead of the wildcard, with Vary: Origin
+	rr = request(cfgStartURL, "https://example.com")
+	assert.Equal(t, 200, rr.Code)
+	assert.Equal(t, "https://example.com", rr.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "Origin", rr.Header().Get("Vary"))
+
+	// host matching is case-insensitive, and entries can carry a port
+	rr = request(cfgStartURL, "https://EXAMPLE.com")
+	assert.Equal(t, 200, rr.Code)
+	assert.Equal(t, "https://EXAMPLE.com", rr.Header().Get("Access-Control-Allow-Origin"))
+	rr = request(cfgStartURL, "http://localhost:3000")
+	assert.Equal(t, 200, rr.Code)
+	assert.Equal(t, "http://localhost:3000", rr.Header().Get("Access-Control-Allow-Origin"))
+
+	// a disallowed origin gets a 403 with no allow-origin header, so the embedding page can't read it either
+	for _, origin := range []string{"https://evil.com", "https://sub.example.com", "https://example.com:8080", "null"} {
+		rr = request(cfgStartURL, origin)
+		assert.Equal(t, 403, rr.Code, origin)
+		assert.Contains(t, rr.Body.String(), "origin not allowed", origin)
+		assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"), origin)
+	}
+
+	// on the receive endpoint too
+	rr = request(cfgReceiveURL, "https://evil.com")
+	assert.Equal(t, 403, rr.Code)
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+
+	// without any contacts being created by the blocked starts
+	var contacts int
+	require.NoError(t, rt.DB.Get(&contacts, `SELECT count(*) FROM contacts_contact WHERE uuid != 'a984069d-0008-4d8c-a772-b14a8a6acccc'`))
+	assert.Equal(t, 4, contacts)
+
+	// but a request with no Origin header (a non-browser client) passes
+	rr = request(cfgStartURL, "")
+	assert.Equal(t, 200, rr.Code)
+
+	// and preflights stay permissive - the channel isn't loaded for them, and the POST response is what gates
+	// the browser
+	req, _ := http.NewRequest(http.MethodOptions, "https://localhost"+cfgStartURL, nil)
+	req.Header.Set("Origin", "https://evil.com")
+	rr = httptest.NewRecorder()
+	s.Router().ServeHTTP(rr, req)
+	assert.Equal(t, 204, rr.Code)
+	assert.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
 // sends don't make HTTP requests so the framework's outgoing cases don't fit - instead we test the socket
 // publishes directly
 func TestOutgoing(t *testing.T) {


### PR DESCRIPTION
A webchat channel's config may now include an `allowed_domains` key — a list of `host[:port]` values naming the sites the chat widget may be embedded on. When set, the `start` and `receive` endpoints check the request's `Origin` header against the list:

- An allowed origin gets it reflected back as `Access-Control-Allow-Origin` instead of the wildcard.
- A disallowed origin gets a 403 with no allow-origin header, so the embedding page's browser also blocks it from reading the response.
- A request with no `Origin` header passes — this is an anti-embedding control for real browsers, not an anti-abuse control, since scripted clients can spoof or omit `Origin` freely (the start rate limit covers that).
- All responses on a domain-restricted channel carry `Vary: Origin`, since the allow-origin value depends on the request's origin in every branch.

Channels without `allowed_domains` are unchanged (wildcard CORS, no origin checks). Host matching is case-insensitive and exact — no subdomain or port wildcards. CORS preflights stay permissive since the channel isn't loaded for them and the actual POST response's header is what gates the browser.