### PR TITLE
Limit incoming message text length on webchat receive endpoint

### DIFF
--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -215,7 +215,9 @@ func (h *handler) allowStart(channel *models.Channel, r *http.Request) bool {
 
 type receivePayload struct {
 	ChatID string `json:"chat_id" validate:"required"`
-	Text   string `json:"text"    validate:"required"`
+	// max counts runes, and we reject rather than truncate because we control the widget - an over-limit
+	// message is a client bug or abuse
+	Text string `json:"text" validate:"required,max=1000"`
 }
 
 // receive is our HTTP handler function for incoming messages

--- a/handlers/webchat/handler_test.go
+++ b/handlers/webchat/handler_test.go
@@ -69,6 +69,22 @@ var incomingCases = []IncomingTestCase{
 		ExpectedBodyContains: "invalid chat id",
 	},
 	{
+		Label:                "Receive Max Length Text",
+		URL:                  receiveURL,
+		Data:                 `{"chat_id": "` + testChatID + `", "text": "` + strings.Repeat("é", 1000) + `"}`,
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: "Message Accepted",
+		ExpectedMsgText:      Sp(strings.Repeat("é", 1000)),
+		ExpectedURN:          urns.URN("webchat:" + testChatID),
+	},
+	{
+		Label:                "Receive Too Long Text",
+		URL:                  receiveURL,
+		Data:                 `{"chat_id": "` + testChatID + `", "text": "` + strings.Repeat("é", 1001) + `"}`,
+		ExpectedRespStatus:   400,
+		ExpectedBodyContains: "Field validation for 'Text' failed on the 'max' tag",
+	},
+	{
 		Label:                "Receive Missing Text",
 		URL:                  receiveURL,
 		Data:                 `{"chat_id": "` + testChatID + `"}`,


### PR DESCRIPTION
## Summary

Adds a maximum text length (1000 characters) to the webchat channel's `/receive` endpoint. Nothing platform-wide bounds incoming message text, and this is a public unauthenticated endpoint — an over-limit message is a widget bug or abuse, so it's rejected rather than truncated.

## Changes

- `handlers/webchat/handler.go`: the `receivePayload.Text` field's validate tag gains `max=1000`. The validator's `max` tag counts runes on strings, so the limit is character-based rather than byte-based. Over-limit payloads get the framework's standard 400 validation response — no handler code changes.
- `handlers/webchat/handler_test.go`: incoming test cases for text at exactly 1000 multi-byte runes (accepted — proving the limit counts runes, not bytes) and at 1001 runes (rejected with 400).

## Behavior examples

| Request text | Before | After |
|---|---|---|
| 1000 × `é` (2000 bytes) | 200 Message Accepted | 200 Message Accepted |
| 1001 × `é` | 200 Message Accepted | 400 `Field validation for 'Text' failed on the 'max' tag` |

## Test plan

- [x] New incoming test cases at the 1000-rune boundary (accept) and 1001 (reject)
- [x] Full suite green: `go test -p=1 ./...`