### PR TITLE
Document where writing an incoming request belongs

### DIFF
--- a/core/channels/doc.go
+++ b/core/channels/doc.go
@@ -1,0 +1,16 @@
+// Package channels is what a channel handler is written against: the handler contract itself, the routes a
+// handler registers, the responses and errors it can write, and - in Incoming and WriteIncoming - the one
+// place that writes what a handler parsed out of a request.
+//
+// That last part is the convention worth knowing. Incoming events are written here, never by a handler: a
+// handler turns a provider's payload into an Incoming and hands it over. A handler that writes for itself
+// opts out of everything WriteIncoming does - writing a request's events in order, and reporting what became
+// of each one so that the response and our stats describe what actually happened rather than what was
+// attempted - and it opts out silently, which is what makes it worth stating.
+//
+// Everything else in core/models is a handler's to use directly. Models owns the data - the types, the
+// constants and the database access - and handlers lean on it constantly, building a models.MsgIn, reading
+// models.ConfigAuthToken, looking a channel up with models.GetChannel. The line is drawn around incoming
+// events rather than around side effects in general: webchat creating a contact when a chat starts isn't an
+// incoming event, and calls models.GetContact for itself.
+package channels

--- a/core/channels/incoming.go
+++ b/core/channels/incoming.go
@@ -18,18 +18,26 @@ import (
 // had to write each part as they parsed it and hand-roll their own response, which leaves no single place
 // to apply anything that spans the request.
 type Incoming struct {
-	items []incomingItem
+	channel *models.Channel
+	items   []incomingItem
 }
 
-// one thing an incoming request contained: either something to write, or a note that we ignored part of the
-// request - which isn't written anywhere but is still described in the response
+// one thing an incoming request contained: an event to write, a message the provider has deleted, or a note
+// that we ignored part of the request - which isn't written anywhere but is still described in the response
 type incomingItem struct {
 	event   Event
+	deleted *deletedMsg
 	ignored string
 }
 
-// NewIncoming creates an empty set of incoming items for a handler to add to
-func NewIncoming() *Incoming { return &Incoming{} }
+// a message we'd previously received which the provider has since deleted
+type deletedMsg struct {
+	externalID string
+}
+
+// NewIncoming creates an empty set of incoming items for a handler to add to. Everything one request
+// contained is for the same channel - the one the server resolved before the handler was called.
+func NewIncoming(ch *models.Channel) *Incoming { return &Incoming{channel: ch} }
 
 // Msg adds a message parsed from the request
 func (i *Incoming) Msg(m *models.MsgIn) { i.items = append(i.items, incomingItem{event: m}) }
@@ -40,12 +48,22 @@ func (i *Incoming) Status(s *models.StatusUpdate) { i.items = append(i.items, in
 // Event adds a channel event parsed from the request
 func (i *Incoming) Event(e *models.ChannelEvent) { i.items = append(i.items, incomingItem{event: e}) }
 
+// DeletedMsg notes that a message we'd received has since been deleted at the provider, which some of them
+// report on the same webhook that delivered it. It's part of the batch rather than something the handler acts
+// on as it parses, so that it happens in order with the rest of the request and can report a failure.
+func (i *Incoming) DeletedMsg(externalID string) {
+	i.items = append(i.items, incomingItem{deleted: &deletedMsg{externalID: externalID}})
+}
+
 // Ignored notes a part of the request we understood but didn't act on, such as a message echoed back to us.
 // Nothing is written for it, but it appears in the response so that what we saw is visible to the provider.
 func (i *Incoming) Ignored(details string) { i.items = append(i.items, incomingItem{ignored: details}) }
 
 // Len returns how many items have been added
 func (i *Incoming) Len() int { return len(i.items) }
+
+// what the response says for a message the provider deleted
+const msgDeletedInfo = "msg deleted"
 
 // Outcome is what became of a single item of an incoming request
 type Outcome string
@@ -84,6 +102,14 @@ func WriteIncoming(ctx context.Context, rt *runtime.Runtime, in *Incoming, clog 
 	results := make([]IncomingResult, 0, len(in.items))
 
 	for _, item := range in.items {
+		if item.deleted != nil {
+			if err := models.DeleteMsgByExternalID(ctx, rt, in.channel, item.deleted.externalID); err != nil {
+				results = append(results, IncomingResult{Details: msgDeletedInfo, Outcome: OutcomeFailed, Err: err})
+				return results, err
+			}
+			results = append(results, IncomingResult{Details: msgDeletedInfo, Outcome: OutcomeWritten})
+			continue
+		}
 		if item.event == nil {
 			results = append(results, IncomingResult{Details: item.ignored, Outcome: OutcomeIgnored})
 			continue

--- a/core/channels/incoming_test.go
+++ b/core/channels/incoming_test.go
@@ -57,7 +57,7 @@ func TestWriteIncoming(t *testing.T) {
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, ch, nil, nil)
 
 	// a mixed batch is written in the order it was added, and each item reports what became of it
-	in := channels.NewIncoming()
+	in := channels.NewIncoming(ch)
 	in.Msg(models.NewIncomingMsg(ch, "tel:+12065551212", "hello", "ext1", clog))
 	in.Ignored("ignoring echo")
 	in.Status(models.NewStatusUpdateByExternalID(ch, "ext2", models.MsgStatusDelivered, clog))
@@ -81,8 +81,21 @@ func TestWriteIncoming(t *testing.T) {
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM msgs_msg WHERE text = 'hello' AND external_identifier = 'ext1'`).Returns(1)
 	assertdb.Query(t, rt.DB, `SELECT count(*) FROM channels_channelevent WHERE event_type = 'stop_contact'`).Returns(1)
 
+	// a message the provider deleted is acted on as part of the batch, and described in the response
+	in = channels.NewIncoming(ch)
+	in.DeletedMsg("ext1")
+
+	results, err = channels.WriteIncoming(ctx, rt, in, clog)
+	assert.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, channels.OutcomeWritten, results[0].Outcome)
+	assert.Equal(t, "msg deleted", results[0].Details)
+
+	// it isn't an event, having not been received - it's something we did to one we already had
+	assert.Empty(t, channels.IncomingEvents(results))
+
 	// a message we've already received is reported as a duplicate rather than written again
-	in = channels.NewIncoming()
+	in = channels.NewIncoming(ch)
 	in.Msg(models.NewIncomingMsg(ch, "tel:+12065551212", "hello", "ext1", clog))
 
 	results, err = channels.WriteIncoming(ctx, rt, in, clog)
@@ -94,7 +107,7 @@ func TestWriteIncoming(t *testing.T) {
 	assert.Len(t, channels.IncomingEvents(results), 1)
 
 	// writing stops at the first item that fails, so the results describe the prefix we got through
-	in = channels.NewIncoming()
+	in = channels.NewIncoming(ch)
 	in.Msg(models.NewIncomingMsg(ch, "tel:+12065551212", "first", "ext3", clog))
 	in.Msg(models.NewIncomingMsg(ch, "tel:+12065551212", "second", "ext4", clog).WithAttachment("data:....."))
 	in.Msg(models.NewIncomingMsg(ch, "tel:+12065551212", "third", "ext5", clog))

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -113,7 +113,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, w h
 //
 // A non-empty second return means the request should be ignored in its entirety.
 func (h *handler) parseWhatsAppPayload(channel *models.Channel, payload *Notifications, r *http.Request, clog *models.ChannelLog) (*channels.Incoming, string) {
-	in := channels.NewIncoming()
+	in := channels.NewIncoming(channel)
 
 	seenMsgIDs := make(map[string]bool)
 	contactNames := make(map[string]string)

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -244,7 +244,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 // own: a parse failure used to leave the events before it written and then ask the provider to resend the whole
 // batch, which wrote them a second time.
 func (h *handler) parseEvents(channel *models.Channel, payload *moPayload, clog *models.ChannelLog) (*channels.Incoming, error) {
-	in := channels.NewIncoming()
+	in := channels.NewIncoming(channel)
 
 	seenMsgIDs := make(map[string]bool, 2)
 

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -58,7 +58,7 @@ type ibStatus struct {
 
 // statusMessage is our HTTP handler function for status updates
 func (h *handler) statusMessage(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, payload *statusPayload, clog *models.ChannelLog) ([]channels.Event, error) {
-	in := channels.NewIncoming()
+	in := channels.NewIncoming(channel)
 
 	for _, s := range payload.Results {
 		msgStatus, found := statusMapping[s.Status.GroupName]

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -138,7 +138,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 		clog.Error(models.ErrorExternal(fmt.Sprint(receivedStatus.StatusErrorCode), "Contact has sent 'stop'"))
 	}
 
-	in := channels.NewIncoming()
+	in := channels.NewIncoming(channel)
 	if stopEvent != nil {
 		in.Event(stopEvent)
 	}

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -228,7 +228,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 	var in *channels.Incoming
 
 	if channel.ChannelType() == "FBA" || channel.ChannelType() == "IG" {
-		in, err = h.parseFacebookInstagramPayload(ctx, channel, payload, r, clog)
+		in, err = h.parseFacebookInstagramPayload(channel, payload, r, clog)
 	} else {
 		in, err = h.parseWhatsAppPayload(channel, payload, r, clog)
 	}
@@ -255,7 +255,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 // a response that describes more than we actually did. It still does I/O, since resolving a message's media
 // means asking the provider for its URL, but it makes no changes.
 func (h *handler) parseWhatsAppPayload(channel *models.Channel, payload *Notifications, r *http.Request, clog *models.ChannelLog) (*channels.Incoming, error) {
-	in := channels.NewIncoming()
+	in := channels.NewIncoming(channel)
 
 	token := h.Runtime().Config.WhatsappAdminSystemUserToken
 
@@ -373,10 +373,8 @@ func (h *handler) parseWhatsAppPayload(channel *models.Channel, payload *Notific
 // of them. It matters most for this payload shape, which carries channel events - those have no duplicate
 // detection of their own, so a parse failure part way through used to leave the events before it written and
 // then ask the provider to resend the whole batch, writing them a second time.
-//
-// It takes a context because a deleted message is acted on as it's parsed rather than being part of the batch.
-func (h *handler) parseFacebookInstagramPayload(ctx context.Context, channel *models.Channel, payload *Notifications, r *http.Request, clog *models.ChannelLog) (*channels.Incoming, error) {
-	in := channels.NewIncoming()
+func (h *handler) parseFacebookInstagramPayload(channel *models.Channel, payload *Notifications, r *http.Request, clog *models.ChannelLog) (*channels.Incoming, error) {
+	in := channels.NewIncoming(channel)
 
 	var err error
 
@@ -490,8 +488,7 @@ func (h *handler) parseFacebookInstagramPayload(ctx context.Context, channel *mo
 			}
 
 			if msg.Message.IsDeleted {
-				models.DeleteMsgByExternalID(ctx, h.Runtime(), channel, msg.Message.MID)
-				in.Ignored("msg deleted")
+				in.DeletedMsg(msg.Message.MID)
 				continue
 			}
 

--- a/handlers/meta/instagram_test.go
+++ b/handlers/meta/instagram_test.go
@@ -171,11 +171,12 @@ var instagramIncomingTests = []IncomingTestCase{
 		PrepRequest:          addValidSignature,
 	},
 	{
-		Label:                "Message unsent",
-		URL:                  "/c/ig/receive",
-		Data:                 string(test.ReadFile("./testdata/ig/unsent_msg.json")),
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `msg deleted`,
+		Label:              "Message unsent",
+		URL:                "/c/ig/receive",
+		Data:               string(test.ReadFile("./testdata/ig/unsent_msg.json")),
+		ExpectedRespStatus: 200,
+		// the deletion is part of the batch now, so it shows up in the response like any other item
+		ExpectedBodyContains: `{"message":"Events Handled","data":[{"type":"info","info":"msg deleted"}]}`,
 		PrepRequest:          addValidSignature,
 	},
 }

--- a/handlers/responses.go
+++ b/handlers/responses.go
@@ -10,7 +10,13 @@ import (
 
 // WriteMsgsAndResponse writes the passed in messages and responds with the handler's message success response
 func WriteMsgsAndResponse(ctx context.Context, h channels.Handler, msgs []*models.MsgIn, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
-	in := channels.NewIncoming()
+	// a request with nothing in it has no channel to speak of, and nothing to write
+	if len(msgs) == 0 {
+		return nil, h.WriteMsgSuccessResponse(ctx, w, msgs)
+	}
+
+	// every message in a request is for the channel the server resolved before calling the handler
+	in := channels.NewIncoming(msgs[0].Channel())
 	for _, m := range msgs {
 		in.Msg(m)
 	}
@@ -25,7 +31,7 @@ func WriteMsgsAndResponse(ctx context.Context, h channels.Handler, msgs []*model
 
 // WriteMsgStatusAndResponse writes the passed in status and responds with the handler's status success response
 func WriteMsgStatusAndResponse(ctx context.Context, h channels.Handler, channel *models.Channel, status *models.StatusUpdate, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
-	in := channels.NewIncoming()
+	in := channels.NewIncoming(channel)
 	in.Status(status)
 
 	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)
@@ -39,7 +45,7 @@ func WriteMsgStatusAndResponse(ctx context.Context, h channels.Handler, channel 
 // WriteChannelEventAndResponse writes the passed in channel event and responds with the standard event success
 // response
 func WriteChannelEventAndResponse(ctx context.Context, h channels.Handler, event *models.ChannelEvent, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
-	in := channels.NewIncoming()
+	in := channels.NewIncoming(event.Channel())
 	in.Event(event)
 
 	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -171,7 +171,7 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, w 
 // that describes more than we actually did. It still does I/O, since resolving a message's media means asking
 // the provider for its URL, but it makes no changes.
 func (h *handler) parseEvents(channel *models.Channel, payload *eventsPayload, r *http.Request, clog *models.ChannelLog) (*channels.Incoming, error) {
-	in := channels.NewIncoming()
+	in := channels.NewIncoming(channel)
 
 	seenMsgIDs := make(map[string]bool, 2)
 

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -226,7 +226,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, w 
 		}
 	}
 
-	in := channels.NewIncoming()
+	in := channels.NewIncoming(channel)
 	if stopEvent != nil {
 		in.Event(stopEvent)
 	}

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -150,7 +150,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, w h
 
 		// the response to this is itself the welcome message, so we write it ourselves rather than using
 		// one of the standard responses
-		in := channels.NewIncoming()
+		in := channels.NewIncoming(channel)
 		in.Event(channelEvent)
 
 		results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -257,7 +257,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, w
 	}
 	// save message to our backend - a VK notification only ever carries the one message, so this is the
 	// degenerate case of a batch, but it keeps writing in the one place that owns it
-	in := channels.NewIncoming()
+	in := channels.NewIncoming(channel)
 	in.Msg(msg)
 
 	results, err := channels.WriteIncoming(ctx, h.Runtime(), in, clog)


### PR DESCRIPTION
## Summary

Follows #1148 and #1149 by writing down the convention they established, and moving the one thing that didn't fit it.

## Changes

**`core/channels/doc.go`** states the rule that actually holds:

> Incoming events are written in `core/channels`, never by a handler. Everything else in `core/models` is a handler's to use directly.

The line is drawn around incoming events rather than side effects in general, which is what makes it true with no exceptions. Handlers lean on `models` constantly and should — building a `models.MsgIn`, reading `models.ConfigAuthToken`, looking a channel up with `models.GetChannel` — and webchat creating a contact when a chat starts isn't an incoming event, so it calls `models.GetContact` for itself.

**`Incoming` gains `DeletedMsg`.** Some providers report on the same webhook that a message they'd delivered has since been deleted. Meta acted on that while parsing; it's now part of the batch, so it happens in order with everything else and a failure is reported rather than discarded — the return value was previously dropped on the floor. That also makes `parseFacebookInstagramPayload` side-effect free, so it no longer takes a context.

**`Incoming` is constructed with its channel.** A request only ever concerns the channel the server resolved before calling the handler, so `NewIncoming(ch)` states that once instead of passing a channel to an instance that already implies one:

```go
in := channels.NewIncoming(channel)
in.Msg(msg)
in.DeletedMsg(externalID)
in.Ignored("ignoring echo")
```

`WriteMsgStatusAndResponse` now uses the `channel` parameter it has carried unused since before this work. `WriteMsgsAndResponse` derives the channel from the messages it was given rather than taking one, since every `MsgIn` already knows its channel — and it now returns early for an empty batch, which zenvia can produce from a payload with no contents, rather than relying on that never happening.

## Behavior examples

The response for a deleted message is unchanged, and now asserted in full rather than by substring:

```
{"message":"Events Handled","data":[{"type":"info","info":"msg deleted"}]}
```

What changed is when the delete happens — with the batch rather than during parsing — and that a failure now surfaces instead of being ignored.

## Test plan

- [x] `TestWriteIncoming` covers the new item: written in order, described in the response, and correctly not an event, since it isn't something we received.
- [x] The meta expectation for a deleted message is tightened from a substring to the whole body.
- [x] Full suite green, `gofmt` and `go vet` clean.

## Notes

Two earlier versions of this PR are worth recording, because both were worse.

The first enforced the boundary with a test that parsed the handler packages and failed on a forbidden call. A structural rule about how code is organised doesn't belong in the test suite, and it only fires once someone has written the code it objects to.

The second moved `GetContact`, `DeleteMsgByExternalID` and `WriteChannelLog` into `core/channels` as wrappers, so that "anything with side effects goes through channels" would be literally true. But that wasn't the real rule — it was an inflated version of it, and the wrappers were pass-throughs that existed only to relocate a name and make the overstatement come out true. Stating the narrower rule needs no wrappers at all, and the `GetContact` carve-out that made the first version awkward simply doesn't arise.

Worth being clear that this is a convention and not a guarantee: a handler can always import `core/models` and call `WriteMsg`. Courier used to have a `Backend` interface that handlers went through, and it wouldn't have prevented that either. What was missing was never enforcement, it was somewhere obvious to look — which is why this is a package doc next to the thing it describes.