### PR TITLE
Don't store channel logs for channel types whose traffic is internal to the platform

### DIFF
--- a/core/channels/handler.go
+++ b/core/channels/handler.go
@@ -34,6 +34,13 @@ type Handler interface {
 	ChannelType() models.ChannelType
 	ChannelName() string
 	UseChannelRouteUUID() bool
+
+	// StoreChannelLogs returns whether channel logs for this handler's channels should be persisted for users
+	// to view. Channel types whose traffic is internal to the platform rather than with an external provider
+	// don't store them - the logs still exist in memory during handling so errors reach server logging and
+	// message statuses as usual.
+	StoreChannelLogs() bool
+
 	RedactValues(*models.Channel) []string
 	GetChannel(context.Context, *http.Request) (*models.Channel, error)
 	Send(context.Context, *models.MsgOut, *SendResult, *models.ChannelLog) error

--- a/core/sender/sender.go
+++ b/core/sender/sender.go
@@ -224,8 +224,10 @@ func (w *Sender) sendMessage(msg *models.MsgOut) {
 
 	clog.End()
 
-	// write our logs as well
-	models.WriteChannelLog(rt, clog)
+	// write our logs as well - unless this channel type doesn't store them
+	if handler == nil || handler.StoreChannelLogs() {
+		models.WriteChannelLog(rt, clog)
+	}
 
 	// mark our send task as complete
 	var newURN urns.URN

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -23,6 +23,7 @@ type BaseHandler struct {
 	name               string
 	rt                 *runtime.Runtime
 	uuidChannelRouting bool
+	storeChannelLogs   bool
 	redactConfigKeys   []string
 }
 
@@ -32,6 +33,7 @@ func NewBaseHandler(channelType models.ChannelType, name string, options ...func
 		channelType:        channelType,
 		name:               name,
 		uuidChannelRouting: true,
+		storeChannelLogs:   true,
 		redactConfigKeys:   defaultRedactConfigKeys,
 	}
 	for _, o := range options {
@@ -43,6 +45,14 @@ func NewBaseHandler(channelType models.ChannelType, name string, options ...func
 func DisableUUIDRouting() func(*BaseHandler) {
 	return func(s *BaseHandler) {
 		s.uuidChannelRouting = false
+	}
+}
+
+// DisableChannelLogStorage is for channel types whose traffic is internal to the platform - their channel logs
+// wouldn't describe anything users could act on, so they aren't persisted for them to view
+func DisableChannelLogStorage() func(*BaseHandler) {
+	return func(s *BaseHandler) {
+		s.storeChannelLogs = false
 	}
 }
 
@@ -75,6 +85,11 @@ func (h *BaseHandler) ChannelName() string {
 // UseChannelRouteUUID returns whether the router should use the channel UUID in the URL path
 func (h *BaseHandler) UseChannelRouteUUID() bool {
 	return h.uuidChannelRouting
+}
+
+// StoreChannelLogs returns whether channel logs for this handler's channels should be persisted for users to view
+func (h *BaseHandler) StoreChannelLogs() bool {
+	return h.storeChannelLogs
 }
 
 func (h *BaseHandler) RedactValues(ch *models.Channel) []string {

--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -48,7 +48,10 @@ type handler struct {
 }
 
 func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("WCH"), "WebChat")}
+	// webchat has no external provider - sends are publishes to our own realtime server and start/receive are
+	// our own public endpoints - so its channel logs would only describe internal infrastructure and aren't
+	// stored for users
+	return &handler{handlers.NewBaseHandler(models.ChannelType("WCH"), "WebChat", handlers.DisableChannelLogStorage())}
 }
 
 // Initialize is called by the engine once everything is loaded

--- a/handlers/webchat/handler_test.go
+++ b/handlers/webchat/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/testsuite"
 	"github.com/nyaruka/courier/v26/web"
+	"github.com/nyaruka/gocommon/aws/dynamo/dyntest"
 	"github.com/nyaruka/gocommon/centrifugo"
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/random"
@@ -83,6 +84,47 @@ func TestIncoming(t *testing.T) {
 	defer random.SetSecureSource(random.DefaultSecureSource)
 
 	RunIncomingTestCases(t, testChannels, newHandler(), incomingCases)
+}
+
+// webchat traffic is internal to the platform so its channel logs are never stored - each visitor request
+// would otherwise write one
+func TestChannelLogsNotStored(t *testing.T) {
+	_, rt := testsuite.Runtime(t)
+	testsuite.ResetDB(t, rt)
+	testsuite.ResetValkey(t, rt)
+	dyntest.Truncate(t, rt.Dynamo.Main.Client(), rt.Dynamo.Main.Table())
+
+	random.SetSecureSource(random.NewSeededSource(1234))
+	defer random.SetSecureSource(random.DefaultSecureSource)
+
+	s := web.NewServer(rt)
+	testsuite.InsertChannel(t, rt, testChannels[0])
+	require.NoError(t, s.MountHandler(newHandler()))
+
+	// capture the in-memory logs of handled requests
+	var clogs []*models.ChannelLog
+	s.OnRequestHandled(func(ch *models.Channel, evts []channels.Event, clog *models.ChannelLog) { clogs = append(clogs, clog) })
+
+	post := func(path, body string) *httptest.ResponseRecorder {
+		req, _ := http.NewRequest(http.MethodPost, "https://localhost"+path, strings.NewReader(body))
+		rr := httptest.NewRecorder()
+		s.Router().ServeHTTP(rr, req)
+		return rr
+	}
+
+	assert.Equal(t, 200, post(startURL, `{}`).Code)
+	assert.Equal(t, 200, post(receiveURL, `{"chat_id": "`+testChatID+`", "text": "Hello"}`).Code)
+
+	// the logs still exist in memory during handling...
+	require.Len(t, clogs, 2)
+	assert.Equal(t, models.ChannelLogTypeChatStart, clogs[0].Type)
+	assert.Equal(t, models.ChannelLogTypeMsgReceive, clogs[1].Type)
+
+	// ...but are never written to storage
+	rt.Dynamo.Main.Flush()
+	for _, item := range dyntest.ScanAll(t, rt.Dynamo.Main.Client(), rt.Dynamo.Main.Table()) {
+		assert.False(t, strings.HasPrefix(item.Key.SK, "log#"), "unexpected channel log stored: %s", item.Key.SK)
+	}
 }
 
 func TestStartRateLimit(t *testing.T) {

--- a/test/handler.go
+++ b/test/handler.go
@@ -34,6 +34,7 @@ func (h *mockHandler) SetRuntime(rt *runtime.Runtime)        { h.rt = rt }
 func (h *mockHandler) ChannelName() string                   { return "Mock Handler" }
 func (h *mockHandler) ChannelType() models.ChannelType       { return models.ChannelType("MCK") }
 func (h *mockHandler) UseChannelRouteUUID() bool             { return true }
+func (h *mockHandler) StoreChannelLogs() bool                { return true }
 func (h *mockHandler) RedactValues(*models.Channel) []string { return []string{"sesame"} }
 
 func (h *mockHandler) GetChannel(ctx context.Context, r *http.Request) (*models.Channel, error) {

--- a/web/attachments.go
+++ b/web/attachments.go
@@ -59,13 +59,16 @@ func fetchAttachment(ctx context.Context, rt *runtime.Runtime, r *http.Request) 
 		return nil, fmt.Errorf("error getting channel: %w", err)
 	}
 
-	clog := models.NewChannelLogForAttachmentFetch(ch, channels.GetHandler(ch.ChannelType()).RedactValues(ch))
+	handler := channels.GetHandler(ch.ChannelType())
+	clog := models.NewChannelLogForAttachmentFetch(ch, handler.RedactValues(ch))
 
 	attachment, err := FetchAndStoreAttachment(ctx, rt, ch, fa.URL, clog)
 
 	// try to write channel log even if we have an error
 	clog.End()
-	models.WriteChannelLog(rt, clog)
+	if handler.StoreChannelLogs() {
+		models.WriteChannelLog(rt, clog)
+	}
 
 	if err != nil {
 		return nil, fmt.Errorf("error fetching attachment for msg %s: %w", fa.MsgUUID, err)

--- a/web/events.go
+++ b/web/events.go
@@ -130,7 +130,7 @@ func sendEvent(ctx context.Context, s *Server, r *http.Request) (*sendEventRespo
 
 	// event sends are frequent and boring when they succeed so we only write logs for errors
 	clog.End()
-	if clog.IsError() {
+	if clog.IsError() && handler.StoreChannelLogs() {
 		models.WriteChannelLog(s.rt, clog)
 	}
 

--- a/web/server.go
+++ b/web/server.go
@@ -315,7 +315,9 @@ func (s *Server) channelHandleWrapper(handler channels.Handler, handlerFunc chan
 
 			clog.End()
 
-			models.WriteChannelLog(s.rt, clog)
+			if handler.StoreChannelLogs() {
+				models.WriteChannelLog(s.rt, clog)
+			}
 
 			s.rt.Stats.RecordIncoming(string(channel.ChannelType()), numMsgs, numStatuses, numEvents, numIgnored, clog.Elapsed)
 

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/core/sender"
+	_ "github.com/nyaruka/courier/v26/handlers/webchat" // for a channel type that doesn't store channel logs
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/testsuite"
@@ -42,6 +43,7 @@ func serverRuntime(t *testing.T) *runtime.Runtime {
 
 func TestIncoming(t *testing.T) {
 	rt := serverRuntime(t)
+	dyntest.Truncate(t, rt.Dynamo.Main.Client(), rt.Dynamo.Main.Table())
 
 	s := web.NewServer(rt)
 
@@ -78,6 +80,16 @@ func TestIncoming(t *testing.T) {
 	if assert.Len(t, clogs, 2) {
 		assert.Len(t, clogs[1].HttpLogs, 1)
 	}
+
+	// and both logs should be written to storage since this channel type stores them
+	rt.Dynamo.Main.Flush()
+	stored := 0
+	for _, item := range dyntest.ScanAll(t, rt.Dynamo.Main.Client(), rt.Dynamo.Main.Table()) {
+		if strings.HasPrefix(item.Key.SK, "log#") && item.Data["type"] == "msg_receive" {
+			stored++
+		}
+	}
+	assert.Equal(t, 2, stored)
 }
 
 func TestOutgoing(t *testing.T) {
@@ -219,6 +231,27 @@ func TestOutgoing(t *testing.T) {
 	var numStopEvents int
 	require.NoError(t, rt.DB.Get(&numStopEvents, `SELECT count(*) FROM channels_channelevent WHERE event_type = 'stop_contact'`))
 	assert.Equal(t, 1, numStopEvents)
+
+	// queue a message on a webchat channel - a type that doesn't store channel logs - it should still be
+	// sent (an internal publish) and marked as wired...
+	wchChannel := test.NewMockChannel("0665bf36-4d2e-4c3f-b8a1-9f8e6a5c2d71", "WCH", "", "", []string{urns.WebChat.Prefix}, nil)
+	testsuite.InsertChannel(t, rt, wchChannel)
+
+	wchMsg := &models.MsgOut{
+		OrgID_: 1, UUID_: "0199df05-a01b-7000-8f5e-2c3d4e5f6a7b", Contact_: &models.ContactReference{ID: 100, UUID: "a984069d-0008-4d8c-a772-b14a8a6acccc"},
+		Text_: "hi", HighPriority_: true, CreatedOn_: time.Now(), ChannelUUID_: wchChannel.UUID(), URN_: "webchat:65vbbDAQCdPdEWlEhDGy4utO", Origin_: models.MsgOriginChat,
+	}
+	insertMsg(wchMsg.UUID_, wchChannel)
+	rc = rt.VK.Get()
+	require.NoError(t, queue.PushOntoQueue(rc, "msgs", string(wchChannel.UUID()), 10, "["+string(jsonx.MustMarshal(wchMsg))+"]", queue.HighPriority))
+	rc.Close()
+	assertStatus(wchMsg.UUID_, models.MsgStatusWired)
+
+	// ...but without a channel log being stored for it
+	rt.Dynamo.Main.Flush()
+	for _, item := range dyntest.ScanAll(t, rt.Dynamo.Main.Client(), rt.Dynamo.Main.Table()) {
+		assert.False(t, strings.HasPrefix(item.Key.PK, "cha#"+string(wchChannel.UUID())), "unexpected channel log stored for webchat channel")
+	}
 }
 
 func TestFetchAttachment(t *testing.T) {
@@ -240,6 +273,9 @@ func TestFetchAttachment(t *testing.T) {
 		},
 		"http://mock.com/media/hello.pdf": {
 			httpx.MockConnectionError,
+		},
+		"http://mock.com/media/hello2.jpg": {
+			httpx.NewMockResponse(200, nil, testJPG),
 		},
 	})
 	require.NoError(t, server.Start())
@@ -298,7 +334,13 @@ func TestFetchAttachment(t *testing.T) {
 	assert.Equal(t, 200, statusCode)
 	assert.JSONEq(t, `{"attachment": {"content_type": "unavailable", "url": "http://mock.com/media/hello.pdf", "size": 0}, "log_uuid": "0191e180-8530-7000-8920-17713634b9f5"}`, string(respBody))
 
-	// and channel logs should have been written for the fetches
+	// a fetch for a channel type that doesn't store channel logs still works
+	testsuite.InsertChannel(t, rt, test.NewMockChannel("0665bf36-4d2e-4c3f-b8a1-9f8e6a5c2d71", "WCH", "", "", []string{urns.WebChat.Prefix}, nil))
+	statusCode, respBody = submit(`{"channel_uuid": "0665bf36-4d2e-4c3f-b8a1-9f8e6a5c2d71", "channel_type": "WCH", "url": "http://mock.com/media/hello2.jpg"}`, "sesame")
+	assert.Equal(t, 200, statusCode)
+	assert.Contains(t, string(respBody), `"image/jpeg"`)
+
+	// and channel logs should have been written for the fetches - except the webchat one
 	require.Eventually(t, func() bool {
 		count := 0
 		for _, item := range dyntest.ScanAll(t, rt.Dynamo.Main.Client(), rt.Dynamo.Main.Table()) {


### PR DESCRIPTION
## Summary

Channel logs exist so users can debug their integration with an external provider. A channel type like webchat has no external provider — sends are publishes to the platform's own realtime server and start/receive are the platform's own public chat endpoints — so its logs are either empty or would only describe internal infrastructure that users can't act on. Storing them would also mean writing a log per visitor HTTP request. This adds a channel-type level trait for such types and declares it on the webchat handler, so their channel logs are no longer persisted.

Only storage is skipped: the in-memory `ChannelLog` still exists during request handling, errors still reach message statuses and the server's own structured logging, and msg/status records still record log UUIDs as before (the UI for such channel types shouldn't offer log views).

## Changes

- `channels.Handler` gains `StoreChannelLogs() bool`, following the existing `UseChannelRouteUUID` pattern: `BaseHandler` defaults it to true, with a `DisableChannelLogStorage()` option for handlers to declare the trait.
- The webchat handler declares `DisableChannelLogStorage()`.
- All four persistence call sites now check the trait before writing: incoming request handling (`web/server.go`), message sends (`core/sender`, still writing when no handler exists for the channel type), event sends (`web/events.go`), and attachment fetches (`web/attachments.go`).
- The test mock handler (the only `Handler` implementer not embedding `BaseHandler`) implements the new method.

## Test plan

- New `TestChannelLogsNotStored` in `handlers/webchat` drives start + receive through a real server and asserts the in-memory logs still reach the request-handled callback but nothing is written to DynamoDB.
- `web/server_test.go` covers the contrast and the other paths: incoming logs for a storing channel type are persisted, a message queued through the real sender on a webchat channel is wired without a stored log, and an attachment fetch for a webchat channel works without writing a log while the other fetches still do.
- Full suite run: `go test -p=1 ./...` green.