### PR TITLE
Include attachments and quick replies in webchat msg_out events

### DIFF
--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -550,7 +550,6 @@ func (m *MsgOut) Channel() *Channel            { return m.Channel_ }
 func (m *MsgOut) Contact() *ContactReference   { return m.Contact_ }
 func (m *MsgOut) Text() string                 { return m.Text_ }
 func (m *MsgOut) Attachments() []string        { return m.Attachments_ }
-func (m *MsgOut) CreatedOn() time.Time         { return m.CreatedOn_ }
 func (m *MsgOut) URN() urns.URN                { return m.URN_ }
 func (m *MsgOut) QuickReplies() []QuickReply   { return m.QuickReplies_ }
 func (m *MsgOut) Locale() i18n.Locale          { return m.Locale_ }

--- a/core/models/msg.go
+++ b/core/models/msg.go
@@ -550,6 +550,7 @@ func (m *MsgOut) Channel() *Channel            { return m.Channel_ }
 func (m *MsgOut) Contact() *ContactReference   { return m.Contact_ }
 func (m *MsgOut) Text() string                 { return m.Text_ }
 func (m *MsgOut) Attachments() []string        { return m.Attachments_ }
+func (m *MsgOut) CreatedOn() time.Time         { return m.CreatedOn_ }
 func (m *MsgOut) URN() urns.URN                { return m.URN_ }
 func (m *MsgOut) QuickReplies() []QuickReply   { return m.QuickReplies_ }
 func (m *MsgOut) Locale() i18n.Locale          { return m.Locale_ }

--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -18,7 +18,9 @@ import (
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/random"
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/events"
+	"github.com/nyaruka/goflow/utils"
 )
 
 const (
@@ -27,9 +29,6 @@ const (
 	// optional channel config: the host[:port] values (no scheme) of the sites the widget may be embedded on -
 	// empty or absent means unrestricted
 	configAllowedDomains = "allowed_domains"
-
-	// the type of the event published to a conversation's chat socket for each outgoing message
-	eventTypeMsgOut = "msg_out"
 
 	// how many chats a single IP can start on a channel per window - generous for a real visitor (who starts
 	// one chat, ever) while capping how fast anyone can mint contacts
@@ -238,27 +237,26 @@ func (h *handler) receive(ctx context.Context, channel *models.Channel, w http.R
 	return handlers.WriteMsgsAndResponse(ctx, h, []*models.MsgIn{msg}, w, r, clog)
 }
 
-// msgOutEvent is the event published to the conversation's chat socket for an outgoing message - the same
-// uuid/type/created_on shape as the engine events published to history sockets, with attachments as
-// content-type:url strings and quick replies as objects like goflow's msg events
-type msgOutEvent struct {
-	events.BaseEvent
-
-	MsgUUID      models.MsgUUID      `json:"msg_uuid"`
-	Text         string              `json:"text"`
-	Attachments  []string            `json:"attachments,omitempty"`
-	QuickReplies []models.QuickReply `json:"quick_replies,omitempty"`
-}
-
+// Send publishes the message to the conversation's chat socket as the engine's msg_created event, redacted
+// to the content fields the widget renders - no URN or channel reference. The event's identity (uuid,
+// created_on) is reproduced from the original: a message's uuid is its msg_created event's uuid, so the
+// widget sees the same event that the contact's history records.
 func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.SendResult, clog *models.ChannelLog) error {
 	socket := models.ChatSocket(msg.Channel().UUID(), msg.URN().Path())
-	event := &msgOutEvent{
-		BaseEvent:    events.NewBaseEvent(eventTypeMsgOut),
-		MsgUUID:      msg.UUID(),
-		Text:         msg.Text(),
-		Attachments:  msg.Attachments(),
-		QuickReplies: msg.QuickReplies(),
+
+	content := &core.MsgContent{Text: msg.Text()}
+	for _, att := range msg.Attachments() {
+		content.Attachments = append(content.Attachments, utils.Attachment(att))
 	}
+	for _, qr := range msg.QuickReplies() {
+		content.QuickReplies = append(content.QuickReplies, core.QuickReply{Type: qr.Type, Text: qr.Text, Extra: qr.Extra})
+	}
+
+	event := &events.MsgCreated{
+		BaseEvent: events.NewBaseEventWithUUID(events.EventUUID(msg.UUID()), events.TypeMsgCreated),
+		Msg:       core.NewMsgOut("", nil, content, nil, "", ""),
+	}
+	event.CreatedOn_ = msg.CreatedOn()
 
 	// like all socket publishes this is presence-aware and best-effort: if the visitor doesn't currently have
 	// the chat open the publish is dropped, and the message is still considered sent

--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -9,16 +9,17 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/gocommon/centrifugo"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/random"
 	"github.com/nyaruka/gocommon/urns"
-	"github.com/nyaruka/goflow/core/events"
 )
 
 const (
@@ -238,12 +239,13 @@ func (h *handler) receive(ctx context.Context, channel *models.Channel, w http.R
 	return handlers.WriteMsgsAndResponse(ctx, h, []*models.MsgIn{msg}, w, r, clog)
 }
 
-// msgOutEvent is the event published to the conversation's chat socket for an outgoing message - the same
-// uuid/type/created_on shape as the engine events published to history sockets, with attachments as
-// content-type:url strings and quick replies as objects like goflow's msg events
+// msgOutEvent is the event published to the conversation's chat socket for an outgoing message. Chat socket
+// events are their own client-centric vocabulary rather than engine events, though the content fields keep
+// the same shapes as the engine's msg events - attachments as content-type:url strings, quick replies as
+// objects.
 type msgOutEvent struct {
-	events.BaseEvent
-
+	Type         string              `json:"type"`
+	CreatedOn    time.Time           `json:"created_on"`
 	MsgUUID      models.MsgUUID      `json:"msg_uuid"`
 	Text         string              `json:"text"`
 	Attachments  []string            `json:"attachments,omitempty"`
@@ -253,7 +255,8 @@ type msgOutEvent struct {
 func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.SendResult, clog *models.ChannelLog) error {
 	socket := models.ChatSocket(msg.Channel().UUID(), msg.URN().Path())
 	event := &msgOutEvent{
-		BaseEvent:    events.NewBaseEvent(eventTypeMsgOut),
+		Type:         eventTypeMsgOut,
+		CreatedOn:    dates.Now(),
 		MsgUUID:      msg.UUID(),
 		Text:         msg.Text(),
 		Attachments:  msg.Attachments(),

--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -18,9 +18,7 @@ import (
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/random"
 	"github.com/nyaruka/gocommon/urns"
-	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/events"
-	"github.com/nyaruka/goflow/utils"
 )
 
 const (
@@ -29,6 +27,9 @@ const (
 	// optional channel config: the host[:port] values (no scheme) of the sites the widget may be embedded on -
 	// empty or absent means unrestricted
 	configAllowedDomains = "allowed_domains"
+
+	// the type of the event published to a conversation's chat socket for each outgoing message
+	eventTypeMsgOut = "msg_out"
 
 	// how many chats a single IP can start on a channel per window - generous for a real visitor (who starts
 	// one chat, ever) while capping how fast anyone can mint contacts
@@ -237,26 +238,27 @@ func (h *handler) receive(ctx context.Context, channel *models.Channel, w http.R
 	return handlers.WriteMsgsAndResponse(ctx, h, []*models.MsgIn{msg}, w, r, clog)
 }
 
-// Send publishes the message to the conversation's chat socket as the engine's msg_created event, redacted
-// to the content fields the widget renders - no URN or channel reference. The event's identity (uuid,
-// created_on) is reproduced from the original: a message's uuid is its msg_created event's uuid, so the
-// widget sees the same event that the contact's history records.
+// msgOutEvent is the event published to the conversation's chat socket for an outgoing message - the same
+// uuid/type/created_on shape as the engine events published to history sockets, with attachments as
+// content-type:url strings and quick replies as objects like goflow's msg events
+type msgOutEvent struct {
+	events.BaseEvent
+
+	MsgUUID      models.MsgUUID      `json:"msg_uuid"`
+	Text         string              `json:"text"`
+	Attachments  []string            `json:"attachments,omitempty"`
+	QuickReplies []models.QuickReply `json:"quick_replies,omitempty"`
+}
+
 func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.SendResult, clog *models.ChannelLog) error {
 	socket := models.ChatSocket(msg.Channel().UUID(), msg.URN().Path())
-
-	content := &core.MsgContent{Text: msg.Text()}
-	for _, att := range msg.Attachments() {
-		content.Attachments = append(content.Attachments, utils.Attachment(att))
+	event := &msgOutEvent{
+		BaseEvent:    events.NewBaseEvent(eventTypeMsgOut),
+		MsgUUID:      msg.UUID(),
+		Text:         msg.Text(),
+		Attachments:  msg.Attachments(),
+		QuickReplies: msg.QuickReplies(),
 	}
-	for _, qr := range msg.QuickReplies() {
-		content.QuickReplies = append(content.QuickReplies, core.QuickReply{Type: qr.Type, Text: qr.Text, Extra: qr.Extra})
-	}
-
-	event := &events.MsgCreated{
-		BaseEvent: events.NewBaseEventWithUUID(events.EventUUID(msg.UUID()), events.TypeMsgCreated),
-		Msg:       core.NewMsgOut("", nil, content, nil, "", ""),
-	}
-	event.CreatedOn_ = msg.CreatedOn()
 
 	// like all socket publishes this is presence-aware and best-effort: if the visitor doesn't currently have
 	// the chat open the publish is dropped, and the message is still considered sent

--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -239,17 +239,26 @@ func (h *handler) receive(ctx context.Context, channel *models.Channel, w http.R
 }
 
 // msgOutEvent is the event published to the conversation's chat socket for an outgoing message - the same
-// uuid/type/created_on shape as the engine events published to history sockets
+// uuid/type/created_on shape as the engine events published to history sockets, with attachments as
+// content-type:url strings and quick replies as objects like goflow's msg events
 type msgOutEvent struct {
 	events.BaseEvent
 
-	MsgUUID models.MsgUUID `json:"msg_uuid"`
-	Text    string         `json:"text"`
+	MsgUUID      models.MsgUUID      `json:"msg_uuid"`
+	Text         string              `json:"text"`
+	Attachments  []string            `json:"attachments,omitempty"`
+	QuickReplies []models.QuickReply `json:"quick_replies,omitempty"`
 }
 
 func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.SendResult, clog *models.ChannelLog) error {
 	socket := models.ChatSocket(msg.Channel().UUID(), msg.URN().Path())
-	event := &msgOutEvent{BaseEvent: events.NewBaseEvent(eventTypeMsgOut), MsgUUID: msg.UUID(), Text: msg.Text()}
+	event := &msgOutEvent{
+		BaseEvent:    events.NewBaseEvent(eventTypeMsgOut),
+		MsgUUID:      msg.UUID(),
+		Text:         msg.Text(),
+		Attachments:  msg.Attachments(),
+		QuickReplies: msg.QuickReplies(),
+	}
 
 	// like all socket publishes this is presence-aware and best-effort: if the visitor doesn't currently have
 	// the chat open the publish is dropped, and the message is still considered sent

--- a/handlers/webchat/handler_test.go
+++ b/handlers/webchat/handler_test.go
@@ -318,7 +318,6 @@ func TestOutgoing(t *testing.T) {
 		Contact_:     &models.ContactReference{ID: 100, UUID: "a984069d-0008-4d8c-a772-b14a8a6acccc"},
 		URN_:         urns.URN("webchat:" + testChatID),
 		Text_:        "Hello there",
-		CreatedOn_:   time.Date(2025, 10, 13, 11, 19, 45, 0, time.UTC),
 		ChannelUUID_: ch.UUID(),
 		Channel_:     ch,
 	}
@@ -345,14 +344,17 @@ func TestOutgoing(t *testing.T) {
 	sent := testsuite.CentrifugoHistory(t, rt, socket)
 	require.Len(t, sent, 1)
 
-	// the published event is the message's own msg_created event - same uuid and created_on - redacted to
-	// just the content
 	var decoded map[string]any
 	require.NoError(t, json.Unmarshal(sent[0], &decoded))
-	assert.Equal(t, "0191e180-7d60-7000-aded-7d8b151cbd5b", decoded["uuid"])
-	assert.Equal(t, "msg_created", decoded["type"])
-	assert.Equal(t, "2025-10-13T11:19:45Z", decoded["created_on"])
-	assert.Equal(t, map[string]any{"text": "Hello there"}, decoded["msg"])
+	assert.True(t, uuids.Is(decoded["uuid"].(string)))
+	assert.Equal(t, "msg_out", decoded["type"])
+	assert.Equal(t, "2025-10-13T11:20:30Z", decoded["created_on"])
+	assert.Equal(t, "0191e180-7d60-7000-aded-7d8b151cbd5b", decoded["msg_uuid"])
+	assert.Equal(t, "Hello there", decoded["text"])
+
+	// a plain text message has no attachments or quick replies fields at all
+	assert.NotContains(t, decoded, "attachments")
+	assert.NotContains(t, decoded, "quick_replies")
 
 	// a message with attachments and quick replies includes them in the event
 	msg.Attachments_ = []string{"image/jpeg:https://example.com/cat.jpg", "audio/mp3:https://example.com/hi.mp3"}
@@ -365,14 +367,12 @@ func TestOutgoing(t *testing.T) {
 
 	decoded = map[string]any{}
 	require.NoError(t, json.Unmarshal(sent[1], &decoded))
-	assert.Equal(t, map[string]any{
-		"text":        "Hello there",
-		"attachments": []any{"image/jpeg:https://example.com/cat.jpg", "audio/mp3:https://example.com/hi.mp3"},
-		"quick_replies": []any{
-			map[string]any{"type": "text", "text": "Yes"},
-			map[string]any{"type": "url", "text": "More", "extra": "https://example.com"},
-		},
-	}, decoded["msg"])
+	assert.Equal(t, "Hello there", decoded["text"])
+	assert.Equal(t, []any{"image/jpeg:https://example.com/cat.jpg", "audio/mp3:https://example.com/hi.mp3"}, decoded["attachments"])
+	assert.Equal(t, []any{
+		map[string]any{"type": "text", "text": "Yes"},
+		map[string]any{"type": "url", "text": "More", "extra": "https://example.com"},
+	}, decoded["quick_replies"])
 
 	// a publish failure is returned as a send error
 	rt.Centrifugo.Client.(*centrifugo.MockClient).SetError(errors.New("boom"))

--- a/handlers/webchat/handler_test.go
+++ b/handlers/webchat/handler_test.go
@@ -352,6 +352,28 @@ func TestOutgoing(t *testing.T) {
 	assert.Equal(t, "0191e180-7d60-7000-aded-7d8b151cbd5b", decoded["msg_uuid"])
 	assert.Equal(t, "Hello there", decoded["text"])
 
+	// a plain text message has no attachments or quick replies fields at all
+	assert.NotContains(t, decoded, "attachments")
+	assert.NotContains(t, decoded, "quick_replies")
+
+	// a message with attachments and quick replies includes them in the event
+	msg.Attachments_ = []string{"image/jpeg:https://example.com/cat.jpg", "audio/mp3:https://example.com/hi.mp3"}
+	msg.QuickReplies_ = []models.QuickReply{{Type: "text", Text: "Yes"}, {Type: "url", Text: "More", Extra: "https://example.com"}}
+
+	require.NoError(t, send())
+
+	sent = testsuite.CentrifugoHistory(t, rt, socket)
+	require.Len(t, sent, 2)
+
+	decoded = map[string]any{}
+	require.NoError(t, json.Unmarshal(sent[1], &decoded))
+	assert.Equal(t, "Hello there", decoded["text"])
+	assert.Equal(t, []any{"image/jpeg:https://example.com/cat.jpg", "audio/mp3:https://example.com/hi.mp3"}, decoded["attachments"])
+	assert.Equal(t, []any{
+		map[string]any{"type": "text", "text": "Yes"},
+		map[string]any{"type": "url", "text": "More", "extra": "https://example.com"},
+	}, decoded["quick_replies"])
+
 	// a publish failure is returned as a send error
 	rt.Centrifugo.Client.(*centrifugo.MockClient).SetError(errors.New("boom"))
 	assert.EqualError(t, send(), "error publishing message event: boom")

--- a/handlers/webchat/handler_test.go
+++ b/handlers/webchat/handler_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/random"
 	"github.com/nyaruka/gocommon/urns"
-	"github.com/nyaruka/gocommon/uuids"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -301,8 +300,6 @@ func TestOutgoing(t *testing.T) {
 	testsuite.ResetDB(t, rt)
 	testsuite.ResetValkey(t, rt)
 
-	uuids.SetGenerator(uuids.NewSeededGenerator(1234, dates.NewSequentialNow(time.Date(2025, 10, 13, 11, 20, 0, 0, time.UTC), time.Second)))
-	defer uuids.SetGenerator(uuids.DefaultGenerator)
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2025, 10, 13, 11, 20, 30, 0, time.UTC)))
 	defer dates.SetNowFunc(time.Now)
 
@@ -344,17 +341,15 @@ func TestOutgoing(t *testing.T) {
 	sent := testsuite.CentrifugoHistory(t, rt, socket)
 	require.Len(t, sent, 1)
 
+	// a plain text message publishes just the envelope and text - no attachments or quick replies fields
 	var decoded map[string]any
 	require.NoError(t, json.Unmarshal(sent[0], &decoded))
-	assert.True(t, uuids.Is(decoded["uuid"].(string)))
-	assert.Equal(t, "msg_out", decoded["type"])
-	assert.Equal(t, "2025-10-13T11:20:30Z", decoded["created_on"])
-	assert.Equal(t, "0191e180-7d60-7000-aded-7d8b151cbd5b", decoded["msg_uuid"])
-	assert.Equal(t, "Hello there", decoded["text"])
-
-	// a plain text message has no attachments or quick replies fields at all
-	assert.NotContains(t, decoded, "attachments")
-	assert.NotContains(t, decoded, "quick_replies")
+	assert.Equal(t, map[string]any{
+		"type":       "msg_out",
+		"created_on": "2025-10-13T11:20:30Z",
+		"msg_uuid":   "0191e180-7d60-7000-aded-7d8b151cbd5b",
+		"text":       "Hello there",
+	}, decoded)
 
 	// a message with attachments and quick replies includes them in the event
 	msg.Attachments_ = []string{"image/jpeg:https://example.com/cat.jpg", "audio/mp3:https://example.com/hi.mp3"}
@@ -367,12 +362,17 @@ func TestOutgoing(t *testing.T) {
 
 	decoded = map[string]any{}
 	require.NoError(t, json.Unmarshal(sent[1], &decoded))
-	assert.Equal(t, "Hello there", decoded["text"])
-	assert.Equal(t, []any{"image/jpeg:https://example.com/cat.jpg", "audio/mp3:https://example.com/hi.mp3"}, decoded["attachments"])
-	assert.Equal(t, []any{
-		map[string]any{"type": "text", "text": "Yes"},
-		map[string]any{"type": "url", "text": "More", "extra": "https://example.com"},
-	}, decoded["quick_replies"])
+	assert.Equal(t, map[string]any{
+		"type":        "msg_out",
+		"created_on":  "2025-10-13T11:20:30Z",
+		"msg_uuid":    "0191e180-7d60-7000-aded-7d8b151cbd5b",
+		"text":        "Hello there",
+		"attachments": []any{"image/jpeg:https://example.com/cat.jpg", "audio/mp3:https://example.com/hi.mp3"},
+		"quick_replies": []any{
+			map[string]any{"type": "text", "text": "Yes"},
+			map[string]any{"type": "url", "text": "More", "extra": "https://example.com"},
+		},
+	}, decoded)
 
 	// a publish failure is returned as a send error
 	rt.Centrifugo.Client.(*centrifugo.MockClient).SetError(errors.New("boom"))

--- a/handlers/webchat/handler_test.go
+++ b/handlers/webchat/handler_test.go
@@ -318,6 +318,7 @@ func TestOutgoing(t *testing.T) {
 		Contact_:     &models.ContactReference{ID: 100, UUID: "a984069d-0008-4d8c-a772-b14a8a6acccc"},
 		URN_:         urns.URN("webchat:" + testChatID),
 		Text_:        "Hello there",
+		CreatedOn_:   time.Date(2025, 10, 13, 11, 19, 45, 0, time.UTC),
 		ChannelUUID_: ch.UUID(),
 		Channel_:     ch,
 	}
@@ -344,17 +345,14 @@ func TestOutgoing(t *testing.T) {
 	sent := testsuite.CentrifugoHistory(t, rt, socket)
 	require.Len(t, sent, 1)
 
+	// the published event is the message's own msg_created event - same uuid and created_on - redacted to
+	// just the content
 	var decoded map[string]any
 	require.NoError(t, json.Unmarshal(sent[0], &decoded))
-	assert.True(t, uuids.Is(decoded["uuid"].(string)))
-	assert.Equal(t, "msg_out", decoded["type"])
-	assert.Equal(t, "2025-10-13T11:20:30Z", decoded["created_on"])
-	assert.Equal(t, "0191e180-7d60-7000-aded-7d8b151cbd5b", decoded["msg_uuid"])
-	assert.Equal(t, "Hello there", decoded["text"])
-
-	// a plain text message has no attachments or quick replies fields at all
-	assert.NotContains(t, decoded, "attachments")
-	assert.NotContains(t, decoded, "quick_replies")
+	assert.Equal(t, "0191e180-7d60-7000-aded-7d8b151cbd5b", decoded["uuid"])
+	assert.Equal(t, "msg_created", decoded["type"])
+	assert.Equal(t, "2025-10-13T11:19:45Z", decoded["created_on"])
+	assert.Equal(t, map[string]any{"text": "Hello there"}, decoded["msg"])
 
 	// a message with attachments and quick replies includes them in the event
 	msg.Attachments_ = []string{"image/jpeg:https://example.com/cat.jpg", "audio/mp3:https://example.com/hi.mp3"}
@@ -367,12 +365,14 @@ func TestOutgoing(t *testing.T) {
 
 	decoded = map[string]any{}
 	require.NoError(t, json.Unmarshal(sent[1], &decoded))
-	assert.Equal(t, "Hello there", decoded["text"])
-	assert.Equal(t, []any{"image/jpeg:https://example.com/cat.jpg", "audio/mp3:https://example.com/hi.mp3"}, decoded["attachments"])
-	assert.Equal(t, []any{
-		map[string]any{"type": "text", "text": "Yes"},
-		map[string]any{"type": "url", "text": "More", "extra": "https://example.com"},
-	}, decoded["quick_replies"])
+	assert.Equal(t, map[string]any{
+		"text":        "Hello there",
+		"attachments": []any{"image/jpeg:https://example.com/cat.jpg", "audio/mp3:https://example.com/hi.mp3"},
+		"quick_replies": []any{
+			map[string]any{"type": "text", "text": "Yes"},
+			map[string]any{"type": "url", "text": "More", "extra": "https://example.com"},
+		},
+	}, decoded["msg"])
 
 	// a publish failure is returned as a send error
 	rt.Centrifugo.Client.(*centrifugo.MockClient).SetError(errors.New("boom"))


### PR DESCRIPTION
## Summary

The webchat handler's outgoing `msg_out` event only carried the message text, so attachments and quick replies on outgoing messages were silently dropped. This adds both to the published event.

The chat socket keeps its own client-centric event vocabulary (`msg_out`) rather than reusing engine event types — from the widget's point of view messages flow in and out, and naming socket events from the engine's perspective would get confusing once the socket carries client-emitted events too. Accordingly the event is now a locally defined struct rather than borrowing goflow's event envelope: `type`, `created_on`, `msg_uuid` and the content fields, with no event uuid (`msg_uuid` is the event's real identity, and a random per-publish uuid would only undermine dedupe on resends). The content field shapes still match the engine's msg events, so rendering code for message content can be shared.

## Changes

- `handlers/webchat/handler.go`: `msgOutEvent` is now a local struct (`type`, `created_on`, `msg_uuid`, `text`, `attachments`, `quick_replies`) instead of embedding goflow's `events.BaseEvent`, and gains the attachments and quick replies fields, populated from the outgoing message. Both use `omitempty`, and their wire shapes follow goflow's msg events — attachments as `content-type:url` strings, quick replies as `{type, text, extra}` objects.
- `handlers/webchat/handler_test.go`: `TestOutgoing` now asserts the exact full event JSON for both a plain text message (no attachment/quick reply fields) and one with attachments and quick replies.

## Behavior examples

Plain text message:

```json
{"type": "msg_out", "created_on": "...", "msg_uuid": "0191e180-…", "text": "Hello there"}
```

A message with attachments and quick replies:

```json
{
  "type": "msg_out", "created_on": "...", "msg_uuid": "0191e180-…",
  "text": "Hello there",
  "attachments": ["image/jpeg:https://example.com/cat.jpg"],
  "quick_replies": [{"type": "text", "text": "Yes"}, {"type": "url", "text": "More", "extra": "https://example.com"}]
}
```

## Test plan

- [x] `go test -p=1 ./...` passes
- [x] `go build ./...` clean
- [x] `gofmt` clean