### PR TITLE
Split the receive seam into write-then-respond

### DIFF
--- a/core/channels/receive.go
+++ b/core/channels/receive.go
@@ -27,77 +27,75 @@ func (r *Routes) AddReceive(handler Handler, method string, action string, logTy
 
 // Receive adapts a ReceiveFunc into a HandleFunc. AddReceive is how routes normally get this; it's exported
 // for the rare route that wraps its handling in something else, like the chat widget's CORS headers.
+//
+// The lifecycle is two steps: write what the receive function parsed, then answer the request. They're
+// separate because they always both happen - even a request that ends in a parse error keeps the good
+// messages ahead of the failure, since a provider that batches several messages into one request won't send
+// them again just because a later one was malformed.
 func Receive(h Handler, fn ReceiveFunc) HandleFunc {
 	return func(ctx context.Context, c *models.Channel, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]Event, error) {
 		// the batch starts out as whatever the route was registered as, which the handler can change once it
 		// knows what it's actually dealing with
 		in := NewReceived(c).As(clog.Type)
 
-		err := fn(ctx, c, r, in, clog)
+		ferr := fn(ctx, c, r, in, clog)
 
 		// whatever the handler worked out it was dealing with is what this gets logged as, however it turned
 		// out - a request we understood and then ignored is still a request of that kind
 		clog.Type = in.Kind()
 
-		if err != nil {
-			// whatever the handler parsed before it gave up is still ours to keep - a provider that batches
-			// several messages into one request won't send the good ones again just because a later one was
-			// malformed, so they're written before the failure is reported
-			events, werr := writeReceived(ctx, h, in, clog)
-			if werr != nil {
-				return events, werr
+		var results []WriteResult
+		if in.Len() > 0 {
+			var err error
+			if results, err = WriteReceived(ctx, h.Runtime(), in, clog); err != nil {
+				// a write failure is courier's problem rather than the request's, so it goes back to the
+				// server to log and answer as an error - reporting whatever was written before the failure
+				// so it isn't lost from our logging and stats
+				return AcceptedEvents(results), err
 			}
-
-			var reply *RequestReply
-			if errors.As(err, &reply) {
-				return events, reply.Write(w)
-			}
-			var ignored *IgnoredRequest
-			if errors.As(err, &ignored) {
-				return events, WriteAndLogRequestIgnored(ctx, h, w, r, c, ignored.Details)
-			}
-			var unauthenticated *UnauthenticatedRequest
-			if errors.As(err, &unauthenticated) {
-				return events, WriteAndLogUnauthorized(w, r, c, unauthenticated.Err)
-			}
-			return events, WriteAndLogRequestError(ctx, h, w, r, c, err)
 		}
 
-		return writeReceivedAndResponse(ctx, h, in, w, r, clog)
+		return AcceptedEvents(results), respond(ctx, h, w, r, in, results, ferr)
 	}
 }
 
-// writes a batch without answering for it, for the paths that answer some other way
-func writeReceived(ctx context.Context, h Handler, in *Received, clog *models.ChannelLog) ([]Event, error) {
+// respond answers the request, now that everything it contained has been written. A failure in the request
+// itself is answered here and logged at request level - it's the provider's problem, which is what separates
+// it from a write failure, which Receive hands back to the server as courier's own.
+func respond(ctx context.Context, h Handler, w http.ResponseWriter, r *http.Request, in *Received, results []WriteResult, ferr error) error {
+	c := in.Channel()
+
+	if ferr != nil {
+		var reply *RequestReply
+		if errors.As(ferr, &reply) {
+			return reply.Write(w)
+		}
+		var ignored *IgnoredRequest
+		if errors.As(ferr, &ignored) {
+			LogRequestIgnored(r, c, ignored.Details)
+			return h.WriteRequestIgnored(ctx, w, ignored.Details)
+		}
+		var unauthenticated *UnauthenticatedRequest
+		if errors.As(ferr, &unauthenticated) {
+			LogRequestError(r, c, unauthenticated.Err)
+			return WriteDataResponse(w, http.StatusUnauthorized, "Unauthorized", []any{NewErrorData(unauthenticated.Err.Error())})
+		}
+		LogRequestError(r, c, ferr)
+		return h.WriteRequestError(ctx, w, ferr)
+	}
+
+	// a request we found nothing in is one we ignored, rather than one we handled emptily - which saves
+	// every handler that can parse its way to nothing from checking for it
 	if in.Len() == 0 {
-		return nil, nil
-	}
-	results, err := WriteReceived(ctx, h.Runtime(), in, clog)
-	return AcceptedEvents(results), err
-}
-
-// writeReceivedAndResponse writes everything a request contained and then answers it.
-//
-// Which response that is comes from what the request is being handled as: a receive answers as a receive, a
-// status callback as a status. The shape a provider expects belongs to the endpoint it called rather than to
-// whatever the request happened to carry, which is why this reads the batch's declared kind instead of
-// inspecting its contents - a status callback that also stopped a contact still answers as a status callback.
-//
-// That declaration is also what the request is logged as, so the two can't drift apart.
-func writeReceivedAndResponse(ctx context.Context, h Handler, in *Received, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]Event, error) {
-	// a request we found nothing in is one we ignored, rather than one we handled emptily - which saves every
-	// handler that can parse its way to nothing from checking for it
-	if in.Len() == 0 {
-		return nil, WriteAndLogRequestIgnored(ctx, h, w, r, in.Channel(), "ignoring request, nothing to handle")
+		LogRequestIgnored(r, c, "ignoring request, nothing to handle")
+		return h.WriteRequestIgnored(ctx, w, "ignoring request, nothing to handle")
 	}
 
-	results, err := WriteReceived(ctx, h.Runtime(), in, clog)
-	if err != nil {
-		// whatever was written before the failure still happened, so report it rather than losing it from our
-		// logging and stats
-		return AcceptedEvents(results), err
-	}
-
+	// which response a written batch gets comes from what the request is being handled as: a receive answers
+	// as a receive, a status callback as a status. The shape a provider expects belongs to the endpoint it
+	// called rather than to whatever the request happened to carry, which is why this reads the batch's
+	// declared kind instead of inspecting its contents - a status callback that also stopped a contact still
+	// answers as a status callback.
 	events := AcceptedEvents(results)
 
 	switch in.Kind() {
@@ -108,7 +106,7 @@ func writeReceivedAndResponse(ctx context.Context, h Handler, in *Received, w ht
 				msgs = append(msgs, m)
 			}
 		}
-		return events, h.WriteMsgSuccessResponse(ctx, w, msgs)
+		return h.WriteMsgSuccessResponse(ctx, w, msgs)
 
 	case models.ChannelLogTypeMsgStatus:
 		statuses := make([]*models.StatusUpdate, 0, len(events))
@@ -117,7 +115,7 @@ func writeReceivedAndResponse(ctx context.Context, h Handler, in *Received, w ht
 				statuses = append(statuses, s)
 			}
 		}
-		return events, h.WriteStatusSuccessResponse(ctx, w, statuses)
+		return h.WriteStatusSuccessResponse(ctx, w, statuses)
 
 	case models.ChannelLogTypeEventReceive:
 		chEvents := make([]*models.ChannelEvent, 0, len(events))
@@ -126,9 +124,9 @@ func writeReceivedAndResponse(ctx context.Context, h Handler, in *Received, w ht
 				chEvents = append(chEvents, ce)
 			}
 		}
-		return events, WriteChannelEventsSuccess(w, chEvents)
+		return WriteChannelEventsSuccess(w, chEvents)
 
 	default:
-		return events, WriteReceivedResponse(w, results)
+		return WriteReceivedResponse(w, results)
 	}
 }

--- a/core/channels/responses.go
+++ b/core/channels/responses.go
@@ -19,12 +19,6 @@ func WriteAndLogRequestError(ctx context.Context, h Handler, w http.ResponseWrit
 	return h.WriteRequestError(ctx, w, err)
 }
 
-// WriteAndLogRequestIgnored writes a JSON response saying the request was ignored and logs why
-func WriteAndLogRequestIgnored(ctx context.Context, h Handler, w http.ResponseWriter, r *http.Request, c *models.Channel, details string) error {
-	LogRequestIgnored(r, c, details)
-	return h.WriteRequestIgnored(ctx, w, details)
-}
-
 // WriteError writes a JSON response for the passed in error
 func WriteError(w http.ResponseWriter, statusCode int, err error) error {
 	errors := []any{NewErrorData(err.Error())}
@@ -41,12 +35,6 @@ func WriteError(w http.ResponseWriter, statusCode int, err error) error {
 // WriteIgnored writes a JSON response indicating that we ignored the request
 func WriteIgnored(w http.ResponseWriter, details string) error {
 	return WriteDataResponse(w, http.StatusOK, "Ignored", []any{NewInfoData(details)})
-}
-
-// WriteAndLogUnauthorized writes a JSON response for the passed in message and logs an info message
-func WriteAndLogUnauthorized(w http.ResponseWriter, r *http.Request, c *models.Channel, err error) error {
-	LogRequestError(r, c, err)
-	return WriteDataResponse(w, http.StatusUnauthorized, "Unauthorized", []any{NewErrorData(err.Error())})
 }
 
 // WriteChannelEventSuccess writes a JSON response for the passed in event indicating we handled it

--- a/core/channels/responses_test.go
+++ b/core/channels/responses_test.go
@@ -2,7 +2,6 @@ package channels_test
 
 import (
 	"errors"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -30,17 +29,6 @@ func TestWriteIgnored(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "{\"message\":\"Ignored\",\"data\":[{\"type\":\"info\",\"info\":\"why you calling\"}]}\n", w.Body.String())
-}
-
-func TestWriteAndLogUnauthorized(t *testing.T) {
-	ch := test.NewMockChannel("5fccf4b6-48d7-4f5a-bce8-b0d1fd5342ec", "NX", "+1234567890", "US", []string{urns.Phone.Prefix}, nil)
-	r, _ := http.NewRequest("GET", "http://example.com", nil)
-	w := httptest.NewRecorder()
-
-	err := channels.WriteAndLogUnauthorized(w, r, ch, errors.New("wrong password"))
-	assert.NoError(t, err)
-	assert.Equal(t, 401, w.Code)
-	assert.Equal(t, "{\"message\":\"Unauthorized\",\"data\":[{\"type\":\"error\",\"error\":\"wrong password\"}]}\n", w.Body.String())
 }
 
 func TestWriteMsgSuccess(t *testing.T) {

--- a/handlers/slack/handler_test.go
+++ b/handlers/slack/handler_test.go
@@ -317,7 +317,7 @@ func TestVerification(t *testing.T) {
 			Data:    `{"token":"one-long-verification-token","challenge":"challenge123","type":"url_verification"}`,
 			Headers: map[string]string{"content-type": "text/plain"},
 		},
-		{Label: "Invalid token", URL: receiveURL, ExpectedRespStatus: 401, ExpectedBodyContains: "wrong validation token",
+		{Label: "Invalid token", URL: receiveURL, ExpectedRespStatus: 401, ExpectedBodyContains: `{"message":"Unauthorized","data":[{"type":"error","error":"wrong validation token`,
 			Data:    `{"token":"abc321","challenge":"challenge123","type":"url_verification"}`,
 			Headers: map[string]string{"content-type": "text/plain"},
 		},


### PR DESCRIPTION
## Summary

Follow-up to #1152. The receive seam wrote the batch in two places — once on its error path, and again inside a function that wrote it and answered for it as one unit. That coupling was the shape of the old per-handler API; with the seam owning the whole lifecycle, `Receive` now reads as the two steps that always both happen: write what the receive function parsed, then answer the request.

## Changes

- **`Receive` restructured** — one write site, then a single `respond` step that absorbs everything response-shaped: the `Reply`/`Ignore`/`Unauthenticated` dispatch, the empty-batch-is-ignored rule, and the envelope switch. `writeReceivedAndResponse` and its `writeReceived` helper dissolve.
- **The fault line is now legible in control flow** — a write failure returns to the server (courier's own error, logged at error level, answered by the wrapper); a failure in the request itself is answered by `respond` and logged at request level.
- **`WriteAndLogRequestIgnored` and `WriteAndLogUnauthorized` deleted** — no callers left outside the seam, so their two lines live where they're used. `WriteAndLogRequestError` stays: the server wrapper and the raw verify routes both want exactly that pairing.

Pure refactor — every path keeps its current status, body and logging.

## Test plan

- Full suite green (`go test -p=1 ./...`)
- The deleted helper's direct unit test was the only assertion on the full `"Unauthorized"` envelope, so Slack's invalid-token case now asserts the whole wrapper (`{"message":"Unauthorized","data":[{"type":"error",...`) rather than just the status and inner error string