### PR TITLE
Add core entrypoint for writing incoming events as a batch

### DIFF
--- a/core/channels/incoming.go
+++ b/core/channels/incoming.go
@@ -1,0 +1,153 @@
+package channels
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/runtime"
+)
+
+// Incoming is the ordered set of things one incoming request contained - the messages, status updates and
+// channel events a handler parsed out of a provider's payload, plus notes about the parts of it that were
+// understood but not acted on. Handlers accumulate one of these while parsing and pass it to WriteIncoming.
+//
+// Collecting the whole request before writing any of it is what makes a mixed batch describable. A single
+// provider webhook can carry messages, statuses and events together, and handlers that receive those have
+// had to write each part as they parsed it and hand-roll their own response, which leaves no single place
+// to apply anything that spans the request.
+type Incoming struct {
+	items []incomingItem
+}
+
+// one thing an incoming request contained: either something to write, or a note that we ignored part of the
+// request - which isn't written anywhere but is still described in the response
+type incomingItem struct {
+	event   Event
+	ignored string
+}
+
+// NewIncoming creates an empty set of incoming items for a handler to add to
+func NewIncoming() *Incoming { return &Incoming{} }
+
+// Msg adds a message parsed from the request
+func (i *Incoming) Msg(m *models.MsgIn) { i.items = append(i.items, incomingItem{event: m}) }
+
+// Status adds a message status update parsed from the request
+func (i *Incoming) Status(s *models.StatusUpdate) { i.items = append(i.items, incomingItem{event: s}) }
+
+// Event adds a channel event parsed from the request
+func (i *Incoming) Event(e *models.ChannelEvent) { i.items = append(i.items, incomingItem{event: e}) }
+
+// Ignored notes a part of the request we understood but didn't act on, such as a message echoed back to us.
+// Nothing is written for it, but it appears in the response so that what we saw is visible to the provider.
+func (i *Incoming) Ignored(details string) { i.items = append(i.items, incomingItem{ignored: details}) }
+
+// Len returns how many items have been added
+func (i *Incoming) Len() int { return len(i.items) }
+
+// Outcome is what became of a single item of an incoming request
+type Outcome string
+
+const (
+	// OutcomeWritten means we accepted the item - it was written to the database, or handed to the status
+	// writer, or spooled because the database was unavailable. Those are the same promise to the provider:
+	// we have it, and they don't need to send it again.
+	OutcomeWritten Outcome = "written"
+
+	// OutcomeDuplicate means the message had already been received, so it wasn't written a second time
+	OutcomeDuplicate Outcome = "duplicate"
+
+	// OutcomeIgnored means there was nothing to write
+	OutcomeIgnored Outcome = "ignored"
+
+	// OutcomeFailed means writing the item was attempted and failed
+	OutcomeFailed Outcome = "failed"
+)
+
+// IncomingResult is what became of one item of an incoming request
+type IncomingResult struct {
+	Event   Event  // what was written, nil for an ignored item
+	Details string // why it was ignored, for an ignored item
+	Outcome Outcome
+	Err     error // set when Outcome is OutcomeFailed
+}
+
+// WriteIncoming writes everything in the given set of incoming items, in the order the handler added them,
+// and returns what became of each. Order is preserved because messages and events are queued to mailroom as
+// they're written, and mailroom handles a contact's tasks in the order they were queued.
+//
+// It stops at the first item that fails, so the results describe the prefix it got through - which is what
+// lets a caller report what was actually accepted rather than discarding a half-written batch.
+func WriteIncoming(ctx context.Context, rt *runtime.Runtime, in *Incoming, clog *models.ChannelLog) ([]IncomingResult, error) {
+	results := make([]IncomingResult, 0, len(in.items))
+
+	for _, item := range in.items {
+		if item.event == nil {
+			results = append(results, IncomingResult{Details: item.ignored, Outcome: OutcomeIgnored})
+			continue
+		}
+
+		var err error
+		outcome := OutcomeWritten
+
+		switch e := item.event.(type) {
+		case *models.MsgIn:
+			if err = models.WriteMsg(ctx, rt, e, clog); err == nil && e.Duplicate_ {
+				outcome = OutcomeDuplicate
+			}
+		case *models.StatusUpdate:
+			err = models.WriteStatusUpdate(ctx, rt, e)
+		case *models.ChannelEvent:
+			err = models.WriteChannelEvent(ctx, rt, e, clog)
+		default:
+			err = fmt.Errorf("unknown incoming item type %T", e)
+		}
+
+		if err != nil {
+			results = append(results, IncomingResult{Event: item.event, Outcome: OutcomeFailed, Err: err})
+			return results, err
+		}
+
+		results = append(results, IncomingResult{Event: item.event, Outcome: outcome})
+	}
+
+	return results, nil
+}
+
+// IncomingEvents returns the events from the given results that we accepted, which is what the server records
+// stats for. Duplicate messages are included because they're still something we received and recognized - the
+// server counts them separately by looking at the message itself.
+func IncomingEvents(results []IncomingResult) []Event {
+	events := make([]Event, 0, len(results))
+
+	for _, r := range results {
+		if r.Event != nil && r.Outcome != OutcomeFailed {
+			events = append(events, r.Event)
+		}
+	}
+
+	return events
+}
+
+// WriteIncomingResponse writes the standard JSON response describing each part of what an incoming request
+// contained. Handlers whose provider requires a particular response body write their own instead.
+func WriteIncomingResponse(w http.ResponseWriter, results []IncomingResult) error {
+	data := make([]any, 0, len(results))
+
+	for _, r := range results {
+		switch e := r.Event.(type) {
+		case *models.MsgIn:
+			data = append(data, NewMsgReceiveData(e))
+		case *models.StatusUpdate:
+			data = append(data, NewStatusData(e))
+		case *models.ChannelEvent:
+			data = append(data, NewEventReceiveData(e))
+		case nil:
+			data = append(data, NewInfoData(r.Details))
+		}
+	}
+
+	return WriteDataResponse(w, http.StatusOK, "Events Handled", data)
+}

--- a/core/channels/incoming_test.go
+++ b/core/channels/incoming_test.go
@@ -1,0 +1,113 @@
+package channels_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nyaruka/courier/v26/core/channels"
+	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/courier/v26/testsuite"
+	"github.com/nyaruka/gocommon/dbutil/assertdb"
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIncomingResponse(t *testing.T) {
+	ch := test.NewMockChannel("dbc126ed-66bc-4e28-b67b-81dc3327c95d", "KN", "2020", "US", []string{urns.Phone.Prefix}, nil)
+	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, ch, nil, nil)
+
+	msg := models.NewIncomingMsg(ch, "tel:+12065551212", "hello", "ext1", clog)
+	status := models.NewStatusUpdateByExternalID(ch, "ext2", models.MsgStatusDelivered, clog)
+	event := models.NewChannelEvent(ch, models.EventTypeStopContact, "tel:+12065551212", clog)
+
+	// a response describes each part of the request in the order the handler added it, including the parts
+	// that weren't written
+	w := httptest.NewRecorder()
+	err := channels.WriteIncomingResponse(w, []channels.IncomingResult{
+		{Event: msg, Outcome: channels.OutcomeWritten},
+		{Event: status, Outcome: channels.OutcomeWritten},
+		{Event: event, Outcome: channels.OutcomeWritten},
+		{Details: "ignoring echo", Outcome: channels.OutcomeIgnored},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 200, w.Code)
+
+	body := w.Body.String()
+	assert.Contains(t, body, `"message":"Events Handled"`)
+	assert.Contains(t, body, `"type":"msg"`)
+	assert.Contains(t, body, `"type":"status"`)
+	assert.Contains(t, body, `"type":"event"`)
+	assert.Contains(t, body, `{"type":"info","info":"ignoring echo"}`)
+
+	// an empty set of items still gets a well formed response
+	w = httptest.NewRecorder()
+	assert.NoError(t, channels.WriteIncomingResponse(w, nil))
+	assert.Equal(t, "{\"message\":\"Events Handled\",\"data\":[]}\n", w.Body.String())
+}
+
+func TestWriteIncoming(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+	testsuite.ResetDB(t, rt)
+	testsuite.ResetValkey(t, rt)
+
+	ch, err := models.GetChannel(ctx, "KN", "dbc126ed-66bc-4e28-b67b-81dc3327c95d")
+	require.NoError(t, err)
+	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, ch, nil, nil)
+
+	// a mixed batch is written in the order it was added, and each item reports what became of it
+	in := channels.NewIncoming()
+	in.Msg(models.NewIncomingMsg(ch, "tel:+12065551212", "hello", "ext1", clog))
+	in.Ignored("ignoring echo")
+	in.Status(models.NewStatusUpdateByExternalID(ch, "ext2", models.MsgStatusDelivered, clog))
+	in.Event(models.NewChannelEvent(ch, models.EventTypeStopContact, "tel:+12065551313", clog))
+	assert.Equal(t, 4, in.Len())
+
+	results, err := channels.WriteIncoming(ctx, rt, in, clog)
+	assert.NoError(t, err)
+	require.Len(t, results, 4)
+	assert.Equal(t, channels.OutcomeWritten, results[0].Outcome)
+	assert.Equal(t, channels.OutcomeIgnored, results[1].Outcome)
+	assert.Equal(t, "ignoring echo", results[1].Details)
+	assert.Equal(t, channels.OutcomeWritten, results[2].Outcome)
+	assert.Equal(t, channels.OutcomeWritten, results[3].Outcome)
+
+	// the ignored item isn't an event because nothing was written for it
+	assert.Len(t, channels.IncomingEvents(results), 3)
+
+	// and the things that reported themselves as written really were - a database failure would have been
+	// absorbed by the spool and still reported as written, so check the rows rather than trusting the outcome
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM msgs_msg WHERE text = 'hello' AND external_identifier = 'ext1'`).Returns(1)
+	assertdb.Query(t, rt.DB, `SELECT count(*) FROM channels_channelevent WHERE event_type = 'stop_contact'`).Returns(1)
+
+	// a message we've already received is reported as a duplicate rather than written again
+	in = channels.NewIncoming()
+	in.Msg(models.NewIncomingMsg(ch, "tel:+12065551212", "hello", "ext1", clog))
+
+	results, err = channels.WriteIncoming(ctx, rt, in, clog)
+	assert.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, channels.OutcomeDuplicate, results[0].Outcome)
+
+	// but it's still an event, because it's something we received and recognized
+	assert.Len(t, channels.IncomingEvents(results), 1)
+
+	// writing stops at the first item that fails, so the results describe the prefix we got through
+	in = channels.NewIncoming()
+	in.Msg(models.NewIncomingMsg(ch, "tel:+12065551212", "first", "ext3", clog))
+	in.Msg(models.NewIncomingMsg(ch, "tel:+12065551212", "second", "ext4", clog).WithAttachment("data:....."))
+	in.Msg(models.NewIncomingMsg(ch, "tel:+12065551212", "third", "ext5", clog))
+
+	results, err = channels.WriteIncoming(ctx, rt, in, clog)
+	assert.EqualError(t, err, "unable to decode attachment data: illegal base64 data at input byte 0")
+	require.Len(t, results, 2)
+	assert.Equal(t, channels.OutcomeWritten, results[0].Outcome)
+	assert.Equal(t, channels.OutcomeFailed, results[1].Outcome)
+	assert.Error(t, results[1].Err)
+
+	// the item that failed isn't an event, but the one written before it is
+	events := channels.IncomingEvents(results)
+	require.Len(t, events, 1)
+	assert.Equal(t, "first", events[0].(*models.MsgIn).Text())
+}

--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -112,7 +112,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 
 	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, form.ID, msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 // Send sends the given message, logging any HTTP calls or errors

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -158,7 +158,7 @@ func (h *handler) statusMessage(ctx context.Context, channel *models.Channel, w 
 
 	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, statusPayload.Message.ID, msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 type mtPayload struct {

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -79,7 +79,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 
 	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, payload.MessageID, msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 type moPayload struct {

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -129,7 +129,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 
 	// write our status
 	status := models.NewStatusUpdate(channel, models.MsgUUID(msgUUID), msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 // DartMedia expects "000" from a message receive request

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -103,7 +103,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 
 	// write our status
 	status := models.NewStatusUpdate(channel, models.MsgUUID(form.UUID), msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.SendResult, clog *models.ChannelLog) error {

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -112,11 +112,7 @@ func (h *handler) receiveStopContact(ctx context.Context, channel *models.Channe
 
 	// create a stop channel event
 	channelEvent := models.NewChannelEvent(channel, models.EventTypeStopContact, urn, clog)
-	err = models.WriteChannelEvent(ctx, h.Runtime(), channelEvent, clog)
-	if err != nil {
-		return nil, err
-	}
-	return []channels.Event{channelEvent}, channels.WriteChannelEventSuccess(w, channelEvent)
+	return handlers.WriteChannelEventAndResponse(ctx, h, channelEvent, w, r, clog)
 }
 
 // utility function to grab the form value for either the passed in name (if non-empty) or the first set
@@ -280,7 +276,7 @@ func (h *handler) receiveStatus(ctx context.Context, statusString string, channe
 
 	// write our status
 	status := models.NewStatusUpdate(channel, models.MsgUUID(msgUUID), msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.SendResult, clog *models.ChannelLog) error {

--- a/handlers/generic.go
+++ b/handlers/generic.go
@@ -56,7 +56,7 @@ func NewExternalIDStatusHandler(h channels.Handler, statuses map[string]models.M
 
 		// create our status
 		status := models.NewStatusUpdateByExternalID(c, externalID, sValue, clog)
-		return WriteMsgStatusAndResponse(ctx, h, c, status, w, r)
+		return WriteMsgStatusAndResponse(ctx, h, c, status, w, r, clog)
 	}
 }
 

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -119,7 +119,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 
 	// write our status
 	status := models.NewStatusUpdate(channel, models.MsgUUID(form.RetID), msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.SendResult, clog *models.ChannelLog) error {

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -58,25 +58,23 @@ type ibStatus struct {
 
 // statusMessage is our HTTP handler function for status updates
 func (h *handler) statusMessage(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, payload *statusPayload, clog *models.ChannelLog) ([]channels.Event, error) {
-	data := make([]any, len(payload.Results))
-	statuses := make([]channels.Event, len(payload.Results))
+	in := channels.NewIncoming()
+
 	for _, s := range payload.Results {
 		msgStatus, found := statusMapping[s.Status.GroupName]
 		if !found {
 			return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, fmt.Errorf("unknown status '%s', must be one of PENDING, DELIVERED, EXPIRED, REJECTED or UNDELIVERABLE", s.Status.GroupName))
 		}
 
-		// write our status
-		status := models.NewStatusUpdateByExternalID(channel, s.MessageID, msgStatus, clog)
-		err := models.WriteStatusUpdate(ctx, h.Runtime(), status)
-		if err != nil {
-			return nil, err
-		}
-		data = append(data, channels.NewStatusData(status))
-		statuses = append(statuses, status)
+		in.Status(models.NewStatusUpdateByExternalID(channel, s.MessageID, msgStatus, clog))
 	}
 
-	return statuses, channels.WriteDataResponse(w, http.StatusOK, "statuses handled", data)
+	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+	if err != nil {
+		return nil, err
+	}
+
+	return channels.IncomingEvents(results), channels.WriteIncomingResponse(w, results)
 }
 
 type v3InboundPayload struct {

--- a/handlers/infobip/handler_test.go
+++ b/handlers/infobip/handler_test.go
@@ -278,11 +278,13 @@ var testCases = []IncomingTestCase{
 		ExpectedBodyContains: "Field validation for 'Results' failed",
 	},
 	{
-		Label:                "Status delivered",
-		URL:                  statusURL,
-		Data:                 validStatusDelivered,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"status":"D"`,
+		Label:              "Status delivered",
+		URL:                statusURL,
+		Data:               validStatusDelivered,
+		ExpectedRespStatus: 200,
+		// asserted from the start of the body so that the envelope shape is covered too - the data used to be
+		// built with make+append and so was prefixed with a null for every status in the request
+		ExpectedBodyContains: `{"message":"Events Handled","data":[{"type":"status","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","status":"D"`,
 		ExpectedStatuses:     []ExpectedStatus{{ExternalID: "0191e180-7d60-7000-aded-7d8b151cbd5b", Status: models.MsgStatusDelivered}},
 	},
 	{
@@ -302,11 +304,13 @@ var testCases = []IncomingTestCase{
 		ExpectedStatuses:     []ExpectedStatus{{ExternalID: "0191e180-7d60-7000-aded-7d8b151cbd5b", Status: models.MsgStatusFailed}},
 	},
 	{
-		Label:                "Status pending",
-		URL:                  statusURL,
-		Data:                 validStatusPending,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"status":"S"`,
+		Label:              "Status pending",
+		URL:                statusURL,
+		Data:               validStatusPending,
+		ExpectedRespStatus: 200,
+		// this request carries two statuses, so the data used to be prefixed with two nulls - anchoring at the
+		// start of the body is what catches that, since the statuses themselves were adjacent either way
+		ExpectedBodyContains: `{"message":"Events Handled","data":[{"type":"status","channel_uuid":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","status":"S","external_id":"0191e180-7d60-7000-aded-7d8b151cbd5b"},{"type":"status"`,
 		ExpectedStatuses:     []ExpectedStatus{{ExternalID: "0191e180-7d60-7000-aded-7d8b151cbd5b", Status: models.MsgStatusSent}, {ExternalID: "0191e180-7d60-7000-aded-7d8b151cbd5b", Status: models.MsgStatusSent}},
 	},
 	{

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -78,7 +78,7 @@ func (h *handler) receiveStatus(ctx context.Context, c *models.Channel, w http.R
 	}
 
 	status := models.NewStatusUpdateByExternalID(c, form.ID, reqStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, c, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, c, status, w, r, clog)
 }
 
 type moForm struct {

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -125,12 +125,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, w
 	if payload.MsgType == "event" && payload.Event == "subscribe" {
 		channelEvent := models.NewChannelEvent(channel, models.EventTypeNewConversation, urn, clog)
 
-		err := models.WriteChannelEvent(ctx, h.Runtime(), channelEvent, clog)
-		if err != nil {
-			return nil, err
-		}
-
-		return []channels.Event{channelEvent}, channels.WriteChannelEventSuccess(w, channelEvent)
+		return handlers.WriteChannelEventAndResponse(ctx, h, channelEvent, w, r, clog)
 	}
 
 	// unknown event type (we only deal with subscribe)

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -144,7 +144,7 @@ func (h *handler) statusMessage(ctx context.Context, c *models.Channel, w http.R
 	}
 	// write our status
 	status := models.NewStatusUpdateByExternalID(c, fmt.Sprint(payload.Data.MessageID), msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, c, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, c, status, w, r, clog)
 }
 
 type mtPayload struct {

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -131,7 +131,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 	}
 
 	// write status
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.SendResult, clog *models.ChannelLog) error {

--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -116,7 +116,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 
 	// write our status
 	status := models.NewStatusUpdate(channel, form.UUID, msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.SendResult, clog *models.ChannelLog) error {

--- a/handlers/macrokiosk/handler.go
+++ b/handlers/macrokiosk/handler.go
@@ -75,7 +75,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 	}
 	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, form.MsgID, msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 
 }
 

--- a/handlers/mblox/handler.go
+++ b/handlers/mblox/handler.go
@@ -76,7 +76,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, w h
 
 		// write our status
 		status := models.NewStatusUpdateByExternalID(channel, payload.BatchID, msgStatus, clog)
-		return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+		return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 
 	} else if payload.Type == "mo_text" {
 		clog.Type = models.ChannelLogTypeMsgReceive

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -135,18 +135,21 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 		}
 		// create a stop channel event
 		stopEvent = models.NewChannelEvent(channel, models.EventTypeStopContact, urn, clog)
-		err = models.WriteChannelEvent(ctx, h.Runtime(), stopEvent, clog)
-		if err != nil {
-			return nil, err
-		}
 		clog.Error(models.ErrorExternal(fmt.Sprint(receivedStatus.StatusErrorCode), "Contact has sent 'stop'"))
 	}
 
-	events, err := handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	in := channels.NewIncoming()
 	if stopEvent != nil {
-		events = append(events, stopEvent)
+		in.Event(stopEvent)
 	}
-	return events, err
+	in.Status(status)
+
+	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+	if err != nil {
+		return nil, err
+	}
+
+	return channels.IncomingEvents(results), h.WriteStatusSuccessResponse(ctx, w, []*models.StatusUpdate{status})
 }
 
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {

--- a/handlers/mtarget/handler.go
+++ b/handlers/mtarget/handler.go
@@ -136,11 +136,7 @@ func (h *handler) receiveMsg(ctx context.Context, c *models.Channel, w http.Resp
 	// if this a stop command, shortcut stopping that contact
 	if keyword == "Stop" {
 		stop := models.NewChannelEvent(c, models.EventTypeStopContact, urn, clog)
-		err := models.WriteChannelEvent(ctx, h.Runtime(), stop, clog)
-		if err != nil {
-			return nil, err
-		}
-		return []channels.Event{stop}, channels.WriteChannelEventSuccess(w, stop)
+		return handlers.WriteChannelEventAndResponse(ctx, h, stop, w, r, clog)
 	}
 
 	// otherwise, create and write the message

--- a/handlers/mtn/handler.go
+++ b/handlers/mtn/handler.go
@@ -108,7 +108,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, w h
 
 		// write our status
 		status := models.NewStatusUpdateByExternalID(channel, payload.TransactionID, msgStatus, clog)
-		return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+		return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 	}
 }
 

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -139,7 +139,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 
 	status := models.NewStatusUpdateByExternalID(channel, form.MessageID, msgStatus, clog)
 
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 type moForm struct {

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -95,7 +95,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 
 	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, externalID, msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 type moForm struct {

--- a/handlers/responses.go
+++ b/handlers/responses.go
@@ -8,28 +8,46 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 )
 
-// WriteMsgsAndResponse writes the passed in message to our backend
+// WriteMsgsAndResponse writes the passed in messages and responds with the handler's message success response
 func WriteMsgsAndResponse(ctx context.Context, h channels.Handler, msgs []*models.MsgIn, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
-	events := make([]channels.Event, len(msgs))
-	for i, m := range msgs {
-		err := models.WriteMsg(ctx, h.Runtime(), m, clog)
-		if err != nil {
-			return nil, err
-		}
-		events[i] = m
+	in := channels.NewIncoming()
+	for _, m := range msgs {
+		in.Msg(m)
 	}
 
-	return events, h.WriteMsgSuccessResponse(ctx, w, msgs)
-}
-
-// WriteMsgStatusAndResponse write the passed in status to our backend
-func WriteMsgStatusAndResponse(ctx context.Context, h channels.Handler, channel *models.Channel, status *models.StatusUpdate, w http.ResponseWriter, r *http.Request) ([]channels.Event, error) {
-	err := models.WriteStatusUpdate(ctx, h.Runtime(), status)
+	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
 	if err != nil {
 		return nil, err
 	}
 
-	return []channels.Event{status}, h.WriteStatusSuccessResponse(ctx, w, []*models.StatusUpdate{status})
+	return channels.IncomingEvents(results), h.WriteMsgSuccessResponse(ctx, w, msgs)
+}
+
+// WriteMsgStatusAndResponse writes the passed in status and responds with the handler's status success response
+func WriteMsgStatusAndResponse(ctx context.Context, h channels.Handler, channel *models.Channel, status *models.StatusUpdate, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
+	in := channels.NewIncoming()
+	in.Status(status)
+
+	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+	if err != nil {
+		return nil, err
+	}
+
+	return channels.IncomingEvents(results), h.WriteStatusSuccessResponse(ctx, w, []*models.StatusUpdate{status})
+}
+
+// WriteChannelEventAndResponse writes the passed in channel event and responds with the standard event success
+// response
+func WriteChannelEventAndResponse(ctx context.Context, h channels.Handler, event *models.ChannelEvent, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
+	in := channels.NewIncoming()
+	in.Event(event)
+
+	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+	if err != nil {
+		return nil, err
+	}
+
+	return channels.IncomingEvents(results), channels.WriteChannelEventSuccess(w, event)
 }
 
 // WriteAndLogRequestError logs the passed in error and writes the response to the response writer

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -77,11 +77,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, w
 	// this is a start command, trigger a new conversation
 	if text == "/start" {
 		event := models.NewChannelEvent(channel, models.EventTypeNewConversation, urn, clog).WithContactName(name).WithOccurredOn(date)
-		err = models.WriteChannelEvent(ctx, h.Runtime(), event, clog)
-		if err != nil {
-			return nil, err
-		}
-		return []channels.Event{event}, channels.WriteChannelEventSuccess(w, event)
+		return handlers.WriteChannelEventAndResponse(ctx, h, event, w, r, clog)
 	}
 
 	// normal message of some kind

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -126,7 +126,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 
 	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, form.GUID, msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 type mtMessage struct {

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -219,10 +219,6 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 
 			// create a stop channel event
 			stopEvent = models.NewChannelEvent(channel, models.EventTypeStopContact, urn, clog)
-			err = models.WriteChannelEvent(ctx, h.Runtime(), stopEvent, clog)
-			if err != nil {
-				return nil, err
-			}
 		}
 		clog.Error(twilioError(errorCode))
 		if errorCode == errorThrottled {
@@ -230,11 +226,18 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 		}
 	}
 
-	events, err := handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	in := channels.NewIncoming()
 	if stopEvent != nil {
-		events = append(events, stopEvent)
+		in.Event(stopEvent)
 	}
-	return events, err
+	in.Status(status)
+
+	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+	if err != nil {
+		return nil, err
+	}
+
+	return channels.IncomingEvents(results), h.WriteStatusSuccessResponse(ctx, w, []*models.StatusUpdate{status})
 }
 
 func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.SendResult, clog *models.ChannelLog) error {

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -148,12 +148,17 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, w h
 		// build the channel event
 		channelEvent := models.NewChannelEvent(channel, models.EventTypeWelcomeMessage, urn, clog).WithContactName(ContactName)
 
-		err = models.WriteChannelEvent(ctx, h.Runtime(), channelEvent, clog)
+		// the response to this is itself the welcome message, so we write it ourselves rather than using
+		// one of the standard responses
+		in := channels.NewIncoming()
+		in.Event(channelEvent)
+
+		results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
 		if err != nil {
 			return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
 		}
 
-		return []channels.Event{channelEvent}, writeWelcomeMessageResponse(w, channel, channelEvent)
+		return channels.IncomingEvents(results), writeWelcomeMessageResponse(w, channel, channelEvent)
 
 	case "subscribed":
 		clog.Type = models.ChannelLogTypeEventReceive
@@ -170,12 +175,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, w h
 		// build the channel event
 		channelEvent := models.NewChannelEvent(channel, models.EventTypeNewConversation, urn, clog).WithContactName(ContactName)
 
-		err = models.WriteChannelEvent(ctx, h.Runtime(), channelEvent, clog)
-		if err != nil {
-			return nil, err
-		}
-
-		return []channels.Event{channelEvent}, channels.WriteChannelEventSuccess(w, channelEvent)
+		return handlers.WriteChannelEventAndResponse(ctx, h, channelEvent, w, r, clog)
 
 	case "unsubscribed":
 		clog.Type = models.ChannelLogTypeEventReceive
@@ -190,18 +190,13 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, w h
 		// build the channel event
 		channelEvent := models.NewChannelEvent(channel, models.EventTypeStopContact, urn, clog)
 
-		err = models.WriteChannelEvent(ctx, h.Runtime(), channelEvent, clog)
-		if err != nil {
-			return nil, err
-		}
-
-		return []channels.Event{channelEvent}, channels.WriteChannelEventSuccess(w, channelEvent)
+		return handlers.WriteChannelEventAndResponse(ctx, h, channelEvent, w, r, clog)
 
 	case "failed":
 		clog.Type = models.ChannelLogTypeMsgStatus
 
 		msgStatus := models.NewStatusUpdateByExternalID(channel, fmt.Sprintf("%d", payload.MessageToken), models.MsgStatusFailed, clog)
-		return handlers.WriteMsgStatusAndResponse(ctx, h, channel, msgStatus, w, r)
+		return handlers.WriteMsgStatusAndResponse(ctx, h, channel, msgStatus, w, r, clog)
 
 	case "delivered":
 		clog.Type = models.ChannelLogTypeMsgStatus

--- a/handlers/wavy/handler.go
+++ b/handlers/wavy/handler.go
@@ -70,7 +70,7 @@ func (h *handler) sentStatusMessage(ctx context.Context, channel *models.Channel
 
 	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, payload.CollerationID, msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 type deliveredStatusPayload struct {
@@ -87,7 +87,7 @@ func (h *handler) deliveredStatusMessage(ctx context.Context, channel *models.Ch
 
 	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, payload.CollerationID, msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 type moPayload struct {

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -131,12 +131,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, w
 
 		channelEvent := models.NewChannelEvent(channel, models.EventTypeNewConversation, urn, clog)
 
-		err := models.WriteChannelEvent(ctx, h.Runtime(), channelEvent, clog)
-		if err != nil {
-			return nil, err
-		}
-
-		return []channels.Event{channelEvent}, channels.WriteChannelEventSuccess(w, channelEvent)
+		return handlers.WriteChannelEventAndResponse(ctx, h, channelEvent, w, r, clog)
 	}
 
 	// unknown event type (we only deal with subscribe)

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -161,7 +161,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 
 	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, payload.MessageID, msgStatus, clog)
-	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
+	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r, clog)
 }
 
 type mtContent struct {


### PR DESCRIPTION
## Summary

Channel handlers have written incoming messages, statuses and channel events by calling the `core/models` writers directly. That leaves nowhere to put anything that spans a request — a single provider webhook can carry all three, and the handlers that receive those write each part as they parse it and hand-roll their own response.

This adds `channels.Incoming`, an ordered accumulation of what one request contained, and `channels.WriteIncoming`, which writes it in order and reports what became of each item. It's the first step of a larger plan to let core own the incoming request lifecycle; nothing about routing or response control changes here.

## Changes

**`core/channels/incoming.go`** (new)

- `Incoming` — an ordered, heterogeneous batch: `Msg`, `Status`, `Event`, and `Ignored` (for a part of a request we understood but didn't act on, which isn't written but is still described in the response).
- `WriteIncoming` — writes items in order, returning an `IncomingResult` per item carrying an `Outcome` of `written` / `duplicate` / `ignored` / `failed`. Order is preserved because messages and events are queued to mailroom as they're written, and mailroom handles a contact's tasks in queue order. It stops at the first failure, so the results describe the prefix it got through rather than discarding a half-written batch.
- `IncomingEvents` — the events to hand back to the server for stats. Duplicates are included, matching existing behaviour.
- `WriteIncomingResponse` — the standard `Events Handled` envelope.

**`handlers/responses.go`** — `WriteMsgsAndResponse` and `WriteMsgStatusAndResponse` now build an `Incoming` instead of calling the model writers, so no handler code reaches for them. Adds `WriteChannelEventAndResponse`: channel events had no shared helper at all, which is why every one of their call sites wrote its own. `WriteMsgStatusAndResponse` gains a trailing `clog` parameter so it can build an `Incoming` like its siblings (24 mechanical call sites).

**Migrated call sites**

- The seven event-then-standard-response sites: telegram, jiochat, wechat, mtarget, external, viber (subscribed and unsubscribed).
- viber's welcome message, which keeps writing its own response because that response *is* the welcome message.
- twiml and messagebird, which each build a genuine mixed batch — a status plus an optional stop event — and previously wrote the event separately then appended it to the returned events.
- infobip's multi-status route.

The only direct model-writer calls left under `handlers/` are the five mixed-batch webhook handlers (meta, turn, dialog360, vk, facebook_legacy), which are deliberately left for a follow-up.

## Behavior examples

Only infobip's status route changes observably. It built its response with `make([]any, len(results))` followed by `append`, so both the response data and the returned events were prefixed with a null per status in the request:

| | Response body for a one-status callback |
|---|---|
| Before | `{"message":"statuses handled","data":[null,{"type":"status",...}]}` |
| After | `{"message":"Events Handled","data":[{"type":"status",...}]}` |

Everywhere else the response bodies are byte-identical, which is why no existing test expectations changed.

## Test plan

- [x] New `core/channels/incoming_test.go` covers a mixed batch written in order, per-item outcomes, duplicate detection, and that writing stops at the first failure while still reporting the successful prefix.
- [x] The write-path assertions check actual database rows, not just outcomes — `WriteMsg` spools on database failure and returns nil, so an outcome-only test would pass even if nothing persisted.
- [x] Response rendering covered for each item type plus the empty case.
- [x] The infobip response-shape change is locked in by two assertions anchored at the start of the body (`Status delivered` and `Status pending`). The existing `ExpectedBodyContains` values matched only the status data object, which is unchanged here, so they'd have passed against either shape. Both new assertions were verified to fail against the previous implementation.
- [x] Full suite green (`go test -p=1 -cover ./...`), with no changes to any existing expectation — the expected result given response bodies are otherwise unchanged and the test framework asserts on returned events rather than database rows.
- [x] `gofmt` and `go vet` clean.