### PR TITLE
Combine multiple contents in an incoming Zenvia payload into a single message

### DIFF
--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -100,34 +100,38 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, w
 
 	contactName := payload.Visitor.Name
 
-	msgs := []*models.MsgIn{}
+	// the contents of a payload are the parts of a single message and so share its id - we combine them into one
+	// msg with attachments rather than creating a msg per part, which would see all but the first part discarded
+	// as duplicates of the first
+	texts := make([]string, 0, len(payload.Message.Contents))
+	attachments := make([]string, 0, len(payload.Message.Contents))
 
 	for _, content := range payload.Message.Contents {
-
-		text := ""
-		mediaURL := ""
-
-		if content.Type == "text" {
-			text = content.Text
-		} else if content.Type == "location" {
-			mediaURL = fmt.Sprintf("geo:%f,%f", content.Latitude, content.Longitude)
-		} else if content.Type == "file" {
-			mediaURL = content.FileURL
-		} else {
+		switch content.Type {
+		case "text":
+			if content.Text != "" {
+				texts = append(texts, content.Text)
+			}
+		case "location":
+			attachments = append(attachments, fmt.Sprintf("geo:%f,%f", content.Latitude, content.Longitude))
+		case "file":
+			if content.FileURL != "" {
+				attachments = append(attachments, content.FileURL)
+			}
+		default:
 			// we received a message type we do not support.
 			channels.LogRequestError(r, channel, fmt.Errorf("unsupported message type %s", content.Type))
 		}
-
-		// build our msg
-		msg := models.NewIncomingMsg(channel, urn, text, payload.Message.ID, clog).WithReceivedOn(date.UTC()).WithContactName(contactName)
-		if mediaURL != "" {
-			msg.WithAttachment(mediaURL)
-		}
-		msgs = append(msgs, msg)
 	}
 
-	// and finally write our messages
-	return handlers.WriteMsgsAndResponse(ctx, h, msgs, w, r, clog)
+	// build our msg
+	msg := models.NewIncomingMsg(channel, urn, strings.Join(texts, "\n"), payload.Message.ID, clog).WithReceivedOn(date.UTC()).WithContactName(contactName)
+	for _, attachment := range attachments {
+		msg.WithAttachment(attachment)
+	}
+
+	// and finally write our message
+	return handlers.WriteMsgsAndResponse(ctx, h, []*models.MsgIn{msg}, w, r, clog)
 }
 
 var statusMapping = map[string]models.MsgStatus{

--- a/handlers/zenvia/handlers_test.go
+++ b/handlers/zenvia/handlers_test.go
@@ -119,6 +119,36 @@ var locationReceive = `{
 	}
 }`
 
+var multiContentReceive = `{
+	"id": "string",
+	"timestamp": "2017-05-03T03:04:45Z",
+	"type": "MESSAGE",
+	"message": {
+	  "id": "string",
+	  "from": "254791541111",
+	  "to": "2020",
+	  "direction": "IN",
+	  "contents": [
+		{
+		  "type": "text",
+		  "text": "Look at this"
+		},
+		{
+		  "type": "file",
+		  "fileUrl": "https://foo.bar/v1/media/41"
+		},
+		{
+		  "type": "location",
+		  "longitude": 1.00,
+		  "latitude": 0.00
+		}
+	  ],
+	  "visitor": {
+		"name": "Bob"
+	  }
+	}
+}`
+
 var invalidDateReceive = `{
 	"id": "string",
 	"timestamp": "2014-08-26T12:55:48.593-03:00",
@@ -173,6 +203,9 @@ var testWhatappCases = []IncomingTestCase{
 	{Label: "Receive location Valid", URL: receiveWhatsappURL, Data: locationReceive, ExpectedRespStatus: 200, ExpectedBodyContains: "Message Accepted",
 		ExpectedMsgText: Sp(""), ExpectedAttachments: []string{"geo:0.000000,1.000000"}, ExpectedURN: "whatsapp:254791541111", ExpectedDate: time.Date(2017, 5, 3, 03, 04, 45, 0, time.UTC)},
 
+	{Label: "Receive multiple contents", URL: receiveWhatsappURL, Data: multiContentReceive, ExpectedRespStatus: 200, ExpectedBodyContains: "Message Accepted",
+		ExpectedMsgText: Sp("Look at this"), ExpectedAttachments: []string{"https://foo.bar/v1/media/41", "geo:0.000000,1.000000"}, ExpectedURN: "whatsapp:254791541111", ExpectedDate: time.Date(2017, 5, 3, 03, 04, 45, 0, time.UTC)},
+
 	{Label: "Not JSON body", URL: receiveWhatsappURL, Data: notJSON, ExpectedRespStatus: 400, ExpectedBodyContains: "unable to parse request JSON"},
 	{Label: "Wrong JSON schema", URL: receiveWhatsappURL, Data: wrongJSONSchema, ExpectedRespStatus: 400, ExpectedBodyContains: "request JSON doesn't match required schema"},
 	{Label: "Missing field", URL: receiveWhatsappURL, Data: missingFieldsReceive, ExpectedRespStatus: 400, ExpectedBodyContains: "validation for 'ID' failed on the 'required'"},
@@ -207,6 +240,9 @@ var testSMSCases = []IncomingTestCase{
 
 	{Label: "Receive location Valid", URL: receiveSMSURL, Data: locationReceive, ExpectedRespStatus: 200, ExpectedBodyContains: "Message Accepted",
 		ExpectedMsgText: Sp(""), ExpectedAttachments: []string{"geo:0.000000,1.000000"}, ExpectedURN: "whatsapp:254791541111", ExpectedDate: time.Date(2017, 5, 3, 03, 04, 45, 0, time.UTC)},
+
+	{Label: "Receive multiple contents", URL: receiveSMSURL, Data: multiContentReceive, ExpectedRespStatus: 200, ExpectedBodyContains: "Message Accepted",
+		ExpectedMsgText: Sp("Look at this"), ExpectedAttachments: []string{"https://foo.bar/v1/media/41", "geo:0.000000,1.000000"}, ExpectedURN: "whatsapp:254791541111", ExpectedDate: time.Date(2017, 5, 3, 03, 04, 45, 0, time.UTC)},
 
 	{Label: "Not JSON body", URL: receiveSMSURL, Data: notJSON, ExpectedRespStatus: 400, ExpectedBodyContains: "unable to parse request JSON"},
 	{Label: "Wrong JSON schema", URL: receiveSMSURL, Data: wrongJSONSchema, ExpectedRespStatus: 400, ExpectedBodyContains: "request JSON doesn't match required schema"},


### PR DESCRIPTION
## Summary

The Zenvia receive endpoint created one message per element of a payload's `contents` array, but gave every one of them the same external ID — the payload's single message ID. Cross-request dedupe fingerprints an incoming message as `channel|urn|external_id`, so for a payload with two or more contents only the first part was ever written; every subsequent part matched the fingerprint the first had just recorded, stole its UUID, was flagged as a duplicate and silently dropped. The endpoint still returned `200 Message Accepted` for the dropped parts, so the channel would never retry them.

The contents of a Zenvia payload are the parts of a *single* message, not separate messages, so they are now combined into one message carrying text plus attachments.

## Changes

**`handlers/zenvia/handlers.go`** — `receiveMessage` now accumulates texts and attachments across the payload's contents and builds one `MsgIn` from them, instead of one per content:

- multiple `text` contents are joined with newlines
- `file` and `location` contents each become an attachment
- unsupported content types are logged as before
- the `if`/`else if` chain over the content type became a `switch`

**`handlers/zenvia/handlers_test.go`** — adds a `Receive multiple contents` case (text + file + location in one payload) to both the WhatsApp and SMS case lists.

## Behavior examples

For a payload whose `contents` are a text part, a file part and a location part:

| | Before | After |
|---|---|---|
| Messages created | 3 | 1 |
| Messages persisted | 1 | 1 |
| Text | `Look at this` | `Look at this` |
| Attachments | dropped | `["https://foo.bar/v1/media/41", "geo:0.000000,1.000000"]` |

Media sent with a caption — a common WhatsApp case — previously lost the media entirely, keeping only the caption text.

## Why one message rather than distinct external IDs

Giving each part its own synthetic external ID would also work around the dedupe, but combining is the better model:

- A Zenvia payload has one message ID; its contents are that message's parts. This mirrors how the handler *sends*, splitting one outgoing message into multiple contents.
- Other handlers already model a message carrying text plus media this way — telegram and viber both build a single incoming message and attach the media to it. The line handler creates a message per element because it iterates over `events`, which really are separate messages each with its own external ID.
- Synthetic per-index IDs would weaken the dedupe they are meant to satisfy, and would not match the `messageId` of a later status callback.

## Test plan

- [x] New `Receive multiple contents` case added for both `ZVW` and `ZVS`; verified it fails against the previous handler (`should have 1 item(s), but has 3`) and passes after the change
- [x] Confirmed the original bug against a real database before fixing: a two-content payload produced two events sharing one UUID, the second marked duplicate, and only one row written
- [x] `go test -p=1 ./handlers/zenvia/...`
- [x] `go test -p=1 ./handlers/... ./core/...`
- [x] `gofmt` and `go vet` clean