### PR TITLE
Parse webhook payloads before writing any of them

### DIFF
--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -90,7 +90,10 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, w h
 
 	in, ignore := h.parseWhatsAppPayload(channel, payload, r, clog)
 	if ignore != "" {
-		return nil, handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, ignore)
+		// the failure is in the payload itself, so asking for it again wouldn't get any further - write whatever
+		// was parsed ahead of it rather than dropping it
+		results, _ := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+		return channels.IncomingEvents(results), handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, ignore)
 	}
 
 	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -88,23 +88,29 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, w h
 		return nil, handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, "ignoring request, no entries")
 	}
 
-	var events []channels.Event
-	var data []any
-
-	events, data, err := h.processWhatsAppPayload(ctx, channel, payload, w, r, clog)
-	if err != nil {
-		return nil, err
+	in, ignore := h.parseWhatsAppPayload(channel, payload, r, clog)
+	if ignore != "" {
+		return nil, handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, ignore)
 	}
 
-	return events, channels.WriteDataResponse(w, http.StatusOK, "Events Handled", data)
+	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+	if err != nil {
+		// whatever was written before the failure still happened, so report it rather than losing it from our
+		// logging and stats - the response is still an error, so the provider resends and the messages dedupe
+		return channels.IncomingEvents(results), err
+	}
+
+	return channels.IncomingEvents(results), channels.WriteIncomingResponse(w, results)
 }
 
-func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Channel, payload *Notifications, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, []any, error) {
-	// the list of events we deal with
-	events := make([]channels.Event, 0, 2)
-
-	// the list of data we will return in our response
-	data := make([]any, 0, 2)
+// parseWhatsAppPayload turns a notification into the set of things it contained, without writing any of them -
+// which is what lets the whole batch be written together, and keeps a failure part way through it from leaving
+// a response that describes more than we actually did. It still does I/O, since resolving a message's media
+// means asking the provider for its URL, but it makes no changes.
+//
+// A non-empty second return means the request should be ignored in its entirety.
+func (h *handler) parseWhatsAppPayload(channel *models.Channel, payload *Notifications, r *http.Request, clog *models.ChannelLog) (*channels.Incoming, string) {
+	in := channels.NewIncoming()
 
 	seenMsgIDs := make(map[string]bool)
 	contactNames := make(map[string]string)
@@ -134,13 +140,13 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Ch
 				}
 
 				if waMsg.GroupID != "" {
-					data = append(data, channels.NewInfoData("ignoring group message"))
+					in.Ignored("ignoring group message")
 					continue
 				}
 
 				date, urn, text, mediaURL, mediaID, err, finalErr := waMsg.ExtractData(clog)
 				if finalErr != nil {
-					return nil, nil, handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, finalErr.Error())
+					return in, finalErr.Error()
 				}
 
 				if err != nil {
@@ -181,13 +187,7 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Ch
 					}
 				}
 
-				err = models.WriteMsg(ctx, h.Runtime(), event, clog)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				events = append(events, event)
-				data = append(data, channels.NewMsgReceiveData(event))
+				in.Msg(event)
 				seenMsgIDs[waMsg.ID] = true
 			}
 
@@ -196,9 +196,10 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Ch
 				msgStatus, found := whatsapp.StatusMapping[status.Status]
 				if !found {
 					if whatsapp.IgnoreStatuses[status.Status] {
-						data = append(data, channels.NewInfoData(fmt.Sprintf("ignoring status: %s", status.Status)))
+						in.Ignored(fmt.Sprintf("ignoring status: %s", status.Status))
 					} else {
-						handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, fmt.Sprintf("unknown status: %s", status.Status))
+						channels.LogRequestIgnored(r, channel, fmt.Sprintf("unknown status: %s", status.Status))
+						in.Ignored(fmt.Sprintf("unknown status: %s", status.Status))
 					}
 					continue
 				}
@@ -207,15 +208,7 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Ch
 					clog.Error(models.ErrorExternal(strconv.Itoa(statusError.Code), statusError.Title))
 				}
 
-				event := models.NewStatusUpdateByExternalID(channel, status.ID, msgStatus, clog)
-				err := models.WriteStatusUpdate(ctx, h.Runtime(), event)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				events = append(events, event)
-				data = append(data, channels.NewStatusData(event))
-
+				in.Status(models.NewStatusUpdateByExternalID(channel, status.ID, msgStatus, clog))
 			}
 
 			for _, chError := range change.Value.Errors {
@@ -225,7 +218,8 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Ch
 		}
 
 	}
-	return events, data, nil
+
+	return in, ""
 }
 
 // BuildAttachmentRequest to download media for message attachment with Bearer token set

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -278,11 +278,13 @@ var testCasesD3C = []IncomingTestCase{
 		ExpectedErrors:       []*svclogs.Error{models.ErrorExternal("131014", "Request for url https://URL.jpg failed with error: 404 (Not Found)")},
 	},
 	{
-		Label:                "Receive Invalid Status",
-		URL:                  d3CReceiveURL,
-		Data:                 string(test.ReadFile("../meta/testdata/wac/invalid_status.json")),
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"unknown status: in_orbit"`,
+		Label:              "Receive Invalid Status",
+		URL:                d3CReceiveURL,
+		Data:               string(test.ReadFile("../meta/testdata/wac/invalid_status.json")),
+		ExpectedRespStatus: 200,
+		// anchored at the start of the body because an unknown status used to write a whole "Ignored" response
+		// of its own and then carry on, leaving two JSON documents concatenated in the one response
+		ExpectedBodyContains: `{"message":"Events Handled","data":[{"type":"info","info":"unknown status: in_orbit"}]}`,
 	},
 	{
 		Label:                "Receive Ignore Status",

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -218,11 +218,30 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 		return nil, handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, "ignoring request, no entries")
 	}
 
-	// the list of events we deal with
-	events := make([]channels.Event, 0, 2)
+	in, err := h.parseEvents(channel, payload, clog)
+	if err != nil {
+		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
+	}
 
-	// the list of data we will return in our response
-	data := make([]any, 0, 2)
+	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+	if err != nil {
+		// whatever was written before the failure still happened, so report it rather than losing it from our
+		// logging and stats - the response is still an error, so the provider resends the batch
+		return channels.IncomingEvents(results), err
+	}
+
+	return channels.IncomingEvents(results), channels.WriteIncomingResponse(w, results)
+}
+
+// parseEvents turns a payload into the set of things it contained, without writing any of them - which is what
+// lets the whole batch be written together, and keeps a failure part way through it from leaving a response
+// that describes more than we actually did.
+//
+// It matters most here because this handler creates channel events, which have no duplicate detection of their
+// own: a parse failure used to leave the events before it written and then ask the provider to resend the whole
+// batch, which wrote them a second time.
+func (h *handler) parseEvents(channel *models.Channel, payload *moPayload, clog *models.ChannelLog) (*channels.Incoming, error) {
+	in := channels.NewIncoming()
 
 	seenMsgIDs := make(map[string]bool, 2)
 
@@ -247,7 +266,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 		// create our URN
 		urn, err := urns.New(urns.Facebook, msg.Sender.ID)
 		if err != nil {
-			return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, errors.New("invalid facebook id"))
+			return in, errors.New("invalid facebook id")
 		}
 		if msg.OptIn != nil {
 			event := models.NewChannelEvent(channel, models.EventTypeReferral, urn, clog).WithOccurredOn(date)
@@ -256,13 +275,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 			extra := map[string]string{referrerIDKey: msg.OptIn.Ref}
 			event = event.WithExtra(extra)
 
-			err := models.WriteChannelEvent(ctx, h.Runtime(), event, clog)
-			if err != nil {
-				return nil, err
-			}
-
-			events = append(events, event)
-			data = append(data, channels.NewEventReceiveData(event))
+			in.Event(event)
 
 		} else if msg.Postback != nil {
 			// by default postbacks are treated as new conversations, unless we have referral information
@@ -291,13 +304,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 
 			event = event.WithExtra(extra)
 
-			err := models.WriteChannelEvent(ctx, h.Runtime(), event, clog)
-			if err != nil {
-				return nil, err
-			}
-
-			events = append(events, event)
-			data = append(data, channels.NewEventReceiveData(event))
+			in.Event(event)
 
 		} else if msg.Referral != nil {
 			// this is an incoming referral
@@ -317,13 +324,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 			}
 			event = event.WithExtra(extra)
 
-			err := models.WriteChannelEvent(ctx, h.Runtime(), event, clog)
-			if err != nil {
-				return nil, err
-			}
-
-			events = append(events, event)
-			data = append(data, channels.NewEventReceiveData(event))
+			in.Event(event)
 
 		} else if msg.Message != nil {
 			// this is an incoming message
@@ -333,7 +334,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 
 			// ignore echos
 			if msg.Message.IsEcho {
-				data = append(data, channels.NewInfoData("ignoring echo"))
+				in.Ignored("ignoring echo")
 				continue
 			}
 
@@ -377,34 +378,21 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 				event.WithAttachment(attURL)
 			}
 
-			err := models.WriteMsg(ctx, h.Runtime(), event, clog)
-			if err != nil {
-				return nil, err
-			}
-
-			events = append(events, event)
-			data = append(data, channels.NewMsgReceiveData(event))
+			in.Msg(event)
 			seenMsgIDs[msg.Message.MID] = true
 
 		} else if msg.Delivery != nil {
 			// this is a delivery report
 			for _, mid := range msg.Delivery.MIDs {
-				event := models.NewStatusUpdateByExternalID(channel, mid, models.MsgStatusDelivered, clog)
-				err := models.WriteStatusUpdate(ctx, h.Runtime(), event)
-				if err != nil {
-					return nil, err
-				}
-
-				events = append(events, event)
-				data = append(data, channels.NewStatusData(event))
+				in.Status(models.NewStatusUpdateByExternalID(channel, mid, models.MsgStatusDelivered, clog))
 			}
 
 		} else {
-			data = append(data, channels.NewInfoData("ignoring unknown entry type"))
+			in.Ignored("ignoring unknown entry type")
 		}
 	}
 
-	return events, channels.WriteDataResponse(w, http.StatusOK, "Events Handled", data)
+	return in, nil
 }
 
 //	{

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -220,7 +220,10 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 
 	in, err := h.parseEvents(channel, payload, clog)
 	if err != nil {
-		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
+		// the failure is in the payload itself, so asking for it again wouldn't get any further - write whatever
+		// was parsed ahead of it rather than dropping it
+		results, _ := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+		return channels.IncomingEvents(results), handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
 	}
 
 	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -225,29 +225,34 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 		return nil, handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, "ignoring request, no entries")
 	}
 
-	var events []channels.Event
-	var data []any
+	var in *channels.Incoming
 
 	if channel.ChannelType() == "FBA" || channel.ChannelType() == "IG" {
-		events, data, err = h.processFacebookInstagramPayload(ctx, channel, payload, w, r, clog)
+		in, err = h.parseFacebookInstagramPayload(ctx, channel, payload, r, clog)
 	} else {
-		events, data, err = h.processWhatsAppPayload(ctx, channel, payload, w, r, clog)
-
+		in, err = h.parseWhatsAppPayload(channel, payload, r, clog)
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
 	}
 
-	return events, channels.WriteDataResponse(w, http.StatusOK, "Events Handled", data)
+	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+	if err != nil {
+		// whatever was written before the failure still happened, so report it rather than losing it from our
+		// logging and stats - the response is still an error, though this handler reports those as 200s
+		return channels.IncomingEvents(results), err
+	}
+
+	return channels.IncomingEvents(results), channels.WriteIncomingResponse(w, results)
 }
 
-func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Channel, payload *Notifications, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, []any, error) {
-	// the list of events we deal with
-	events := make([]channels.Event, 0, 2)
-
-	// the list of data we will return in our response
-	data := make([]any, 0, 2)
+// parseWhatsAppPayload turns a notification into the set of things it contained, without writing any of them -
+// which is what lets the whole batch be written together, and keeps a failure part way through it from leaving
+// a response that describes more than we actually did. It still does I/O, since resolving a message's media
+// means asking the provider for its URL, but it makes no changes.
+func (h *handler) parseWhatsAppPayload(channel *models.Channel, payload *Notifications, r *http.Request, clog *models.ChannelLog) (*channels.Incoming, error) {
+	in := channels.NewIncoming()
 
 	token := h.Runtime().Config.WhatsappAdminSystemUserToken
 
@@ -279,13 +284,13 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Ch
 				}
 
 				if waMsg.GroupID != "" {
-					data = append(data, channels.NewInfoData("ignoring group message"))
+					in.Ignored("ignoring group message")
 					continue
 				}
 
 				date, urn, text, mediaURL, mediaID, err, finalErr := waMsg.ExtractData(clog)
 				if finalErr != nil {
-					return nil, nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, finalErr)
+					return in, finalErr
 				}
 
 				if err != nil {
@@ -326,13 +331,7 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Ch
 					}
 				}
 
-				err = models.WriteMsg(ctx, h.Runtime(), event, clog)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				events = append(events, event)
-				data = append(data, channels.NewMsgReceiveData(event))
+				in.Msg(event)
 				seenMsgIDs[waMsg.ID] = true
 			}
 
@@ -341,9 +340,10 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Ch
 				msgStatus, found := whatsapp.StatusMapping[status.Status]
 				if !found {
 					if whatsapp.IgnoreStatuses[status.Status] {
-						data = append(data, channels.NewInfoData(fmt.Sprintf("ignoring status: %s", status.Status)))
+						in.Ignored(fmt.Sprintf("ignoring status: %s", status.Status))
 					} else {
-						handlers.WriteAndLogRequestError(ctx, h, channel, w, r, fmt.Errorf("unknown status: %s", status.Status))
+						channels.LogRequestError(r, channel, fmt.Errorf("unknown status: %s", status.Status))
+						in.Ignored(fmt.Sprintf("unknown status: %s", status.Status))
 					}
 					continue
 				}
@@ -352,15 +352,7 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Ch
 					statusError.ErrorChannelLog(clog)
 				}
 
-				event := models.NewStatusUpdateByExternalID(channel, status.ID, msgStatus, clog)
-				err := models.WriteStatusUpdate(ctx, h.Runtime(), event)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				events = append(events, event)
-				data = append(data, channels.NewStatusData(event))
-
+				in.Status(models.NewStatusUpdateByExternalID(channel, status.ID, msgStatus, clog))
 			}
 
 			for _, chError := range change.Value.Errors {
@@ -370,17 +362,20 @@ func (h *handler) processWhatsAppPayload(ctx context.Context, channel *models.Ch
 		}
 
 	}
-	return events, data, nil
+
+	return in, nil
 }
 
-func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel *models.Channel, payload *Notifications, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, []any, error) {
+// parseFacebookInstagramPayload turns a notification into the set of things it contained, without writing any
+// of them. It matters most for this payload shape, which carries channel events - those have no duplicate
+// detection of their own, so a parse failure part way through used to leave the events before it written and
+// then ask the provider to resend the whole batch, writing them a second time.
+//
+// It takes a context because a deleted message is acted on as it's parsed rather than being part of the batch.
+func (h *handler) parseFacebookInstagramPayload(ctx context.Context, channel *models.Channel, payload *Notifications, r *http.Request, clog *models.ChannelLog) (*channels.Incoming, error) {
+	in := channels.NewIncoming()
+
 	var err error
-
-	// the list of events we deal with
-	events := make([]channels.Event, 0, 2)
-
-	// the list of data we will return in our response
-	data := make([]any, 0, 2)
 
 	seenMsgIDs := make(map[string]bool, 2)
 
@@ -412,31 +407,25 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel *
 		if payload.Object == "instagram" {
 			urn, err = urns.New(urns.Instagram, sender)
 			if err != nil {
-				return nil, nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, errors.New("invalid instagram id"))
+				return in, errors.New("invalid instagram id")
 			}
 		} else {
 			urn, err = urns.New(urns.Facebook, sender)
 			if err != nil {
-				return nil, nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, errors.New("invalid facebook id"))
+				return in, errors.New("invalid facebook id")
 			}
 		}
 
 		if msg.OptIn != nil {
 			if msg.OptIn.Type == "notification_messages" {
-				data = append(data, channels.NewInfoData("ignoring optin"))
+				in.Ignored("ignoring optin")
 			} else {
 				// this is an optin from the checkbox plugin, treat it as a referral
 				event := models.NewChannelEvent(channel, models.EventTypeReferral, urn, clog).
 					WithOccurredOn(date).
 					WithExtra(map[string]string{referrerIDKey: msg.OptIn.Ref})
 
-				err := models.WriteChannelEvent(ctx, h.Runtime(), event, clog)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				events = append(events, event)
-				data = append(data, channels.NewEventReceiveData(event))
+				in.Event(event)
 			}
 
 		} else if msg.Postback != nil {
@@ -463,13 +452,7 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel *
 
 			event = event.WithExtra(extra)
 
-			err := models.WriteChannelEvent(ctx, h.Runtime(), event, clog)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			events = append(events, event)
-			data = append(data, channels.NewEventReceiveData(event))
+			in.Event(event)
 
 		} else if msg.Referral != nil {
 			// this is an incoming referral
@@ -489,13 +472,7 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel *
 			}
 			event = event.WithExtra(extra)
 
-			err := models.WriteChannelEvent(ctx, h.Runtime(), event, clog)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			events = append(events, event)
-			data = append(data, channels.NewEventReceiveData(event))
+			in.Event(event)
 
 		} else if msg.Message != nil {
 			// this is an incoming message
@@ -505,13 +482,13 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel *
 
 			// ignore echos
 			if msg.Message.IsEcho {
-				data = append(data, channels.NewInfoData("ignoring echo"))
+				in.Ignored("ignoring echo")
 				continue
 			}
 
 			if msg.Message.IsDeleted {
 				models.DeleteMsgByExternalID(ctx, h.Runtime(), channel, msg.Message.MID)
-				data = append(data, channels.NewInfoData("msg deleted"))
+				in.Ignored("msg deleted")
 				continue
 			}
 
@@ -532,7 +509,7 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel *
 				}
 
 				if att.Type == "story_mention" {
-					data = append(data, channels.NewInfoData("ignoring story_mention"))
+					in.Ignored("ignoring story_mention")
 					continue
 				}
 
@@ -554,34 +531,21 @@ func (h *handler) processFacebookInstagramPayload(ctx context.Context, channel *
 				event.WithAttachment(attURL)
 			}
 
-			err := models.WriteMsg(ctx, h.Runtime(), event, clog)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			events = append(events, event)
-			data = append(data, channels.NewMsgReceiveData(event))
+			in.Msg(event)
 			seenMsgIDs[msg.Message.MID] = true
 
 		} else if msg.Delivery != nil {
 			// this is a delivery report
 			for _, mid := range msg.Delivery.MIDs {
-				event := models.NewStatusUpdateByExternalID(channel, mid, models.MsgStatusDelivered, clog)
-				err := models.WriteStatusUpdate(ctx, h.Runtime(), event)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				events = append(events, event)
-				data = append(data, channels.NewStatusData(event))
+				in.Status(models.NewStatusUpdateByExternalID(channel, mid, models.MsgStatusDelivered, clog))
 			}
 
 		} else {
-			data = append(data, channels.NewInfoData("ignoring unknown entry type"))
+			in.Ignored("ignoring unknown entry type")
 		}
 	}
 
-	return events, data, nil
+	return in, nil
 }
 
 func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.SendResult, clog *models.ChannelLog) error {

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -234,7 +234,10 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 	}
 
 	if err != nil {
-		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
+		// the failure is in the payload itself, so asking for it again wouldn't get any further - write whatever
+		// was parsed ahead of it rather than dropping it
+		results, _ := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+		return channels.IncomingEvents(results), handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
 	}
 
 	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -301,11 +301,13 @@ var whatsappIncomingTests = []IncomingTestCase{
 		PrepRequest: addValidSignature,
 	},
 	{
-		Label:                "Receive Invalid Status",
-		URL:                  whatappReceiveURL,
-		Data:                 string(test.ReadFile("./testdata/wac/invalid_status.json")),
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"unknown status: in_orbit"`,
+		Label:              "Receive Invalid Status",
+		URL:                whatappReceiveURL,
+		Data:               string(test.ReadFile("./testdata/wac/invalid_status.json")),
+		ExpectedRespStatus: 200,
+		// anchored at the start of the body because an unknown status used to write a whole "Error" response of
+		// its own and then carry on, leaving two JSON documents concatenated in the one response
+		ExpectedBodyContains: `{"message":"Events Handled","data":[{"type":"info","info":"unknown status: in_orbit"}]}`,
 		PrepRequest:          addValidSignature,
 	},
 	{

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -148,10 +148,27 @@ type eventsPayload struct {
 
 // receiveEvents is our HTTP handler function for incoming messages and status updates
 func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, payload *eventsPayload, clog *models.ChannelLog) ([]channels.Event, error) {
-	events := make([]channels.Event, 0, 2)
+	in, err := h.parseEvents(channel, payload, r, clog)
+	if err != nil {
+		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
+	}
 
-	// the list of data we will return in our response
-	data := make([]any, 0, 2)
+	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+	if err != nil {
+		// whatever was written before the failure still happened, so report it rather than losing it from our
+		// logging and stats - the response is still an error, so the provider resends and the messages dedupe
+		return channels.IncomingEvents(results), err
+	}
+
+	return channels.IncomingEvents(results), channels.WriteIncomingResponse(w, results)
+}
+
+// parseEvents turns a payload into the set of things it contained, without writing any of them - which is what
+// lets the whole batch be written together, and keeps a failure part way through it from leaving a response
+// that describes more than we actually did. It still does I/O, since resolving a message's media means asking
+// the provider for its URL, but it makes no changes.
+func (h *handler) parseEvents(channel *models.Channel, payload *eventsPayload, r *http.Request, clog *models.ChannelLog) (*channels.Incoming, error) {
+	in := channels.NewIncoming()
 
 	seenMsgIDs := make(map[string]bool, 2)
 
@@ -174,14 +191,14 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 		}
 
 		if msg.GroupID != "" {
-			data = append(data, channels.NewInfoData("ignoring group message"))
+			in.Ignored("ignoring group message")
 			continue
 		}
 
 		// create our date from the timestamp
 		ts, err := strconv.ParseInt(msg.Timestamp, 10, 64)
 		if err != nil {
-			return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, fmt.Errorf("invalid timestamp: %s", msg.Timestamp))
+			return in, fmt.Errorf("invalid timestamp: %s", msg.Timestamp)
 		}
 		date := time.Unix(ts, 0).UTC()
 
@@ -191,7 +208,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 
 		urn, err := urns.New(urns.WhatsApp, sender)
 		if err != nil {
-			return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, errors.New("invalid whatsapp id"))
+			return in, errors.New("invalid whatsapp id")
 		}
 
 		for _, msgError := range msg.Errors {
@@ -273,13 +290,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 			}
 		}
 
-		err = models.WriteMsg(ctx, h.Runtime(), event, clog)
-		if err != nil {
-			return nil, err
-		}
-
-		events = append(events, event)
-		data = append(data, channels.NewMsgReceiveData(event))
+		in.Msg(event)
 		seenMsgIDs[msg.ID] = true
 	}
 
@@ -288,9 +299,10 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 		msgStatus, found := turnWaStatusMapping[status.Status]
 		if !found {
 			if turnWaIgnoreStatuses[status.Status] {
-				data = append(data, channels.NewInfoData(fmt.Sprintf("ignoring status: %s", status.Status)))
+				in.Ignored(fmt.Sprintf("ignoring status: %s", status.Status))
 			} else {
-				handlers.WriteAndLogRequestIgnored(ctx, h, channel, w, r, fmt.Sprintf("unknown status: %s", status.Status))
+				channels.LogRequestIgnored(r, channel, fmt.Sprintf("unknown status: %s", status.Status))
+				in.Ignored(fmt.Sprintf("unknown status: %s", status.Status))
 			}
 			continue
 		}
@@ -299,17 +311,10 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 			statusError.ErrorChannelLog(clog)
 		}
 
-		event := models.NewStatusUpdateByExternalID(channel, status.ID, msgStatus, clog)
-		err := models.WriteStatusUpdate(ctx, h.Runtime(), event)
-		if err != nil {
-			return nil, err
-		}
-
-		events = append(events, event)
-		data = append(data, channels.NewStatusData(event))
+		in.Status(models.NewStatusUpdateByExternalID(channel, status.ID, msgStatus, clog))
 	}
 
-	return events, channels.WriteDataResponse(w, http.StatusOK, "Events Handled", data)
+	return in, nil
 }
 
 func resolveMediaURL(channel *models.Channel, mediaID string) (string, error) {

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -150,7 +150,10 @@ type eventsPayload struct {
 func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, payload *eventsPayload, clog *models.ChannelLog) ([]channels.Event, error) {
 	in, err := h.parseEvents(channel, payload, r, clog)
 	if err != nil {
-		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
+		// the failure is in the payload itself, so asking for it again wouldn't get any further - write whatever
+		// was parsed ahead of it rather than dropping it
+		results, _ := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+		return channels.IncomingEvents(results), handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
 	}
 
 	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -361,6 +361,34 @@ var invalidTimestamp = `{
   }]
 }`
 
+// a payload whose first message is fine and whose second can't be parsed - the unparseable one is in the data
+// rather than the transport, so redelivering it would fail the same way and the first would never land
+var validThenInvalidTimestamp = `{
+	"contacts":[{
+		"profile": {
+			"name": "Jerry Cooney"
+		},
+		"wa_id": "250788123123"
+	}],
+  "messages": [{
+    "from": "250788123123",
+    "id": "41",
+    "timestamp": "1454119029",
+    "text": {
+      "body": "hello world"
+    },
+    "type": "text"
+   },{
+    "from": "250788123123",
+    "id": "42",
+    "timestamp": "asdf",
+    "text": {
+      "body": "second message"
+    },
+    "type": "text"
+   }]
+}`
+
 var invalidMsg = `not json`
 
 var validStatus = `
@@ -725,6 +753,17 @@ var testCasesTurn = []IncomingTestCase{
 		Data:                 invalidTimestamp,
 		ExpectedRespStatus:   400,
 		ExpectedBodyContains: "invalid timestamp",
+	},
+	{
+		Label:                "Receive valid message ahead of an invalid one",
+		URL:                  turnWhatsappReceiveURL,
+		Data:                 validThenInvalidTimestamp,
+		ExpectedRespStatus:   400,
+		ExpectedBodyContains: "invalid timestamp",
+		ExpectedContactName:  Sp("Jerry Cooney"),
+		ExpectedMsgText:      Sp("hello world"),
+		ExpectedURN:          "whatsapp:250788123123",
+		ExpectedExternalID:   "41",
 	},
 
 	{

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -758,11 +758,13 @@ var testCasesTurn = []IncomingTestCase{
 		},
 	},
 	{
-		Label:                "Receive invalid status",
-		URL:                  turnWhatsappReceiveURL,
-		Data:                 invalidStatus,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"unknown status: in_orbit"`,
+		Label:              "Receive invalid status",
+		URL:                turnWhatsappReceiveURL,
+		Data:               invalidStatus,
+		ExpectedRespStatus: 200,
+		// anchored at the start of the body because an unknown status used to write a whole "Ignored" response
+		// of its own and then carry on, leaving two JSON documents concatenated in the one response
+		ExpectedBodyContains: `{"message":"Events Handled","data":[{"type":"info","info":"unknown status: in_orbit"}]}`,
 	},
 	{
 		Label:                "Receive ignore status",

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -255,14 +255,19 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, w
 	if msg.Text() == "" && len(msg.Attachments()) == 0 {
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, errors.New("no text or attachment"))
 	}
-	// save message to our backend
-	if err := models.WriteMsg(ctx, h.Runtime(), msg, clog); err != nil {
+	// save message to our backend - a VK notification only ever carries the one message, so this is the
+	// degenerate case of a batch, but it keeps writing in the one place that owns it
+	in := channels.NewIncoming()
+	in.Msg(msg)
+
+	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
+	if err != nil {
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
 	}
 	// write required response
 	_, err = fmt.Fprint(w, responseIncomingMessage)
 
-	return []channels.Event{msg}, err
+	return channels.IncomingEvents(results), err
 }
 
 // DescribeURN handles VK contact details


### PR DESCRIPTION
## Summary

Follow-up to #1148, which added `channels.Incoming` and `channels.WriteIncoming`. This migrates the five handlers that receive mixed webhook batches — dialog360, turn, facebook_legacy, vk and meta — from writing each event as they parse it to parsing the whole payload first and writing it as one batch.

With these, **no handler calls `models.WriteMsg` / `WriteStatusUpdate` / `WriteChannelEvent` directly any more**, so that seam can now be enforced by a lint.

## Changes

One commit per handler. Each turns its `processX`/inline loop into a `parseX` that returns a `*channels.Incoming` and makes no changes, leaving the entrypoint to write the batch and render the response.

- **dialog360** — `parseWhatsAppPayload`
- **turn** — `parseEvents`
- **facebook_legacy** — `parseEvents`
- **vk** — the degenerate case; a notification only ever carries one message, and its plain text `ok` response is unchanged. Migrated so that writing lives in one place.
- **meta** — `parseWhatsAppPayload` and `parseFacebookInstagramPayload`, covering both payload shapes

Parsing still does I/O where it always did — resolving a message's media means asking the provider for its URL — and meta still acts on a deleted message as it parses it. What changed is that nothing is *written* until the whole payload has been read.

A final commit handles the case where part of a payload can't be parsed at all: whatever was parsed ahead of it is still written, then the handler responds as it did before. Splitting parse from write introduced that hazard, and review caught it — see **Review notes**.

## Behavior examples

**One response document instead of two.** An unknown status wrote a complete response and then carried on to write a second one at the end of the batch:

| | Response to a status this handler doesn't recognize |
|---|---|
| Before | `{"message":"Ignored","data":[{"type":"info","info":"unknown status: in_orbit"}]}` `{"message":"Events Handled","data":[]}` |
| After | `{"message":"Events Handled","data":[{"type":"info","info":"unknown status: in_orbit"}]}` |

Four such paths are fixed: two in dialog360, one in turn, one in meta. `ExpectedBodyContains` couldn't see them, since it can't distinguish one JSON document from two.

**Partial failures are reported.** A write failure part way through a batch returned no events at all, so the request was recorded as ignored despite having written rows. It now returns whatever was written before the failure. The response is still an error.

## Review notes

The bot review caught a regression this PR introduced, in meta and dialog360. Parsing the whole payload first meant that a payload whose later entries couldn't be parsed discarded the ones ahead of them, which had previously been written inline. Because the failure is in the payload rather than the transport, redelivery fails identically — so on the handlers that ack with 200 (meta, dialog360) those events were lost permanently, and on the ones that respond 400 and are resent (turn, facebook_legacy — which the review didn't cover, but had the same defect) they never landed at all.

Fixed in `eb3cf7d3` by writing the parsed prefix before responding, with a regression test on turn verified to fail without it.

Not changed: turn and facebook_legacy still answer 400 on an unparseable payload, which means their channel events are rewritten on each redelivery. That predates this PR, and widening scope while fixing a regression invites a second one. It does mean the parse-first change only removes channel-event duplication where the handler already acks with a 200 — an earlier draft of this description claimed that benefit more broadly than it holds.

## Test plan

- [x] Each of the four response fixes is locked by an assertion anchored at the *start* of the body, and each was verified to fail against the pre-change handler by reverting it and re-running.
- [x] The prefix-discard regression has a test (`Receive valid message ahead of an invalid one`) asserting the first message is still written, verified to fail with the fix reverted.
- [x] Full suite green (`go test -p=1 -cover ./...`) after each commit.
- [x] No existing expectations changed except those four — the successful-path response bodies are byte-identical, since the standard envelope is what these handlers already built by hand.
- [x] `gofmt` and `go vet` clean.

## Notes

Two things deliberately left out, both for want of a caller:

- **Continue-on-error on `WriteIncoming`.** None of the five wants to ACK a partially written batch; abort plus provider redelivery is right for all of them.
- **Channel event dedupe.** Channel events carry no external ID, so a fingerprint for them needs its own design.

The four `seenMsgIDs` maps are also still per-handler. They are near-identical and could move into `Incoming`, but it would have to stay explicit rather than becoming implicit in `Incoming.Msg()` — silently deduping on external ID would drop messages that legitimately share one, which is the bug #1147 just fixed in zenvia.