### PR TITLE
Clean up after the receive seam refactor

### DIFF
--- a/core/channels/doc.go
+++ b/core/channels/doc.go
@@ -1,6 +1,7 @@
 // Package channels is what a channel handler is written against: the handler contract itself, the routes a
-// handler registers, the responses and errors it can write, and - in Received and WriteReceived - the one
-// place that writes what a handler parsed out of a request.
+// handler registers, the responses and errors it can answer a request with, and - in Received and
+// WriteReceived - the one place that writes what a handler parsed out of a request. Writing means the
+// database; a request is answered by the Respond functions.
 //
 // That last part is the convention worth knowing. Received events are written here, never by a handler: a
 // handler turns a provider's payload into a Received and hands it over. A handler that writes for itself

--- a/core/channels/handler.go
+++ b/core/channels/handler.go
@@ -54,10 +54,10 @@ type Handler interface {
 	SendableEvents(*models.Channel) map[string]time.Duration
 	SendEvent(context.Context, *models.Channel, events.Event, *models.ChannelLog) error
 
-	WriteStatusSuccessResponse(context.Context, http.ResponseWriter, []*models.StatusUpdate) error
-	WriteMsgSuccessResponse(context.Context, http.ResponseWriter, []*models.MsgIn) error
-	WriteRequestError(context.Context, http.ResponseWriter, error) error
-	WriteRequestIgnored(context.Context, http.ResponseWriter, string) error
+	RespondStatuses(context.Context, http.ResponseWriter, []*models.StatusUpdate) error
+	RespondMsgs(context.Context, http.ResponseWriter, []*models.MsgIn) error
+	RespondError(context.Context, http.ResponseWriter, error) error
+	RespondIgnored(context.Context, http.ResponseWriter, string) error
 }
 
 // AttachmentRequestBuilder is the interface handlers which can allow a custom way to download attachment media for messages should satisfy

--- a/core/channels/handler.go
+++ b/core/channels/handler.go
@@ -17,7 +17,10 @@ type Event interface {
 	EventUUID() uuids.UUID
 }
 
-// HandleFunc is the interface handlers must satisfy to handle incoming requests.
+// HandleFunc is the raw form of a route: it owns the whole exchange, writing the response itself and
+// returning the events it created. Routes that receive events don't implement this directly - they register
+// a ReceiveFunc with AddReceive and the seam handles the exchange for them - so this is the form for routes
+// that aren't receiving anything: verification handshakes, CORS preflights, contact registration.
 // The server takes care of looking up the channel by UUID before passing it to this function.
 // Errors in format of the request or by the caller should be handled and logged internally. Errors in
 // execution or in courier itself should be passed back.

--- a/core/channels/log.go
+++ b/core/channels/log.go
@@ -18,71 +18,16 @@ const (
 )
 
 // WithRequestContext returns a context carrying the request details that the logging below reports. The web server
-// puts them there before invoking a handler, so that handlers can log without being passed them explicitly.
+// puts them there before invoking a handler, so that the seam can log without being passed them explicitly.
 func WithRequestContext(ctx context.Context, url string, start time.Time) context.Context {
 	ctx = context.WithValue(ctx, contextRequestURL, url)
 	return context.WithValue(ctx, contextRequestStart, start)
-}
-
-// LogMsgStatusReceived logs that we received a new MsgStatus
-func LogMsgStatusReceived(r *http.Request, status *models.StatusUpdate) {
-	if slog.Default().Enabled(r.Context(), slog.LevelDebug) {
-		slog.Debug("status updated",
-			"channel_uuid", status.ChannelUUID(),
-			"url", r.Context().Value(contextRequestURL),
-			"elapsed_ms", getElapsedMS(r),
-			"status", status.Status(),
-			"msg_external_id", status.ExternalIdentifier(),
-		)
-	}
-
-}
-
-// LogMsgReceived logs that we received the passed in message
-func LogMsgReceived(r *http.Request, msg *models.MsgIn) {
-	if slog.Default().Enabled(r.Context(), slog.LevelDebug) {
-		slog.Debug("msg received",
-			"channel_uuid", msg.Channel().UUID(),
-			"url", r.Context().Value(contextRequestURL),
-			"elapsed_ms", getElapsedMS(r),
-			"msg_uuid", msg.UUID(),
-			"msg_urn", msg.URN().Identity(),
-			"msg_text", msg.Text(),
-			"msg_attachments", msg.Attachments(),
-		)
-	}
-
-}
-
-// LogChannelEventReceived logs that we received the passed in channel event
-func LogChannelEventReceived(r *http.Request, event *models.ChannelEvent) {
-	if slog.Default().Enabled(r.Context(), slog.LevelDebug) {
-		slog.Debug("event received",
-			"channel_uuid", event.ChannelUUID(),
-			"url", r.Context().Value(contextRequestURL),
-			"elapsed_ms", getElapsedMS(r),
-			"event_type", event.EventType(),
-			"event_urn", event.URN().Identity(),
-		)
-	}
 }
 
 // LogRequestIgnored logs that we ignored the passed in request
 func LogRequestIgnored(r *http.Request, channel *models.Channel, details string) {
 	if slog.Default().Enabled(r.Context(), slog.LevelDebug) {
 		slog.Debug("request ignored",
-			"channel_uuid", channel.UUID(),
-			"url", r.Context().Value(contextRequestURL),
-			"elapsed_ms", getElapsedMS(r),
-			"details", details,
-		)
-	}
-}
-
-// LogRequestHandled logs that we handled the passed in request but didn't create any events
-func LogRequestHandled(r *http.Request, channel *models.Channel, details string) {
-	if slog.Default().Enabled(r.Context(), slog.LevelDebug) {
-		slog.Debug("request handled",
 			"channel_uuid", channel.UUID(),
 			"url", r.Context().Value(contextRequestURL),
 			"elapsed_ms", getElapsedMS(r),

--- a/core/channels/log.go
+++ b/core/channels/log.go
@@ -24,7 +24,7 @@ func WithRequestContext(ctx context.Context, url string, start time.Time) contex
 	return context.WithValue(ctx, contextRequestStart, start)
 }
 
-// LogMsgStatusReceived logs our that we received a new MsgStatus
+// LogMsgStatusReceived logs that we received a new MsgStatus
 func LogMsgStatusReceived(r *http.Request, status *models.StatusUpdate) {
 	if slog.Default().Enabled(r.Context(), slog.LevelDebug) {
 		slog.Debug("status updated",
@@ -91,7 +91,7 @@ func LogRequestHandled(r *http.Request, channel *models.Channel, details string)
 	}
 }
 
-// LogRequestError logs that errored during parsing (this is logged as an info as it isn't an error on our side)
+// LogRequestError logs a request that errored during parsing (this is logged as an info as it isn't an error on our side)
 func LogRequestError(r *http.Request, channel *models.Channel, err error) {
 	log := slog.With(
 		"url", r.Context().Value(contextRequestURL),

--- a/core/channels/receive.go
+++ b/core/channels/receive.go
@@ -73,22 +73,22 @@ func respond(ctx context.Context, h Handler, w http.ResponseWriter, r *http.Requ
 		var ignored *IgnoredRequest
 		if errors.As(ferr, &ignored) {
 			LogRequestIgnored(r, c, ignored.Details)
-			return h.WriteRequestIgnored(ctx, w, ignored.Details)
+			return h.RespondIgnored(ctx, w, ignored.Details)
 		}
 		var unauthenticated *UnauthenticatedRequest
 		if errors.As(ferr, &unauthenticated) {
 			LogRequestError(r, c, unauthenticated.Err)
-			return WriteDataResponse(w, http.StatusUnauthorized, "Unauthorized", []any{NewErrorData(unauthenticated.Err.Error())})
+			return RespondData(w, http.StatusUnauthorized, "Unauthorized", []any{NewErrorData(unauthenticated.Err.Error())})
 		}
 		LogRequestError(r, c, ferr)
-		return h.WriteRequestError(ctx, w, ferr)
+		return h.RespondError(ctx, w, ferr)
 	}
 
 	// a request we found nothing in is one we ignored, rather than one we handled emptily - which saves
 	// every handler that can parse its way to nothing from checking for it
 	if in.Len() == 0 {
 		LogRequestIgnored(r, c, "ignoring request, nothing to handle")
-		return h.WriteRequestIgnored(ctx, w, "ignoring request, nothing to handle")
+		return h.RespondIgnored(ctx, w, "ignoring request, nothing to handle")
 	}
 
 	// which response a written batch gets comes from what the request is being handled as: a receive answers
@@ -106,7 +106,7 @@ func respond(ctx context.Context, h Handler, w http.ResponseWriter, r *http.Requ
 				msgs = append(msgs, m)
 			}
 		}
-		return h.WriteMsgSuccessResponse(ctx, w, msgs)
+		return h.RespondMsgs(ctx, w, msgs)
 
 	case models.ChannelLogTypeMsgStatus:
 		statuses := make([]*models.StatusUpdate, 0, len(events))
@@ -115,7 +115,7 @@ func respond(ctx context.Context, h Handler, w http.ResponseWriter, r *http.Requ
 				statuses = append(statuses, s)
 			}
 		}
-		return h.WriteStatusSuccessResponse(ctx, w, statuses)
+		return h.RespondStatuses(ctx, w, statuses)
 
 	case models.ChannelLogTypeEventReceive:
 		chEvents := make([]*models.ChannelEvent, 0, len(events))
@@ -124,9 +124,9 @@ func respond(ctx context.Context, h Handler, w http.ResponseWriter, r *http.Requ
 				chEvents = append(chEvents, ce)
 			}
 		}
-		return WriteChannelEventsSuccess(w, chEvents)
+		return RespondEvents(w, chEvents)
 
 	default:
-		return WriteReceivedResponse(w, results)
+		return RespondReceived(w, results)
 	}
 }

--- a/core/channels/received.go
+++ b/core/channels/received.go
@@ -173,9 +173,9 @@ func AcceptedEvents(results []WriteResult) []Event {
 	return events
 }
 
-// WriteReceivedResponse writes the standard JSON response describing each part of what an incoming request
+// RespondReceived writes the standard JSON response describing each part of what an incoming request
 // contained. Handlers whose provider requires a particular response body write their own instead.
-func WriteReceivedResponse(w http.ResponseWriter, results []WriteResult) error {
+func RespondReceived(w http.ResponseWriter, results []WriteResult) error {
 	data := make([]any, 0, len(results))
 
 	for _, r := range results {
@@ -191,5 +191,5 @@ func WriteReceivedResponse(w http.ResponseWriter, results []WriteResult) error {
 		}
 	}
 
-	return WriteDataResponse(w, http.StatusOK, "Events Handled", data)
+	return RespondData(w, http.StatusOK, "Events Handled", data)
 }

--- a/core/channels/received_test.go
+++ b/core/channels/received_test.go
@@ -25,7 +25,7 @@ func TestReceivedResponse(t *testing.T) {
 	// a response describes each part of the request in the order the handler added it, including the parts
 	// that weren't written
 	w := httptest.NewRecorder()
-	err := channels.WriteReceivedResponse(w, []channels.WriteResult{
+	err := channels.RespondReceived(w, []channels.WriteResult{
 		{Event: msg, Outcome: channels.OutcomeWritten},
 		{Event: status, Outcome: channels.OutcomeWritten},
 		{Event: event, Outcome: channels.OutcomeWritten},
@@ -43,7 +43,7 @@ func TestReceivedResponse(t *testing.T) {
 
 	// an empty set of items still gets a well formed response
 	w = httptest.NewRecorder()
-	assert.NoError(t, channels.WriteReceivedResponse(w, nil))
+	assert.NoError(t, channels.RespondReceived(w, nil))
 	assert.Equal(t, "{\"message\":\"Events Handled\",\"data\":[]}\n", w.Body.String())
 }
 

--- a/core/channels/responses.go
+++ b/core/channels/responses.go
@@ -13,8 +13,8 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 )
 
-// WriteAndLogRequestError writes a JSON response for the passed in error and logs an info message
-func WriteAndLogRequestError(ctx context.Context, h Handler, w http.ResponseWriter, r *http.Request, c *models.Channel, err error) error {
+// WriteErrorResponse writes an error response for the passed in error, using the handler's error writer
+func WriteErrorResponse(ctx context.Context, h Handler, w http.ResponseWriter, r *http.Request, c *models.Channel, err error) error {
 	LogRequestError(r, c, err)
 	return h.WriteRequestError(ctx, w, err)
 }

--- a/core/channels/responses.go
+++ b/core/channels/responses.go
@@ -13,14 +13,14 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 )
 
-// WriteErrorResponse writes an error response for the passed in error, using the handler's error writer
-func WriteErrorResponse(ctx context.Context, h Handler, w http.ResponseWriter, r *http.Request, c *models.Channel, err error) error {
+// RespondRequestError answers the request as an error, using the handler's own error response
+func RespondRequestError(ctx context.Context, h Handler, w http.ResponseWriter, r *http.Request, c *models.Channel, err error) error {
 	LogRequestError(r, c, err)
-	return h.WriteRequestError(ctx, w, err)
+	return h.RespondError(ctx, w, err)
 }
 
-// WriteError writes a JSON response for the passed in error
-func WriteError(w http.ResponseWriter, statusCode int, err error) error {
+// RespondError writes a JSON response for the passed in error
+func RespondError(w http.ResponseWriter, statusCode int, err error) error {
 	errors := []any{NewErrorData(err.Error())}
 
 	vErrs, isValidation := err.(validator.ValidationErrors)
@@ -29,45 +29,45 @@ func WriteError(w http.ResponseWriter, statusCode int, err error) error {
 			errors = append(errors, NewErrorData(fmt.Sprintf("field '%s' %s", strings.ToLower(vErrs[i].Field()), vErrs[i].Tag())))
 		}
 	}
-	return WriteDataResponse(w, statusCode, "Error", errors)
+	return RespondData(w, statusCode, "Error", errors)
 }
 
-// WriteIgnored writes a JSON response indicating that we ignored the request
-func WriteIgnored(w http.ResponseWriter, details string) error {
-	return WriteDataResponse(w, http.StatusOK, "Ignored", []any{NewInfoData(details)})
+// RespondIgnored writes a JSON response indicating that we ignored the request
+func RespondIgnored(w http.ResponseWriter, details string) error {
+	return RespondData(w, http.StatusOK, "Ignored", []any{NewInfoData(details)})
 }
 
-// WriteChannelEventsSuccess writes a JSON response for the passed in events indicating we handled them
-func WriteChannelEventsSuccess(w http.ResponseWriter, events []*models.ChannelEvent) error {
+// RespondEvents writes a JSON response for the passed in events indicating we handled them
+func RespondEvents(w http.ResponseWriter, events []*models.ChannelEvent) error {
 	data := make([]any, len(events))
 	for i, e := range events {
 		data[i] = NewEventReceiveData(e)
 	}
-	return WriteDataResponse(w, http.StatusOK, "Event Accepted", data)
+	return RespondData(w, http.StatusOK, "Event Accepted", data)
 }
 
-// WriteMsgSuccess writes a JSON response for the passed in msgs indicating we handled them
-func WriteMsgSuccess(w http.ResponseWriter, msgs []*models.MsgIn) error {
+// RespondMsgs writes a JSON response for the passed in msgs indicating we handled them
+func RespondMsgs(w http.ResponseWriter, msgs []*models.MsgIn) error {
 	data := []any{}
 	for _, msg := range msgs {
 		data = append(data, NewMsgReceiveData(msg))
 	}
 
-	return WriteDataResponse(w, http.StatusOK, "Message Accepted", data)
+	return RespondData(w, http.StatusOK, "Message Accepted", data)
 }
 
-// WriteStatusSuccess writes a JSON response for the passed in status update indicating we handled it
-func WriteStatusSuccess(w http.ResponseWriter, statuses []*models.StatusUpdate) error {
+// RespondStatuses writes a JSON response for the passed in statuses indicating we handled them
+func RespondStatuses(w http.ResponseWriter, statuses []*models.StatusUpdate) error {
 	data := []any{}
 	for _, status := range statuses {
 		data = append(data, NewStatusData(status))
 	}
 
-	return WriteDataResponse(w, http.StatusOK, "Status Update Accepted", data)
+	return RespondData(w, http.StatusOK, "Status Update Accepted", data)
 }
 
-// WriteDataResponse writes a JSON formatted response with the passed in status code, message and data
-func WriteDataResponse(w http.ResponseWriter, statusCode int, message string, data []any) error {
+// RespondData writes a JSON formatted response with the passed in status code, message and data
+func RespondData(w http.ResponseWriter, statusCode int, message string, data []any) error {
 	return writeJSONResponse(w, statusCode, &dataResponse{message, data})
 }
 

--- a/core/channels/responses.go
+++ b/core/channels/responses.go
@@ -37,11 +37,6 @@ func WriteIgnored(w http.ResponseWriter, details string) error {
 	return WriteDataResponse(w, http.StatusOK, "Ignored", []any{NewInfoData(details)})
 }
 
-// WriteChannelEventSuccess writes a JSON response for the passed in event indicating we handled it
-func WriteChannelEventSuccess(w http.ResponseWriter, event *models.ChannelEvent) error {
-	return WriteChannelEventsSuccess(w, []*models.ChannelEvent{event})
-}
-
 // WriteChannelEventsSuccess writes a JSON response for the passed in events indicating we handled them
 func WriteChannelEventsSuccess(w http.ResponseWriter, events []*models.ChannelEvent) error {
 	data := make([]any, len(events))

--- a/core/channels/responses.go
+++ b/core/channels/responses.go
@@ -13,7 +13,7 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 )
 
-// WriteAndLogRequestError writes a JSON response for the passed in message and logs an info message
+// WriteAndLogRequestError writes a JSON response for the passed in error and logs an info message
 func WriteAndLogRequestError(ctx context.Context, h Handler, w http.ResponseWriter, r *http.Request, c *models.Channel, err error) error {
 	LogRequestError(r, c, err)
 	return h.WriteRequestError(ctx, w, err)
@@ -51,7 +51,7 @@ func WriteChannelEventsSuccess(w http.ResponseWriter, events []*models.ChannelEv
 	return WriteDataResponse(w, http.StatusOK, "Event Accepted", data)
 }
 
-// WriteMsgSuccess writes a JSON response for the passed in msg indicating we handled it
+// WriteMsgSuccess writes a JSON response for the passed in msgs indicating we handled them
 func WriteMsgSuccess(w http.ResponseWriter, msgs []*models.MsgIn) error {
 	data := []any{}
 	for _, msg := range msgs {

--- a/core/channels/responses_test.go
+++ b/core/channels/responses_test.go
@@ -13,25 +13,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWriteError(t *testing.T) {
+func TestRespondError(t *testing.T) {
 	w := httptest.NewRecorder()
 
-	err := channels.WriteError(w, 406, errors.New("boom"))
+	err := channels.RespondError(w, 406, errors.New("boom"))
 	assert.NoError(t, err)
 	assert.Equal(t, 406, w.Code)
 	assert.Equal(t, "{\"message\":\"Error\",\"data\":[{\"type\":\"error\",\"error\":\"boom\"}]}\n", w.Body.String())
 }
 
-func TestWriteIgnored(t *testing.T) {
+func TestRespondIgnored(t *testing.T) {
 	w := httptest.NewRecorder()
 
-	err := channels.WriteIgnored(w, "why you calling")
+	err := channels.RespondIgnored(w, "why you calling")
 	assert.NoError(t, err)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "{\"message\":\"Ignored\",\"data\":[{\"type\":\"info\",\"info\":\"why you calling\"}]}\n", w.Body.String())
 }
 
-func TestWriteMsgSuccess(t *testing.T) {
+func TestRespondMsgs(t *testing.T) {
 	ch := test.NewMockChannel("5fccf4b6-48d7-4f5a-bce8-b0d1fd5342ec", "NX", "+1234567890", "US", []string{urns.Phone.Prefix}, nil)
 	msg := &models.MsgIn{
 		UUID_:        "588aafc4-ab5c-48ce-89e8-05c9fdeeafb7",
@@ -42,13 +42,13 @@ func TestWriteMsgSuccess(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 
-	err := channels.WriteMsgSuccess(w, []*models.MsgIn{msg})
+	err := channels.RespondMsgs(w, []*models.MsgIn{msg})
 	assert.NoError(t, err)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "{\"message\":\"Message Accepted\",\"data\":[{\"type\":\"msg\",\"channel_uuid\":\"5fccf4b6-48d7-4f5a-bce8-b0d1fd5342ec\",\"msg_uuid\":\"588aafc4-ab5c-48ce-89e8-05c9fdeeafb7\",\"text\":\"hi there\",\"urn\":\"tel:+0987654321\"}]}\n", w.Body.String())
 }
 
-func TestWriteChannelEventsSuccess(t *testing.T) {
+func TestRespondEvents(t *testing.T) {
 	ch := test.NewMockChannel("5fccf4b6-48d7-4f5a-bce8-b0d1fd5342ec", "NX", "+1234567890", "US", []string{urns.Phone.Prefix}, nil)
 	evt := &models.ChannelEvent{
 		UUID_:        "0199df03-621a-7e52-a6b0-7086c8b1a86a",
@@ -60,7 +60,7 @@ func TestWriteChannelEventsSuccess(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 
-	err := channels.WriteChannelEventsSuccess(w, []*models.ChannelEvent{evt})
+	err := channels.RespondEvents(w, []*models.ChannelEvent{evt})
 	assert.NoError(t, err)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "{\"message\":\"Event Accepted\",\"data\":[{\"type\":\"event\",\"channel_uuid\":\"5fccf4b6-48d7-4f5a-bce8-b0d1fd5342ec\",\"event_type\":\"stop_contact\",\"urn\":\"tel:+0987654321\",\"received_on\":\"2022-09-15T12:07:30Z\"}]}\n", w.Body.String())

--- a/core/channels/responses_test.go
+++ b/core/channels/responses_test.go
@@ -48,7 +48,7 @@ func TestWriteMsgSuccess(t *testing.T) {
 	assert.Equal(t, "{\"message\":\"Message Accepted\",\"data\":[{\"type\":\"msg\",\"channel_uuid\":\"5fccf4b6-48d7-4f5a-bce8-b0d1fd5342ec\",\"msg_uuid\":\"588aafc4-ab5c-48ce-89e8-05c9fdeeafb7\",\"text\":\"hi there\",\"urn\":\"tel:+0987654321\"}]}\n", w.Body.String())
 }
 
-func TestWriteChannelEventSuccess(t *testing.T) {
+func TestWriteChannelEventsSuccess(t *testing.T) {
 	ch := test.NewMockChannel("5fccf4b6-48d7-4f5a-bce8-b0d1fd5342ec", "NX", "+1234567890", "US", []string{urns.Phone.Prefix}, nil)
 	evt := &models.ChannelEvent{
 		UUID_:        "0199df03-621a-7e52-a6b0-7086c8b1a86a",
@@ -60,7 +60,7 @@ func TestWriteChannelEventSuccess(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 
-	err := channels.WriteChannelEventSuccess(w, evt)
+	err := channels.WriteChannelEventsSuccess(w, []*models.ChannelEvent{evt})
 	assert.NoError(t, err)
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "{\"message\":\"Event Accepted\",\"data\":[{\"type\":\"event\",\"channel_uuid\":\"5fccf4b6-48d7-4f5a-bce8-b0d1fd5342ec\",\"event_type\":\"stop_contact\",\"urn\":\"tel:+0987654321\",\"received_on\":\"2022-09-15T12:07:30Z\"}]}\n", w.Body.String())

--- a/core/sender/sender.go
+++ b/core/sender/sender.go
@@ -61,8 +61,8 @@ func (f *Foreman) Stop() {
 	f.waitGroup.Wait()
 }
 
-// Assign is our main loop for the Foreman, it takes care of popping the next outgoing messages from our
-// backend and assigning them to workers
+// Assign is our main loop for the Foreman, it takes care of popping the next outgoing messages from the
+// queue and assigning them to workers
 func (f *Foreman) Assign() {
 	f.waitGroup.Add(1)
 	defer f.waitGroup.Done()

--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -40,7 +40,7 @@ type moForm struct {
 	Date string `name:"date" validate:"required"`
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodPost, "callback", models.ChannelLogTypeMsgReceive, h.receiveMessage)
@@ -49,7 +49,7 @@ func (h *handler) Initialize(r *channels.Routes) error {
 	return nil
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// get our params
 	form := &moForm{}
@@ -95,7 +95,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"Expired":  models.MsgStatusFailed,
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// get our params
 	form := &statusForm{}
@@ -109,7 +109,6 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 		return fmt.Errorf("unknown status '%s', must be one of 'Success','Sent','Buffered','Rejected', 'Failed', or 'Expired'", form.Status)
 	}
 
-	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, form.ID, msgStatus, clog)
 	in.Status(status)
 	return nil

--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -106,7 +106,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
-		return fmt.Errorf("unknown status '%s', must be one of 'Success','Sent','Buffered','Rejected', 'Failed', or 'Expired'", form.Status)
+		return handlers.UnknownStatusError(statusMapping, form.Status)
 	}
 
 	status := models.NewStatusUpdateByExternalID(channel, form.ID, msgStatus, clog)

--- a/handlers/arabiacell/handler.go
+++ b/handlers/arabiacell/handler.go
@@ -34,7 +34,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("AC"), "Arabia Cell")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	receiveHandler := handlers.NewTelReceiveHandler("M", "B")
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -42,7 +42,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("BW"), "Bandwidth")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.statusMessage)
@@ -60,7 +60,7 @@ type moMessageData struct {
 	} `json:"message" validate:"required"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	var payload []moMessageData
 
@@ -123,7 +123,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"message-failed":    models.MsgStatusFailed,
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// statusMessage is our receive function for status updates
 func (h *handler) statusMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	var payload []moStatusData
 	body, err := handlers.ReadBody(r, 1000000)
@@ -155,7 +155,6 @@ func (h *handler) statusMessage(ctx context.Context, channel *models.Channel, r 
 		clog.Error(models.ErrorExternal(strconv.Itoa(statusPayload.ErrorCode), statusPayload.Description))
 	}
 
-	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, statusPayload.Message.ID, msgStatus, clog)
 	in.Status(status)
 	return nil

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -148,7 +148,7 @@ func (h *handler) statusMessage(ctx context.Context, channel *models.Channel, r 
 	statusPayload := payload[0]
 	msgStatus, found := statusMapping[statusPayload.Type]
 	if !found {
-		return fmt.Errorf("unknown status '%s', must be one of 'message-sending', 'message-delivered' or 'message-failed'", statusPayload.Type)
+		return handlers.UnknownStatusError(statusMapping, statusPayload.Type)
 	}
 
 	if statusPayload.ErrorCode != 0 {

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -17,7 +17,7 @@ import (
 
 var defaultRedactConfigKeys = []string{models.ConfigAuthToken, models.ConfigAPIKey, models.ConfigSecret, models.ConfigPassword, models.ConfigSendAuthorization}
 
-// BaseHandler is the base class for most handlers, it just stored the runtime, name and channel type for the handler
+// BaseHandler is the base class for most handlers, holding the identity and options they're constructed with
 type BaseHandler struct {
 	channelType        models.ChannelType
 	name               string

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -164,24 +164,24 @@ func userAgent(version string) string {
 	return "Courier/" + version
 }
 
-// WriteStatusSuccessResponse writes a success response for the statuses
-func (h *BaseHandler) WriteStatusSuccessResponse(ctx context.Context, w http.ResponseWriter, statuses []*models.StatusUpdate) error {
-	return channels.WriteStatusSuccess(w, statuses)
+// RespondStatuses writes a success response for the statuses
+func (h *BaseHandler) RespondStatuses(ctx context.Context, w http.ResponseWriter, statuses []*models.StatusUpdate) error {
+	return channels.RespondStatuses(w, statuses)
 }
 
-// WriteMsgSuccessResponse writes a success response for the messages
-func (h *BaseHandler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
-	return channels.WriteMsgSuccess(w, msgs)
+// RespondMsgs writes a success response for the messages
+func (h *BaseHandler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+	return channels.RespondMsgs(w, msgs)
 }
 
-// WriteRequestError writes the passed in error to our response writer
-func (h *BaseHandler) WriteRequestError(ctx context.Context, w http.ResponseWriter, err error) error {
-	return channels.WriteError(w, http.StatusBadRequest, err)
+// RespondError writes the passed in error to our response writer
+func (h *BaseHandler) RespondError(ctx context.Context, w http.ResponseWriter, err error) error {
+	return channels.RespondError(w, http.StatusBadRequest, err)
 }
 
-// WriteRequestIgnored writes an ignored payload to our response writer
-func (h *BaseHandler) WriteRequestIgnored(ctx context.Context, w http.ResponseWriter, details string) error {
-	return channels.WriteIgnored(w, details)
+// RespondIgnored writes an ignored payload to our response writer
+func (h *BaseHandler) RespondIgnored(ctx context.Context, w http.ResponseWriter, details string) error {
+	return channels.RespondIgnored(w, details)
 }
 
 // WithValkeyConn is a utility to execute some code with a valkey connection

--- a/handlers/burstsms/handler.go
+++ b/handlers/burstsms/handler.go
@@ -37,7 +37,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("BS"), "Burst SMS")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	receiveHandler := handlers.NewTelReceiveHandler("mobile", "response")
 	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)

--- a/handlers/burstsms/handler_test.go
+++ b/handlers/burstsms/handler_test.go
@@ -43,7 +43,7 @@ var testCases = []IncomingTestCase{
 		Label:                "Receive Invalid Status",
 		URL:                  statusURL + "?message_id=12345&status=unknown",
 		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "unknown status value",
+		ExpectedBodyContains: "unknown status 'unknown'",
 	},
 }
 

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -36,7 +36,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("CT"), "Clickatell")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h.receiveStatus))
@@ -64,7 +64,7 @@ var statusMapping = map[int]models.MsgStatus{
 	14: models.MsgStatusFailed, // too long
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, payload *statusPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.MessageID == "" || payload.StatusCode == 0 {
 		return fmt.Errorf("missing one of 'messageId' or 'statusCode' in request parameters")
@@ -75,7 +75,6 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 		return fmt.Errorf("unknown status '%d', must be one of 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14", payload.StatusCode)
 	}
 
-	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, payload.MessageID, msgStatus, clog)
 	in.Status(status)
 	return nil
@@ -90,7 +89,7 @@ type moPayload struct {
 	Charset    string `name:"charset"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.FromNumber == "" || payload.MessageID == "" || payload.Text == "" || payload.Timestamp == 0 {
 		return fmt.Errorf("missing one of 'messageId', 'fromNumber', 'text' or 'timestamp' in request body")

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -44,8 +44,8 @@ func (h *handler) Initialize(r *channels.Routes) error {
 }
 
 type statusPayload struct {
-	MessageID  string `name:"messageId"`
-	StatusCode int    `name:"statusCode"`
+	MessageID  string `json:"messageId"`
+	StatusCode int    `json:"statusCode"`
 }
 
 var statusMapping = map[int]models.MsgStatus{
@@ -81,12 +81,12 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 }
 
 type moPayload struct {
-	MessageID  string `name:"messageId"`
-	FromNumber string `name:"fromNumber"`
-	ToNumber   string `name:"toNumber"`
-	Timestamp  int64  `name:"timestamp"`
-	Text       string `name:"text"`
-	Charset    string `name:"charset"`
+	MessageID  string `json:"messageId"`
+	FromNumber string `json:"fromNumber"`
+	ToNumber   string `json:"toNumber"`
+	Timestamp  int64  `json:"timestamp"`
+	Text       string `json:"text"`
+	Charset    string `json:"charset"`
 }
 
 // receiveMessage is our receive function for incoming messages

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -72,7 +72,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 
 	msgStatus, found := statusMapping[payload.StatusCode]
 	if !found {
-		return fmt.Errorf("unknown status '%d', must be one of 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14", payload.StatusCode)
+		return handlers.UnknownStatusError(statusMapping, payload.StatusCode)
 	}
 
 	status := models.NewStatusUpdateByExternalID(channel, payload.MessageID, msgStatus, clog)

--- a/handlers/clickmobile/handler.go
+++ b/handlers/clickmobile/handler.go
@@ -59,7 +59,7 @@ type moPayload struct {
 	Text        string   `xml:"text"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	payload := &moPayload{}
 	err := handlers.DecodeAndValidateXML(payload, r)

--- a/handlers/clicksend/handler.go
+++ b/handlers/clicksend/handler.go
@@ -30,7 +30,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("CS"), "ClickSend")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.NewTelReceiveHandler("from", "body"))
 	return nil

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -133,14 +133,14 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 }
 
 // DartMedia expects "000" from a status request
-func (h *handler) WriteStatusSuccessResponse(ctx context.Context, w http.ResponseWriter, statuses []*models.StatusUpdate) error {
+func (h *handler) RespondStatuses(ctx context.Context, w http.ResponseWriter, statuses []*models.StatusUpdate) error {
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, "000")
 	return err
 }
 
 // DartMedia expects "000" from a message receive request
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, "000")
 	return err

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -49,7 +49,7 @@ func init() {
 	channels.RegisterHandler(NewHandler("DA", "DartMedia", sendURL, maxMsgLength))
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodGet, "delivered", models.ChannelLogTypeMsgStatus, h.receiveStatus)
@@ -63,7 +63,7 @@ type moForm struct {
 	MessageID string `name:"messageid"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &moForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
@@ -96,7 +96,7 @@ type statusForm struct {
 	Status    string `name:"status"`
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &statusForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
@@ -127,20 +127,19 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 		return fmt.Errorf("parsing failed: messageid '%s' is not a UUID", form.MessageID)
 	}
 
-	// write our status
 	status := models.NewStatusUpdate(channel, models.MsgUUID(msgUUID), msgStatus, clog)
 	in.Status(status)
 	return nil
 }
 
-// DartMedia expects "000" from a message receive request
+// DartMedia expects "000" from a status request
 func (h *handler) WriteStatusSuccessResponse(ctx context.Context, w http.ResponseWriter, statuses []*models.StatusUpdate) error {
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, "000")
 	return err
 }
 
-// DartMedia expects "000" from a status request
+// DartMedia expects "000" from a message receive request
 func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, "000")

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -43,7 +43,7 @@ func newWAHandler(channelType models.ChannelType, name string) channels.Handler 
 	return &handler{handlers.NewBaseHandler(channelType, name)}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h.receiveEvent))
 	return nil
@@ -75,7 +75,7 @@ type Notifications struct {
 	} `json:"entry"`
 }
 
-// receiveEvent is our HTTP handler function for incoming messages and status updates
+// receiveEvent is our receive function for incoming messages and status updates
 func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *http.Request, payload *Notifications, in *channels.Received, clog *models.ChannelLog) error {
 	// is not a 'whatsapp_business_account' object? ignore it
 	if payload.Object != "whatsapp_business_account" {
@@ -96,8 +96,6 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *
 // which is what lets the whole batch be written together, and keeps a failure part way through it from leaving
 // a response that describes more than we actually did. It still does I/O, since resolving a message's media
 // means asking the provider for its URL, but it makes no changes.
-//
-// A non-empty second return means the request should be ignored in its entirety.
 func (h *handler) parseWhatsAppPayload(channel *models.Channel, payload *Notifications, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 
 	seenMsgIDs := make(map[string]bool)
@@ -288,8 +286,8 @@ func (h *handler) Send(ctx context.Context, msg *models.MsgOut, res *channels.Se
 		}
 	}
 
-	// if we got a user_id in the response, set it as a new URN on the send result so the backend
-	// can queue a contact_changed task to append it to the contact (unless it's the URN we sent to)
+	// if we got a user_id in the response, set it as a new URN on the send result so that send completion
+	// can queue a contact_changed task to append it to the contact (unless it is the URN we sent to)
 	if userID != "" {
 		userIDURN, err := urns.New(urns.WhatsApp, userID)
 		if err != nil {

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -32,7 +32,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("DK"), "dmark")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
@@ -46,7 +46,7 @@ type moForm struct {
 	TStamp    string `name:"tstamp"     validate:"required"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// get our params
 	form := &moForm{}
@@ -87,7 +87,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"16": models.MsgStatusErrored,
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// get our params
 	form := &statusForm{}
@@ -101,7 +101,6 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 		return fmt.Errorf("unknown status '%s', must be one of '1','2','4','8' or '16'", form.Status)
 	}
 
-	// write our status
 	status := models.NewStatusUpdate(channel, models.MsgUUID(form.UUID), msgStatus, clog)
 	in.Status(status)
 	return nil

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -98,7 +98,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
-		return fmt.Errorf("unknown status '%s', must be one of '1','2','4','8' or '16'", form.Status)
+		return handlers.UnknownStatusError(statusMapping, form.Status)
 	}
 
 	status := models.NewStatusUpdate(channel, models.MsgUUID(form.UUID), msgStatus, clog)

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -65,7 +65,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("EX"), "External")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
@@ -136,7 +136,7 @@ func getFormField(form url.Values, defaultNames []string, name string) string {
 	return ""
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	var err error
 
@@ -215,7 +215,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 	return nil
 }
 
-// WriteMsgSuccessResponse writes our response in TWIML format
+// WriteMsgSuccessResponse writes the channel's configured MO response if it has one
 func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	moResponse := msgs[0].Channel().StringConfigForKey(configMOResponse, "")
 	if moResponse == "" {
@@ -248,7 +248,7 @@ var statusMappings = map[string]models.MsgStatus{
 	"delivered": models.MsgStatusDelivered,
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, statusString string, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &statusForm{}
 	err := handlers.DecodeAndValidateForm(form, r)

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -215,11 +215,11 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 	return nil
 }
 
-// WriteMsgSuccessResponse writes the channel's configured MO response if it has one
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+// RespondMsgs writes the channel's configured MO response if it has one
+func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	moResponse := msgs[0].Channel().StringConfigForKey(configMOResponse, "")
 	if moResponse == "" {
-		return channels.WriteMsgSuccess(w, msgs)
+		return channels.RespondMsgs(w, msgs)
 	}
 	moResponseContentType := msgs[0].Channel().StringConfigForKey(configMOResponseContentType, "")
 	if moResponseContentType != "" {

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -75,19 +75,19 @@ func (h *handler) receiveVerify(ctx context.Context, channel *models.Channel, w 
 
 	// this isn't a subscribe verification, that's an error
 	if mode != "subscribe" {
-		return nil, channels.WriteAndLogRequestError(ctx, h, w, r, channel, fmt.Errorf("unknown request"))
+		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, fmt.Errorf("unknown request"))
 	}
 
 	// verify the token against our secret, if the same return the challenge FB sent us
 	secret := r.URL.Query().Get("hub.verify_token")
 	if !utils.SecretEqual(secret, channel.StringConfigForKey(models.ConfigSecret, "")) {
-		return nil, channels.WriteAndLogRequestError(ctx, h, w, r, channel, fmt.Errorf("token does not match secret"))
+		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, fmt.Errorf("token does not match secret"))
 	}
 
 	// make sure we have an auth token
 	authToken := channel.StringConfigForKey(models.ConfigAuthToken, "")
 	if authToken == "" {
-		return nil, channels.WriteAndLogRequestError(ctx, h, w, r, channel, fmt.Errorf("missing auth token for FB channel"))
+		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, fmt.Errorf("missing auth token for FB channel"))
 	}
 
 	// everything looks good, we will subscribe to this page's messages asynchronously

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -62,7 +62,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("FB"), "Facebook")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h.receiveEvents))
 	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
@@ -206,7 +206,7 @@ type moPayload struct {
 	} `json:"entry"`
 }
 
-// receiveEvents is our HTTP handler function for incoming messages and status updates
+// receiveEvents is our receive function for incoming messages and status updates
 func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	// not a page object? ignore
 	if payload.Object != "page" {

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -75,19 +75,19 @@ func (h *handler) receiveVerify(ctx context.Context, channel *models.Channel, w 
 
 	// this isn't a subscribe verification, that's an error
 	if mode != "subscribe" {
-		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, fmt.Errorf("unknown request"))
+		return nil, channels.RespondRequestError(ctx, h, w, r, channel, fmt.Errorf("unknown request"))
 	}
 
 	// verify the token against our secret, if the same return the challenge FB sent us
 	secret := r.URL.Query().Get("hub.verify_token")
 	if !utils.SecretEqual(secret, channel.StringConfigForKey(models.ConfigSecret, "")) {
-		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, fmt.Errorf("token does not match secret"))
+		return nil, channels.RespondRequestError(ctx, h, w, r, channel, fmt.Errorf("token does not match secret"))
 	}
 
 	// make sure we have an auth token
 	authToken := channel.StringConfigForKey(models.ConfigAuthToken, "")
 	if authToken == "" {
-		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, fmt.Errorf("missing auth token for FB channel"))
+		return nil, channels.RespondRequestError(ctx, h, w, r, channel, fmt.Errorf("missing auth token for FB channel"))
 	}
 
 	// everything looks good, we will subscribe to this page's messages asynchronously

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -63,7 +63,7 @@ type receiveForm struct {
 	Name     string `name:"name"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &receiveForm{}
 	err := handlers.DecodeAndValidateForm(form, r)

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -109,13 +109,13 @@ func (h *handler) registerContact(ctx context.Context, channel *models.Channel, 
 	form := &registerForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
 	if err != nil {
-		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, err)
+		return nil, channels.RespondRequestError(ctx, h, w, r, channel, err)
 	}
 
 	// create our URN
 	urn, err := urns.New(urns.Firebase, form.URN)
 	if err != nil {
-		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, err)
+		return nil, channels.RespondRequestError(ctx, h, w, r, channel, err)
 	}
 
 	// create our contact

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -109,13 +109,13 @@ func (h *handler) registerContact(ctx context.Context, channel *models.Channel, 
 	form := &registerForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
 	if err != nil {
-		return nil, channels.WriteAndLogRequestError(ctx, h, w, r, channel, err)
+		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, err)
 	}
 
 	// create our URN
 	urn, err := urns.New(urns.Firebase, form.URN)
 	if err != nil {
-		return nil, channels.WriteAndLogRequestError(ctx, h, w, r, channel, err)
+		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, err)
 	}
 
 	// create our contact

--- a/handlers/freshchat/handler.go
+++ b/handlers/freshchat/handler.go
@@ -43,7 +43,7 @@ func newHandler(channelType models.ChannelType, name string, validateSignatures 
 	return &handler{handlers.NewBaseHandler(models.ChannelType("FC"), "FreshChat"), validateSignatures}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h.receiveMessage))
 	return nil

--- a/handlers/generic.go
+++ b/handlers/generic.go
@@ -1,15 +1,29 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/gocommon/urns"
 )
+
+// UnknownStatusError creates the error for a status value that isn't in the given mapping, listing the values
+// that are - from the mapping itself, so the message can't drift from the map.
+func UnknownStatusError[K cmp.Ordered](statuses map[K]models.MsgStatus, value K) error {
+	vals := make([]string, 0, len(statuses))
+	for _, k := range slices.Sorted(maps.Keys(statuses)) {
+		vals = append(vals, fmt.Sprintf("'%v'", k))
+	}
+	return fmt.Errorf("unknown status '%v', must be one of %s", value, strings.Join(vals, ", "))
+}
 
 // NewTelReceiveHandler creates a new receive function given the passed in text and from fields
 func NewTelReceiveHandler(fromField string, bodyField string) channels.ReceiveFunc {
@@ -49,7 +63,7 @@ func NewExternalIDStatusHandler(statuses map[string]models.MsgStatus, externalID
 		s := r.Form.Get(statusField)
 		sValue, found := statuses[s]
 		if !found {
-			return fmt.Errorf("unknown status value '%s'", s)
+			return UnknownStatusError(statuses, s)
 		}
 
 		in.Status(models.NewStatusUpdateByExternalID(c, externalID, sValue, clog))

--- a/handlers/globe/handler.go
+++ b/handlers/globe/handler.go
@@ -38,7 +38,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("GL"), "Globe Labs", handlers.WithRedactConfigKeys(configPassphrase, configAppSecret))}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h.receiveMessage))
 	return nil
@@ -73,7 +73,7 @@ type moPayload struct {
 	} `json:"inboundSMSMessageList"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if len(payload.InboundSMSMessageList.InboundSMSMessage) == 0 {
 		return channels.Ignore("no messages, ignored")

--- a/handlers/handlertest/handlertest.go
+++ b/handlers/handlertest/handlertest.go
@@ -369,7 +369,7 @@ func (e *ExpectedRequest) AssertMatches(t *testing.T, actual *http.Request, requ
 		}
 	}
 	if e.Path != "" {
-		assert.Equal(t, e.Path, actual.URL.Path, "patch mismatch for request %d", requestNum)
+		assert.Equal(t, e.Path, actual.URL.Path, "path mismatch for request %d", requestNum)
 	}
 	if e.Params != nil {
 		assert.Equal(t, e.Params, actual.URL.Query(), "URL params mismatch for request %d", requestNum)

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -32,7 +32,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("HX"), "High Connection")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
@@ -47,7 +47,7 @@ type moForm struct {
 	ReceiveDate string `name:"RECEPTION_DATE"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &moForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
@@ -104,7 +104,7 @@ var statusMapping = map[int]models.MsgStatus{
 	16: models.MsgStatusFailed,
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &statusForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
@@ -117,7 +117,6 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 		return fmt.Errorf("unknown status '%d', must be one of 2, 4, 6, 11, 12, 13, 14, 15  or 16", form.Status)
 	}
 
-	// write our status
 	status := models.NewStatusUpdate(channel, models.MsgUUID(form.RetID), msgStatus, clog)
 	in.Status(status)
 	return nil

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -114,7 +114,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
-		return fmt.Errorf("unknown status '%d', must be one of 2, 4, 6, 11, 12, 13, 14, 15  or 16", form.Status)
+		return handlers.UnknownStatusError(statusMapping, form.Status)
 	}
 
 	status := models.NewStatusUpdate(channel, models.MsgUUID(form.RetID), msgStatus, clog)

--- a/handlers/hormuud/handler.go
+++ b/handlers/hormuud/handler.go
@@ -37,7 +37,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("HM"), "Hormuud")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
@@ -50,7 +50,7 @@ type moPayload struct {
 	TimeSent    int64  // ignored as not reliable or accurate (e.g. 20230418, 202304172)
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	payload := &moPayload{}
 	err := handlers.DecodeAndValidateForm(payload, r)

--- a/handlers/i2sms/handler.go
+++ b/handlers/i2sms/handler.go
@@ -140,8 +140,8 @@ func (h *handler) RedactValues(ch *models.Channel) []string {
 	}
 }
 
-// WriteMsgSuccessResponse writes a success response for the messages, i2SMS expects an empty body in our response
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+// RespondMsgs writes a success response for the messages, i2SMS expects an empty body in our response
+func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	w.Header().Add("Content-type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write([]byte{})

--- a/handlers/i2sms/handler.go
+++ b/handlers/i2sms/handler.go
@@ -37,7 +37,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("I2"), "I2SMS", handlers.WithRedactConfigKeys(models.ConfigPassword, configChannelHash))}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receive)
 	return nil

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -31,7 +31,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("IB"), "Infobip")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "delivered", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h.statusMessage))
@@ -56,7 +56,7 @@ type ibStatus struct {
 	} `validate:"required" json:"status"`
 }
 
-// statusMessage is our HTTP handler function for status updates
+// statusMessage is our receive function for status updates
 func (h *handler) statusMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *statusPayload, in *channels.Received, clog *models.ChannelLog) error {
 
 	for _, s := range payload.Results {
@@ -105,7 +105,7 @@ type v3InboundPrice struct {
 	Currency        string  `json:"currency"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages (both SMS and MMS)
+// receiveMessage is our receive function for incoming messages (both SMS and MMS)
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *v3InboundPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.MessageCount == 0 {
 		return channels.Ignore("ignoring request, no message")

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -62,7 +62,7 @@ func (h *handler) statusMessage(ctx context.Context, channel *models.Channel, r 
 	for _, s := range payload.Results {
 		msgStatus, found := statusMapping[s.Status.GroupName]
 		if !found {
-			return fmt.Errorf("unknown status '%s', must be one of PENDING, DELIVERED, EXPIRED, REJECTED or UNDELIVERABLE", s.Status.GroupName)
+			return handlers.UnknownStatusError(statusMapping, s.Status.GroupName)
 		}
 
 		in.Status(models.NewStatusUpdateByExternalID(channel, s.MessageID, msgStatus, clog))

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -118,15 +118,15 @@ func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http
 	return nil
 }
 
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	return writeJasminACK(w)
 }
 
-func (h *handler) WriteStatusSuccessResponse(ctx context.Context, w http.ResponseWriter, statuses []*models.StatusUpdate) error {
+func (h *handler) RespondStatuses(ctx context.Context, w http.ResponseWriter, statuses []*models.StatusUpdate) error {
 	return writeJasminACK(w)
 }
 
-func (h *handler) WriteRequestIgnored(ctx context.Context, w http.ResponseWriter, details string) error {
+func (h *handler) RespondIgnored(ctx context.Context, w http.ResponseWriter, details string) error {
 	return writeJasminACK(w)
 }
 

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -32,7 +32,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("JS"), "Jasmin")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
@@ -56,7 +56,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"DELIVRD": models.MsgStatusDelivered,
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &statusForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
@@ -90,7 +90,7 @@ type moForm struct {
 	ID      string `name:"id"       validate:"required"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// get our params
 	form := &moForm{}

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -52,7 +52,7 @@ func newHandler() channels.Handler {
 	}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
 	r.AddReceive(h, http.MethodPost, "rcv/msg/message", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h.receiveMessage))
@@ -109,7 +109,7 @@ type moPayload struct {
 	MediaID      string `json:"MediaId"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.MsgID == "" && payload.Event == "" {
 		return fmt.Errorf("missing parameters, must have either 'MsgId' or 'Event'")

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -73,7 +73,7 @@ func (h *handler) VerifyURL(ctx context.Context, channel *models.Channel, w http
 	form := &verifyForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
 	if err != nil {
-		return nil, channels.WriteAndLogRequestError(ctx, h, w, r, channel, err)
+		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, err)
 	}
 
 	dictOrder := []string{channel.StringConfigForKey(configAppSecret, ""), form.Timestamp, form.Nonce}

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -73,7 +73,7 @@ func (h *handler) VerifyURL(ctx context.Context, channel *models.Channel, w http
 	form := &verifyForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
 	if err != nil {
-		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, err)
+		return nil, channels.RespondRequestError(ctx, h, w, r, channel, err)
 	}
 
 	dictOrder := []string{channel.StringConfigForKey(configAppSecret, ""), form.Timestamp, form.Nonce}

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -140,7 +140,7 @@ func (h *handler) statusMessage(ctx context.Context, c *models.Channel, r *http.
 
 	msgStatus, found := statusMapping[payload.Data.Status]
 	if !found {
-		return fmt.Errorf("unknown status '%s', must be one of send, delivered, undelivered, failed", payload.Data.Status)
+		return handlers.UnknownStatusError(statusMapping, payload.Data.Status)
 	}
 	status := models.NewStatusUpdateByExternalID(c, fmt.Sprint(payload.Data.MessageID), msgStatus, clog)
 	in.Status(status)

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -142,7 +142,6 @@ func (h *handler) statusMessage(ctx context.Context, c *models.Channel, r *http.
 	if !found {
 		return fmt.Errorf("unknown status '%s', must be one of send, delivered, undelivered, failed", payload.Data.Status)
 	}
-	// write our status
 	status := models.NewStatusUpdateByExternalID(c, fmt.Sprint(payload.Data.MessageID), msgStatus, clog)
 	in.Status(status)
 	return nil

--- a/handlers/justcall/handler_test.go
+++ b/handlers/justcall/handler_test.go
@@ -258,7 +258,7 @@ var testCases = []IncomingTestCase{
 		URL:                  statusURL,
 		Data:                 unknownStatus,
 		ExpectedRespStatus:   400,
-		ExpectedBodyContains: `unknown status 'foo', must be one of send, delivered, undelivered, failed`,
+		ExpectedBodyContains: `unknown status 'foo', must be one of 'delivered', 'failed', 'sent', 'undelivered'`,
 	},
 }
 

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -41,7 +41,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("KWA"), "Kaleyra WhatsApp")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
 	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
@@ -62,7 +62,7 @@ type moStatusForm struct {
 	Status string `name:"status" validate:"required"`
 }
 
-// receiveMsg is our HTTP handler function for incoming messages
+// receiveMsg is our receive function for incoming messages
 func (h *handler) receiveMsg(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &moMsgForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
@@ -110,7 +110,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"read":      models.MsgStatusRead,
 }
 
-// receiveStatus is our HTTP handler function for outgoing messages statuses
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &moStatusForm{}
 	err := handlers.DecodeAndValidateForm(form, r)

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -124,13 +124,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 		return channels.Ignore("unknown status: %s", form.Status)
 	}
 
-	// msg not found? ignore this
-	status := models.NewStatusUpdateByExternalID(channel, form.ID, msgStatus, clog)
-	if status == nil {
-		return channels.Ignore("ignoring request, message %s not found", form.ID)
-	}
-
-	in.Status(status)
+	in.Status(models.NewStatusUpdateByExternalID(channel, form.ID, msgStatus, clog))
 	return nil
 }
 

--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -42,7 +42,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("KN"), "Kannel")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
@@ -56,7 +56,7 @@ type moForm struct {
 	Sender  string `validate:"required" name:"sender"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// get our params
 	form := &moForm{}
@@ -94,7 +94,7 @@ type statusForm struct {
 	Status int            `name:"status" validate:"required"`
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// get our params
 	form := &statusForm{}
@@ -114,7 +114,6 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 		return channels.Ignore("ignoring sent report (message aready wired)")
 	}
 
-	// write our status
 	status := models.NewStatusUpdate(channel, form.UUID, msgStatus, clog)
 	in.Status(status)
 	return nil

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -55,7 +55,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("LN"), "Line")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h.receiveMessage))
 	return nil
@@ -113,7 +113,7 @@ type moPayload struct {
 	} `json:"events"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	err := h.validateSignature(channel, r)
 	if err != nil {

--- a/handlers/m3tech/handler.go
+++ b/handlers/m3tech/handler.go
@@ -32,7 +32,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("M3"), "M3Tech")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
@@ -57,7 +57,6 @@ func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http
 		return err
 	}
 
-	// create and write the message
 	msg := models.NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(time.Now().UTC())
 	in.Msg(msg)
 	return nil

--- a/handlers/m3tech/handler.go
+++ b/handlers/m3tech/handler.go
@@ -62,8 +62,8 @@ func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http
 	return nil
 }
 
-// WriteMsgSuccessResponse writes a success response for the messages
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+// RespondMsgs writes a success response for the messages
+func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	w.Header().Set("Content-Type", "application/json")
 	_, err := fmt.Fprintf(w, "SMS Accepted: %s", msgs[0].UUID())
 	return err

--- a/handlers/macrokiosk/handler.go
+++ b/handlers/macrokiosk/handler.go
@@ -133,8 +133,8 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 	return nil
 }
 
-// WriteMsgSuccessResponse
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+// RespondMsgs
+func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, "-1") // MacroKiosk expects "-1" back for successful requests
 	return err

--- a/handlers/macrokiosk/handler.go
+++ b/handlers/macrokiosk/handler.go
@@ -40,7 +40,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("MK"), "Macrokiosk")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
@@ -61,7 +61,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"PROCESSING":  models.MsgStatusWired,
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &statusForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
@@ -73,7 +73,6 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 	if !found {
 		return channels.Ignore("ignoring unknown status '%s'", form.Status)
 	}
-	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, form.MsgID, msgStatus, clog)
 	in.Status(status)
 	return nil
@@ -90,7 +89,7 @@ type moForm struct {
 	Time      string `name:"time"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &moForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
@@ -129,7 +128,6 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 		return err
 	}
 
-	// create and write the message
 	msg := models.NewIncomingMsg(channel, urn, form.Text, form.MsgID, clog).WithReceivedOn(date.UTC())
 	in.Msg(msg)
 	return nil

--- a/handlers/mblox/handler.go
+++ b/handlers/mblox/handler.go
@@ -34,7 +34,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("MB"), "Mblox")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h.receiveEvent))
 	return nil
@@ -60,7 +60,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"Expired":    models.MsgStatusFailed,
 }
 
-// receiveEvent is our HTTP handler function for incoming messages
+// receiveEvent is our receive function for incoming messages
 func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *http.Request, payload *eventPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.Type == "recipient_delivery_report_sms" {
 		in.As(models.ChannelLogTypeMsgStatus)

--- a/handlers/mblox/handler.go
+++ b/handlers/mblox/handler.go
@@ -71,7 +71,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *
 
 		msgStatus, found := statusMapping[payload.Status]
 		if !found {
-			return fmt.Errorf(`unknown status '%s', must be one of 'Delivered', 'Dispatched', 'Aborted', 'Rejected', 'Failed'  or 'Expired'`, payload.Status)
+			return handlers.UnknownStatusError(statusMapping, payload.Status)
 		}
 
 		in.Status(models.NewStatusUpdateByExternalID(channel, payload.BatchID, msgStatus, clog))

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -326,8 +326,8 @@ func (h *handler) validateSignature(c *models.Channel, r *http.Request) error {
 	return nil
 }
 
-// WriteMsgSuccessResponse writes a success response for the messages, MB expects an 'OK' body in our response
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+// RespondMsgs writes a success response for the messages, MB expects an 'OK' body in our response
+func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	w.Header().Add("Content-type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write([]byte("OK"))

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -89,7 +89,7 @@ func newHandler(channelType models.ChannelType, name string, validateSignatures 
 	return &handler{handlers.NewBaseHandler(models.ChannelType("MBD"), "Messagebird"), validateSignatures}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -108,7 +108,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 
 	msgStatus, found := statusMapping[receivedStatus.Status]
 	if !found {
-		return fmt.Errorf("unknown status '%s', must be one of 'queued', 'failed', 'sent', 'delivered', or 'undelivered'", receivedStatus.Status)
+		return handlers.UnknownStatusError(statusMapping, receivedStatus.Status)
 	}
 
 	// if the message id was passed explicitely, use that

--- a/handlers/messagebird/handler_test.go
+++ b/handlers/messagebird/handler_test.go
@@ -190,7 +190,7 @@ var defaultReceiveTestCases = []IncomingTestCase{
 		Label:                "Receive Invalid Status",
 		URL:                  statusBaseURL + "&status=expiryttd",
 		ExpectedRespStatus:   400,
-		ExpectedBodyContains: `{"message":"Error","data":[{"type":"error","error":"unknown status 'expiryttd', must be one of 'queued', 'failed', 'sent', 'delivered', or 'undelivered'"}]}`,
+		ExpectedBodyContains: `{"message":"Error","data":[{"type":"error","error":"unknown status 'expiryttd', must be one of 'buffered', 'delivered', 'delivery_failed', 'expired', 'scheduled', 'sent'"}]}`,
 	},
 }
 

--- a/handlers/messangi/handler.go
+++ b/handlers/messangi/handler.go
@@ -39,7 +39,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("MG"), "Messangi")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	receiveHandler := handlers.NewTelReceiveHandler("mobile", "mo")
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, receiveHandler)

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -75,7 +75,7 @@ type handler struct {
 	handlers.BaseHandler
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h.receiveEvents))
@@ -208,7 +208,7 @@ func (h *handler) resolveMediaURL(mediaID string, token string, clog *models.Cha
 	return mediaURL, err
 }
 
-// receiveEvents is our HTTP handler function for incoming messages and status updates
+// receiveEvents is our receive function for incoming messages and status updates
 func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, r *http.Request, payload *Notifications, in *channels.Received, clog *models.ChannelLog) error {
 	if err := h.validateSignature(r); err != nil {
 		return err
@@ -659,8 +659,8 @@ func (h *handler) sendWhatsAppMsg(ctx context.Context, msg *models.MsgOut, res *
 		}
 	}
 
-	// if we got a user_id in the response, set it as a new URN on the send result so the backend
-	// can queue a contact_changed task to append it to the contact (unless it's the URN we sent to)
+	// if we got a user_id in the response, set it as a new URN on the send result so that send completion
+	// can queue a contact_changed task to append it to the contact (unless it is the URN we sent to)
 	if userID != "" {
 		userIDURN, err := urns.New(urns.WhatsApp, userID)
 		if err != nil {

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -117,9 +117,9 @@ func (h *handler) RedactValues(ch *models.Channel) []string {
 	return vals
 }
 
-// WriteRequestError writes the passed in error to our response writer
-func (h *handler) WriteRequestError(ctx context.Context, w http.ResponseWriter, err error) error {
-	return channels.WriteError(w, http.StatusOK, err)
+// RespondError writes the passed in error to our response writer
+func (h *handler) RespondError(ctx context.Context, w http.ResponseWriter, err error) error {
+	return channels.RespondError(w, http.StatusOK, err)
 }
 
 // GetChannel returns the channel
@@ -172,13 +172,13 @@ func (h *handler) receiveVerify(ctx context.Context, channel *models.Channel, w 
 
 	// this isn't a subscribe verification, that's an error
 	if mode != "subscribe" {
-		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, fmt.Errorf("unknown request"))
+		return nil, channels.RespondRequestError(ctx, h, w, r, channel, fmt.Errorf("unknown request"))
 	}
 
 	// verify the token against our server facebook webhook secret, if the same return the challenge FB sent us
 	secret := r.URL.Query().Get("hub.verify_token")
 	if !utils.SecretEqual(secret, h.Runtime().Config.FacebookWebhookSecret) {
-		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, fmt.Errorf("token does not match secret"))
+		return nil, channels.RespondRequestError(ctx, h, w, r, channel, fmt.Errorf("token does not match secret"))
 	}
 	// and respond with the challenge token
 	_, err := fmt.Fprint(w, r.URL.Query().Get("hub.challenge"))

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -214,15 +214,8 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, r 
 		return err
 	}
 
-	// is not a 'page' and 'instagram' object? ignore it
-	if payload.Object != "page" && payload.Object != "instagram" && payload.Object != "whatsapp_business_account" {
-		return channels.Ignore("ignoring request")
-	}
-
-	// no entries? ignore this request
-	if len(payload.Entry) == 0 {
-		return channels.Ignore("ignoring request, no entries")
-	}
+	// a payload with an unexpected object or no entries never gets here - GetChannel decodes the same body
+	// and fails the request first
 
 	// a failure here is in the payload itself, so asking for it again wouldn't get any further. The seam writes
 	// whatever was parsed ahead of it rather than dropping it.

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -172,13 +172,13 @@ func (h *handler) receiveVerify(ctx context.Context, channel *models.Channel, w 
 
 	// this isn't a subscribe verification, that's an error
 	if mode != "subscribe" {
-		return nil, channels.WriteAndLogRequestError(ctx, h, w, r, channel, fmt.Errorf("unknown request"))
+		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, fmt.Errorf("unknown request"))
 	}
 
 	// verify the token against our server facebook webhook secret, if the same return the challenge FB sent us
 	secret := r.URL.Query().Get("hub.verify_token")
 	if !utils.SecretEqual(secret, h.Runtime().Config.FacebookWebhookSecret) {
-		return nil, channels.WriteAndLogRequestError(ctx, h, w, r, channel, fmt.Errorf("token does not match secret"))
+		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, fmt.Errorf("token does not match secret"))
 	}
 	// and respond with the challenge token
 	_, err := fmt.Fprint(w, r.URL.Query().Get("hub.challenge"))

--- a/handlers/mtarget/handler.go
+++ b/handlers/mtarget/handler.go
@@ -43,7 +43,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"6": models.MsgStatusFailed,
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
 
@@ -52,7 +52,7 @@ func (h *handler) Initialize(r *channels.Routes) error {
 	return nil
 }
 
-// ReceiveMsg handles both MO messages and Stop commands
+// receiveMsg handles both MO messages and Stop commands
 func (h *handler) receiveMsg(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	err := r.ParseForm()
 	if err != nil {
@@ -68,7 +68,7 @@ func (h *handler) receiveMsg(ctx context.Context, c *models.Channel, r *http.Req
 		return fmt.Errorf("missing required field 'Msisdn'")
 	}
 
-	// if we have a long message id, then this is part of a multipart message, we don't write the message until
+	// if we have a long message id, then this is part of a multipart message, we don't create the message until
 	// we have received all parts, which we buffer in Redis
 	longID := r.Form.Get("msglong.id")
 	if longID != "" {
@@ -142,7 +142,6 @@ func (h *handler) receiveMsg(ctx context.Context, c *models.Channel, r *http.Req
 		return nil
 	}
 
-	// otherwise, create and write the message
 	msg := models.NewIncomingMsg(c, urn, text, msgID, clog).WithReceivedOn(time.Now().UTC())
 	in.Msg(msg)
 	return nil

--- a/handlers/mtn/handler.go
+++ b/handlers/mtn/handler.go
@@ -74,7 +74,7 @@ type moPayload struct {
 	DeliveryStatus string `json:"deliveryStatus"`
 }
 
-// receiveEvent is our HTTP handler function for incoming messages
+// receiveEvent is our receive function for incoming messages
 func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.Message != "" {
 		in.As(models.ChannelLogTypeMsgReceive)
@@ -85,7 +85,6 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *
 			return err
 		}
 
-		// create and write the message
 		msg := models.NewIncomingMsg(channel, urn, payload.Message, "", clog).WithReceivedOn(date)
 		in.Msg(msg)
 		return nil
@@ -106,7 +105,6 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *
 			return channels.Ignore("no status changed, ignored")
 		}
 
-		// write our status
 		status := models.NewStatusUpdateByExternalID(channel, payload.TransactionID, msgStatus, clog)
 		in.Status(status)
 		return nil

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -92,7 +92,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("NX"), "Nexmo", handlers.WithRedactConfigKeys(configNexmoAPISecret, configNexmoAppPrivateKey))}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
@@ -119,7 +119,7 @@ var statusMappings = map[string]models.MsgStatus{
 	"delivered": models.MsgStatusDelivered,
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &statusForm{}
 	handlers.DecodeAndValidateForm(form, r)
@@ -150,7 +150,7 @@ type moForm struct {
 	MessageID string `name:"messageId"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &moForm{}
 	handlers.DecodeAndValidateForm(form, r)
@@ -165,7 +165,6 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 		return err
 	}
 
-	// create and write the message
 	msg := models.NewIncomingMsg(channel, urn, form.Text, form.MessageID, clog)
 	in.Msg(msg)
 	return nil

--- a/handlers/novo/handler.go
+++ b/handlers/novo/handler.go
@@ -39,13 +39,13 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("NV"), "Novo")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// check authentication
 	secret := c.StringConfigForKey(models.ConfigSecret, "")
@@ -73,7 +73,6 @@ func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http
 		return err
 	}
 
-	// create and write the message
 	msg := models.NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(time.Now().UTC())
 	in.Msg(msg)
 	return nil

--- a/handlers/playmobile/handler.go
+++ b/handlers/playmobile/handler.go
@@ -41,7 +41,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("PM"), "Play Mobile")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
@@ -93,7 +93,7 @@ type mtResponse struct {
 	} `xml:"message"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	payload := &mtResponse{}
 	err := handlers.DecodeAndValidateXML(payload, r)
@@ -143,7 +143,6 @@ func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http
 		in.Msg(msg)
 	}
 
-	// and finally write our message
 	return nil
 }
 

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -48,7 +48,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("PL"), "Plivo")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
@@ -71,7 +71,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"rejected":    models.MsgStatusFailed,
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &statusForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
@@ -93,7 +93,6 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 		externalID = form.ParentMessageUUID
 	}
 
-	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, externalID, msgStatus, clog)
 	in.Status(status)
 	return nil
@@ -106,7 +105,7 @@ type moForm struct {
 	Text        string `name:"Text"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &moForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
@@ -124,7 +123,6 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 		return err
 	}
 
-	// create and write the message
 	msg := models.NewIncomingMsg(channel, urn, form.Text, form.MessageUUID, clog)
 	in.Msg(msg)
 	return nil

--- a/handlers/rocketchat/handler.go
+++ b/handlers/rocketchat/handler.go
@@ -35,7 +35,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("RC"), "RocketChat")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h.receiveMessage))
 	return nil
@@ -56,7 +56,7 @@ type moPayload struct {
 	Attachments []RCAttachment `json:"attachments"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	// check authorization
 	secret := channel.StringConfigForKey(configSecret, "")

--- a/handlers/smscentral/handler.go
+++ b/handlers/smscentral/handler.go
@@ -31,7 +31,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("SC"), "SMS Central")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
@@ -42,7 +42,7 @@ type moForm struct {
 	Mobile  string `name:"mobile" validate:"required" `
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &moForm{}
 	err := handlers.DecodeAndValidateForm(form, r)

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -90,7 +90,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 }
 
 // Start Mobile expects a XML response from a message receive request
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	w.Header().Set("Content-Type", "text/xml")
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, `<answer type="async"><state>Accepted</state></answer>`)

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -38,7 +38,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("ST"), "Start Mobile")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	return nil
@@ -57,7 +57,7 @@ type moPayload struct {
 	} `xml:"body"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	payload := &moPayload{}
 	err := handlers.DecodeAndValidateXML(payload, r)

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -46,13 +46,13 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("TG"), "Telegram")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h.receiveMessage))
 	return nil
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	// no message? ignore this
 	if payload.Message.MessageID == 0 {

--- a/handlers/telesom/handler.go
+++ b/handlers/telesom/handler.go
@@ -45,7 +45,7 @@ type moForm struct {
 	Message string `name:"msg" validate:"required"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &moForm{}
 	err := handlers.DecodeAndValidateForm(form, r)

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -37,7 +37,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("TQ"), "ThinQ")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
@@ -56,7 +56,7 @@ type moForm struct {
 	Message string `name:"message"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// get our params
 	form := &moForm{}
@@ -110,7 +110,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"REJECTD": models.MsgStatusFailed,
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// get our params
 	form := &statusForm{}
@@ -124,7 +124,6 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 		return fmt.Errorf("unknown status: '%s'", form.Status)
 	}
 
-	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, form.GUID, msgStatus, clog)
 	in.Status(status)
 	return nil

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -52,7 +52,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("TRN"), "Turn.io WhatsApp")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMultiReceive, handlers.JSONPayload(h.receiveEvents))
 
@@ -146,7 +146,7 @@ type eventsPayload struct {
 	} `json:"statuses"`
 }
 
-// receiveEvents is our HTTP handler function for incoming messages and status updates
+// receiveEvents is our receive function for incoming messages and status updates
 func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, r *http.Request, payload *eventsPayload, in *channels.Received, clog *models.ChannelLog) error {
 	// a failure here is in the payload itself, so asking for it again wouldn't get any further. The seam writes
 	// whatever was parsed ahead of it rather than dropping it.

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -86,7 +86,7 @@ func init() {
 	channels.RegisterHandler(newTWIMLHandler("SW", "SignalWire", false))
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
 	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
@@ -122,7 +122,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"undelivered": models.MsgStatusFailed,
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	err := h.validateSignature(channel, r)
 	if err != nil {
@@ -176,7 +176,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 	return nil
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	err := h.validateSignature(channel, r)
 	if err != nil {

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -641,16 +641,16 @@ func twCalculateSignature(url string, form url.Values, authToken string) ([]byte
 	return encoded, nil
 }
 
-// WriteMsgSuccessResponse writes our response in TWIML format
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+// RespondMsgs writes our response in TWIML format
+func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	w.Header().Set("Content-Type", "text/xml")
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><Response/>`)
 	return err
 }
 
-// WriteRequestIgnored writes our response in TWIML format
-func (h *handler) WriteRequestIgnored(ctx context.Context, w http.ResponseWriter, details string) error {
+// RespondIgnored writes our response in TWIML format
+func (h *handler) RespondIgnored(ctx context.Context, w http.ResponseWriter, details string) error {
 	w.Header().Set("Content-Type", "text/xml")
 	w.WriteHeader(200)
 	_, err := fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?><!-- %s --><Response/>`, details)

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -192,7 +192,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 
 	msgStatus, found := statusMapping[form.MessageStatus]
 	if !found {
-		return fmt.Errorf("unknown status '%s', must be one of 'queued', 'failed', 'sent', 'delivered', or 'undelivered'", form.MessageStatus)
+		return handlers.UnknownStatusError(statusMapping, form.MessageStatus)
 	}
 
 	// if we are ignoring delivery reports and this isn't failed then move on

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -72,7 +72,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("VP"), "Viber")}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeUnknown, handlers.JSONPayload(h.receiveEvent))
 	return nil
@@ -116,7 +116,7 @@ type welcomeMessagePayload struct {
 	Sender       map[string]string `json:"sender,omitempty"`
 }
 
-// receiveEvent is our HTTP handler function for incoming messages
+// receiveEvent is our receive function for incoming messages
 func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *http.Request, payload *eventPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if err := h.validateSignature(channel, r); err != nil {
 		return err

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -226,8 +226,6 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *
 	}
 }
 
-// verifyServer handles VK's callback verification
-
 // receiveMessage handles new message event
 func (h *handler) receiveMessage(channel *models.Channel, payload *moNewMessagePayload, in *channels.Received, clog *models.ChannelLog) error {
 	userId := payload.Object.Message.UserId

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -251,8 +251,8 @@ func (h *handler) receiveMessage(channel *models.Channel, payload *moNewMessageP
 	return nil
 }
 
-// WriteMsgSuccessResponse writes the body VK requires for a message it delivered
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+// RespondMsgs writes the body VK requires for a message it delivered
+func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	_, err := fmt.Fprint(w, responseIncomingMessage)
 	return err
 }

--- a/handlers/wavy/handler.go
+++ b/handlers/wavy/handler.go
@@ -32,7 +32,7 @@ func init() {
 	channels.RegisterHandler(newHandler())
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "sent", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h.sentStatusMessage))
@@ -61,14 +61,13 @@ type sentStatusPayload struct {
 	SentStatusCode int    `json:"sentStatusCode"   validate:"required"`
 }
 
-// sentStatusMessage is our HTTP handler function for status updates
+// sentStatusMessage is our receive function for status updates
 func (h *handler) sentStatusMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *sentStatusPayload, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[payload.SentStatusCode]
 	if !found {
 		return fmt.Errorf("unknown sent status code '%d', must be one of 2, 101, 102, 103, 201, 202, 203, 204, 205, 207 or 301 ", payload.SentStatusCode)
 	}
 
-	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, payload.CollerationID, msgStatus, clog)
 	in.Status(status)
 	return nil
@@ -79,14 +78,13 @@ type deliveredStatusPayload struct {
 	DeliveredStatusCode int    `json:"deliveredStatusCode"    validate:"required"`
 }
 
-// sentStatusMessage is our HTTP handler function for status updates
+// deliveredStatusMessage is our receive function for status updates
 func (h *handler) deliveredStatusMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *deliveredStatusPayload, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[payload.DeliveredStatusCode]
 	if !found {
 		return fmt.Errorf("unknown delivered status code '%d', must be 4 or 104", payload.DeliveredStatusCode)
 	}
 
-	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, payload.CollerationID, msgStatus, clog)
 	in.Status(status)
 	return nil
@@ -100,7 +98,7 @@ type moPayload struct {
 	Timestamp int64  `json:"receivedAt"    validate:"required"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	date := time.Unix(0, int64(payload.Timestamp*1000000)).UTC()
 

--- a/handlers/wavy/handler.go
+++ b/handlers/wavy/handler.go
@@ -3,7 +3,6 @@ package wavy
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -65,7 +64,7 @@ type sentStatusPayload struct {
 func (h *handler) sentStatusMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *sentStatusPayload, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[payload.SentStatusCode]
 	if !found {
-		return fmt.Errorf("unknown sent status code '%d', must be one of 2, 101, 102, 103, 201, 202, 203, 204, 205, 207 or 301 ", payload.SentStatusCode)
+		return handlers.UnknownStatusError(statusMapping, payload.SentStatusCode)
 	}
 
 	status := models.NewStatusUpdateByExternalID(channel, payload.CollerationID, msgStatus, clog)
@@ -82,7 +81,7 @@ type deliveredStatusPayload struct {
 func (h *handler) deliveredStatusMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *deliveredStatusPayload, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[payload.DeliveredStatusCode]
 	if !found {
-		return fmt.Errorf("unknown delivered status code '%d', must be 4 or 104", payload.DeliveredStatusCode)
+		return handlers.UnknownStatusError(statusMapping, payload.DeliveredStatusCode)
 	}
 
 	status := models.NewStatusUpdateByExternalID(channel, payload.CollerationID, msgStatus, clog)

--- a/handlers/wavy/handler_test.go
+++ b/handlers/wavy/handler_test.go
@@ -115,7 +115,7 @@ var testCases = []IncomingTestCase{
 		URL:                  sentStatusURL,
 		Data:                 unknownSentStatus,
 		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "unknown sent status code",
+		ExpectedBodyContains: "unknown status '777'",
 	},
 	{
 		Label:                "Invalid JSON sent Status",
@@ -144,7 +144,7 @@ var testCases = []IncomingTestCase{
 		URL:                  deliveredStatusURL,
 		Data:                 unknownDeliveredStatus,
 		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "unknown delivered status code",
+		ExpectedBodyContains: "unknown status '777'",
 	},
 	{
 		Label:                "Invalid JSON delivered Statu",

--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -97,7 +97,7 @@ func withCORS(fn channels.HandleFunc) channels.HandleFunc {
 				// deliberately no allow-origin header on this response, so the embedding page's browser also
 				// blocks it from reading the error
 				channels.LogRequestError(r, channel, fmt.Errorf("origin not allowed: %s", origin))
-				return nil, channels.WriteError(w, http.StatusForbidden, fmt.Errorf("origin not allowed"))
+				return nil, channels.RespondError(w, http.StatusForbidden, fmt.Errorf("origin not allowed"))
 			}
 
 			// reflect the specific origin instead of * so only pages on allowed domains get readable responses
@@ -161,7 +161,7 @@ type startResponse struct {
 func (h *handler) start(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
 	if !h.allowStart(channel, r) {
 		channels.LogRequestError(r, channel, fmt.Errorf("rate limit exceeded"))
-		return nil, channels.WriteError(w, http.StatusTooManyRequests, fmt.Errorf("rate limit exceeded"))
+		return nil, channels.RespondError(w, http.StatusTooManyRequests, fmt.Errorf("rate limit exceeded"))
 	}
 
 	// a chat ID is a bearer credential - possession is the only thing that identifies a webchat visitor - so it

--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -55,7 +55,7 @@ func newHandler() channels.Handler {
 	return &handler{handlers.NewBaseHandler(models.ChannelType("WCH"), "WebChat", handlers.DisableChannelLogStorage())}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodPost, "start", models.ChannelLogTypeChatStart, withCORS(h.start))
 	r.Add(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, withCORS(channels.Receive(h, handlers.JSONPayload(h.receive))))
@@ -220,7 +220,7 @@ type receivePayload struct {
 	Text string `json:"text" validate:"required,max=1000"`
 }
 
-// receive is our HTTP handler function for incoming messages
+// receive is our receive function for incoming messages
 func (h *handler) receive(ctx context.Context, channel *models.Channel, r *http.Request, payload *receivePayload, in *channels.Received, clog *models.ChannelLog) error {
 	urn, err := urns.NewFromParts(urns.WebChat.Prefix, payload.ChatID, nil, "")
 	if err != nil {

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -71,7 +71,7 @@ func (h *handler) VerifyURL(ctx context.Context, channel *models.Channel, w http
 	form := &verifyForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
 	if err != nil {
-		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, err)
+		return nil, channels.RespondRequestError(ctx, h, w, r, channel, err)
 	}
 
 	dictOrder := []string{channel.StringConfigForKey(models.ConfigSecret, ""), form.Timestamp, form.Nonce}
@@ -153,8 +153,8 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 	return nil
 }
 
-// WriteMsgSuccessResponse writes our response
-func (h *handler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+// RespondMsgs writes our response
+func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
 	w.WriteHeader(200)
 	_, err := fmt.Fprint(w, "") // WeChat expected empty string to not retry looking for passive reply
 	return err

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -52,7 +52,7 @@ func newHandler() channels.Handler {
 	}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
 	r.AddReceive(h, http.MethodPost, "", models.ChannelLogTypeMsgReceive, h.receiveMessage)
@@ -107,7 +107,7 @@ type moPayload struct {
 	MediaID      string `xml:"MediaId"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	payload := &moPayload{}
 	err := handlers.DecodeAndValidateXML(payload, r)

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -71,7 +71,7 @@ func (h *handler) VerifyURL(ctx context.Context, channel *models.Channel, w http
 	form := &verifyForm{}
 	err := handlers.DecodeAndValidateForm(form, r)
 	if err != nil {
-		return nil, channels.WriteAndLogRequestError(ctx, h, w, r, channel, err)
+		return nil, channels.WriteErrorResponse(ctx, h, w, r, channel, err)
 	}
 
 	dictOrder := []string{channel.StringConfigForKey(models.ConfigSecret, ""), form.Timestamp, form.Nonce}

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -52,7 +52,7 @@ type moForm struct {
 	Time    string `name:"time"`
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	form := &moForm{}
 	err := handlers.DecodeAndValidateForm(form, r)

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -36,7 +36,7 @@ func newHandler(channelType models.ChannelType, name string) channels.Handler {
 	return &handler{handlers.NewBaseHandler(channelType, name)}
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.JSONPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.JSONPayload(h.receiveStatus))
@@ -75,7 +75,7 @@ type moPayload struct {
 	}
 }
 
-// receiveMessage is our HTTP handler function for incoming messages
+// receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if strings.ToUpper(payload.Type) != "MESSAGE" {
 		return fmt.Errorf("unsupported event type: %s", payload.Type)
@@ -152,7 +152,7 @@ type statusPayload struct {
 	} `json:"messageStatus"`
 }
 
-// receiveStatus is our HTTP handler function for status updates
+// receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, payload *statusPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if strings.ToUpper(payload.Type) != "MESSAGE_STATUS" {
 		return fmt.Errorf("unsupported event type: %s", payload.Type)
@@ -163,7 +163,6 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 		msgStatus = models.MsgStatusErrored
 	}
 
-	// write our status
 	status := models.NewStatusUpdateByExternalID(channel, payload.MessageID, msgStatus, clog)
 	in.Status(status)
 	return nil

--- a/test/handler.go
+++ b/test/handler.go
@@ -41,7 +41,7 @@ func (h *mockHandler) GetChannel(ctx context.Context, r *http.Request) (*models.
 	return models.GetChannel(ctx, "MCK", "e4bb1578-29da-4fa5-a214-9da19dd24230")
 }
 
-// Initialize is called by the engine once everything is loaded
+// Initialize registers the routes this handler serves
 func (h *mockHandler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
 	return nil
@@ -114,7 +114,7 @@ func (h *mockHandler) WriteRequestIgnored(ctx context.Context, w http.ResponseWr
 	return channels.WriteIgnored(w, details)
 }
 
-// ReceiveMsg sends the passed in message, returning any error
+// receiveMsg receives a message from the request form, returning any error
 func (h *mockHandler) receiveMsg(ctx context.Context, channel *models.Channel, w http.ResponseWriter, r *http.Request, clog *models.ChannelLog) ([]channels.Event, error) {
 	r.ParseForm()
 	from := r.Form.Get("from")

--- a/test/handler.go
+++ b/test/handler.go
@@ -98,20 +98,20 @@ func (h *mockHandler) SendableEvents(ch *models.Channel) map[string]time.Duratio
 	return map[string]time.Duration{events.TypeTypingStarted: 10 * time.Second}
 }
 
-func (h *mockHandler) WriteStatusSuccessResponse(ctx context.Context, w http.ResponseWriter, statuses []*models.StatusUpdate) error {
-	return channels.WriteStatusSuccess(w, statuses)
+func (h *mockHandler) RespondStatuses(ctx context.Context, w http.ResponseWriter, statuses []*models.StatusUpdate) error {
+	return channels.RespondStatuses(w, statuses)
 }
 
-func (h *mockHandler) WriteMsgSuccessResponse(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
-	return channels.WriteMsgSuccess(w, msgs)
+func (h *mockHandler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs []*models.MsgIn) error {
+	return channels.RespondMsgs(w, msgs)
 }
 
-func (h *mockHandler) WriteRequestError(ctx context.Context, w http.ResponseWriter, err error) error {
-	return channels.WriteError(w, http.StatusBadRequest, err)
+func (h *mockHandler) RespondError(ctx context.Context, w http.ResponseWriter, err error) error {
+	return channels.RespondError(w, http.StatusBadRequest, err)
 }
 
-func (h *mockHandler) WriteRequestIgnored(ctx context.Context, w http.ResponseWriter, details string) error {
-	return channels.WriteIgnored(w, details)
+func (h *mockHandler) RespondIgnored(ctx context.Context, w http.ResponseWriter, details string) error {
+	return channels.RespondIgnored(w, details)
 }
 
 // receiveMsg receives a message from the request form, returning any error

--- a/web/server.go
+++ b/web/server.go
@@ -249,14 +249,14 @@ func (s *Server) channelHandleWrapper(handler channels.Handler, handlerFunc chan
 
 		recorder, err := httpx.NewRecorder(r, w, true)
 		if err != nil {
-			channels.WriteErrorResponse(ctx, handler, w, r, nil, err)
+			channels.RespondRequestError(ctx, handler, w, r, nil, err)
 			return
 		}
 
 		// get the channel for this request - can be nil, e.g. FBA verification requests
 		channel, err := handler.GetChannel(ctx, r)
 		if err != nil {
-			channels.WriteErrorResponse(ctx, handler, recorder.ResponseWriter, r, channel, err)
+			channels.RespondRequestError(ctx, handler, recorder.ResponseWriter, r, channel, err)
 			return
 		}
 
@@ -270,7 +270,7 @@ func (s *Server) channelHandleWrapper(handler channels.Handler, handlerFunc chan
 			if panicVal := recover(); panicVal != nil {
 				runtime.PanicHandler(panicVal, map[string]string{"channel_type": string(handler.ChannelType())})
 
-				channels.WriteErrorResponse(ctx, handler, recorder.ResponseWriter, r, channel, errors.New("panic handling msg"))
+				channels.RespondRequestError(ctx, handler, recorder.ResponseWriter, r, channel, errors.New("panic handling msg"))
 			}
 		}()
 
@@ -282,13 +282,13 @@ func (s *Server) channelHandleWrapper(handler channels.Handler, handlerFunc chan
 		// it's logged as an error above the response, rather than as the provider's problem
 		if hErr != nil {
 			slog.Error("error handling request", "error", hErr, "channel", channelUUID, "url", recorder.Trace.Request.URL.String())
-			handler.WriteRequestError(ctx, recorder.ResponseWriter, hErr)
+			handler.RespondError(ctx, recorder.ResponseWriter, hErr)
 		}
 
 		// end recording of the request so that we have a response trace
 		if err := recorder.End(); err != nil {
 			slog.Error("error recording request", "error", err, "channel", channelUUID)
-			handler.WriteRequestError(ctx, w, err)
+			handler.RespondError(ctx, w, err)
 		}
 
 		if channel != nil {
@@ -367,7 +367,7 @@ func (s *Server) handleFetchAttachment(w http.ResponseWriter, r *http.Request) {
 	resp, err := fetchAttachment(ctx, s.rt, r)
 	if err != nil {
 		slog.Error("error fetching attachment", "error", err)
-		channels.WriteError(w, http.StatusBadRequest, err)
+		channels.RespondError(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -383,7 +383,7 @@ func (s *Server) handleSendEvent(w http.ResponseWriter, r *http.Request) {
 	resp, err := sendEvent(ctx, s, r)
 	if err != nil {
 		slog.Error("error sending event", "error", err)
-		channels.WriteError(w, http.StatusBadRequest, err)
+		channels.RespondError(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -402,7 +402,7 @@ func (s *Server) handle404(listener string) http.HandlerFunc {
 			slog.Info("not found", "listener", listener, "url", r.URL.String(), "method", r.Method, "resp_status", "404")
 		}
 		errors := []any{channels.NewErrorData(fmt.Sprintf("not found: %s", r.URL.String()))}
-		err := channels.WriteDataResponse(w, http.StatusNotFound, "Not Found", errors)
+		err := channels.RespondData(w, http.StatusNotFound, "Not Found", errors)
 		if err != nil {
 			slog.Error("error writing response", "error", err)
 		}
@@ -417,7 +417,7 @@ func (s *Server) handle405(listener string) http.HandlerFunc {
 			slog.Info("invalid method", "listener", listener, "url", r.URL.String(), "method", r.Method, "resp_status", "405")
 		}
 		errors := []any{channels.NewErrorData(fmt.Sprintf("method not allowed: %s", r.Method))}
-		err := channels.WriteDataResponse(w, http.StatusMethodNotAllowed, "Method Not Allowed", errors)
+		err := channels.RespondData(w, http.StatusMethodNotAllowed, "Method Not Allowed", errors)
 		if err != nil {
 			slog.Error("error writing response", "error", err)
 		}

--- a/web/server.go
+++ b/web/server.go
@@ -249,14 +249,14 @@ func (s *Server) channelHandleWrapper(handler channels.Handler, handlerFunc chan
 
 		recorder, err := httpx.NewRecorder(r, w, true)
 		if err != nil {
-			channels.WriteAndLogRequestError(ctx, handler, w, r, nil, err)
+			channels.WriteErrorResponse(ctx, handler, w, r, nil, err)
 			return
 		}
 
 		// get the channel for this request - can be nil, e.g. FBA verification requests
 		channel, err := handler.GetChannel(ctx, r)
 		if err != nil {
-			channels.WriteAndLogRequestError(ctx, handler, recorder.ResponseWriter, r, channel, err)
+			channels.WriteErrorResponse(ctx, handler, recorder.ResponseWriter, r, channel, err)
 			return
 		}
 
@@ -270,7 +270,7 @@ func (s *Server) channelHandleWrapper(handler channels.Handler, handlerFunc chan
 			if panicVal := recover(); panicVal != nil {
 				runtime.PanicHandler(panicVal, map[string]string{"channel_type": string(handler.ChannelType())})
 
-				channels.WriteAndLogRequestError(ctx, handler, recorder.ResponseWriter, r, channel, errors.New("panic handling msg"))
+				channels.WriteErrorResponse(ctx, handler, recorder.ResponseWriter, r, channel, errors.New("panic handling msg"))
 			}
 		}()
 

--- a/web/server.go
+++ b/web/server.go
@@ -237,8 +237,10 @@ func (s *Server) MountHandler(handler channels.Handler) error {
 
 func (s *Server) channelHandleWrapper(handler channels.Handler, handlerFunc channels.HandleFunc, logType svclogs.Type) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
 		// stuff a few things in our context that help with logging
-		baseCtx := channels.WithRequestContext(r.Context(), r.URL.String(), time.Now())
+		baseCtx := channels.WithRequestContext(r.Context(), r.URL.String(), start)
 
 		// add a 30 second timeout to the request
 		ctx, cancel := context.WithTimeout(baseCtx, time.Second*30)
@@ -276,35 +278,48 @@ func (s *Server) channelHandleWrapper(handler channels.Handler, handlerFunc chan
 
 		events, hErr := handlerFunc(ctx, channel, recorder.ResponseWriter, r, clog)
 
-		// if we received an error, write it out and report it
+		// an error from the handler here is courier's own - the seam answers request-level errors itself - so
+		// it's logged as an error above the response, rather than as the provider's problem
 		if hErr != nil {
 			slog.Error("error handling request", "error", hErr, "channel", channelUUID, "url", recorder.Trace.Request.URL.String())
-			channels.WriteAndLogRequestError(ctx, handler, recorder.ResponseWriter, r, channel, hErr)
+			handler.WriteRequestError(ctx, recorder.ResponseWriter, hErr)
 		}
 
 		// end recording of the request so that we have a response trace
 		if err := recorder.End(); err != nil {
 			slog.Error("error recording request", "error", err, "channel", channelUUID)
-			channels.WriteAndLogRequestError(ctx, handler, w, r, channel, err)
+			handler.WriteRequestError(ctx, w, err)
 		}
 
 		if channel != nil {
 			numMsgs, numStatuses, numEvents, numIgnored := 0, 0, 0, 0
 
+			debugLog := slog.Default().Enabled(ctx, slog.LevelDebug)
+			elapsedMS := float64(time.Since(start)) / float64(time.Millisecond)
+
 			for _, event := range events {
 				switch e := event.(type) {
 				case *models.MsgIn:
-					channels.LogMsgReceived(r, e)
+					if debugLog {
+						slog.Debug("msg received", "channel_uuid", channelUUID, "url", r.URL.String(), "elapsed_ms", elapsedMS,
+							"msg_uuid", e.UUID(), "msg_urn", e.URN().Identity(), "msg_text", e.Text(), "msg_attachments", e.Attachments())
+					}
 					if e.Duplicate_ {
 						numIgnored++
 					} else {
 						numMsgs++
 					}
 				case *models.StatusUpdate:
-					channels.LogMsgStatusReceived(r, e)
+					if debugLog {
+						slog.Debug("status updated", "channel_uuid", channelUUID, "url", r.URL.String(), "elapsed_ms", elapsedMS,
+							"status", e.Status(), "msg_external_id", e.ExternalIdentifier())
+					}
 					numStatuses++
 				case *models.ChannelEvent:
-					channels.LogChannelEventReceived(r, e)
+					if debugLog {
+						slog.Debug("event received", "channel_uuid", channelUUID, "url", r.URL.String(), "elapsed_ms", elapsedMS,
+							"event_type", e.EventType(), "event_urn", e.URN().Identity())
+					}
 					numEvents++
 				}
 			}

--- a/web/server.go
+++ b/web/server.go
@@ -59,8 +59,7 @@ func NewServer(rt *runtime.Runtime) *Server {
 // connection errors
 func (s *Server) Start() error {
 	// bind both listener sockets up front so callers know we're accepting connections by the
-	// time Start returns, and so a bind failure fails fast before we've started the backend,
-	// spool flushers, or anything else that would need to be unwound
+	// time Start returns, and so a bind failure fails fast before the serve goroutines start
 	internetAddr := fmt.Sprintf("%s:%d", s.rt.Config.InternetAddress, s.rt.Config.InternetPort)
 	internetLn, err := net.Listen("tcp", internetAddr)
 	if err != nil {

--- a/web/server.go
+++ b/web/server.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/nyaruka/courier/v26/core/channels"
 	"log/slog"
 	"net"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"


### PR DESCRIPTION
## Summary

Follow-up cleanup after the incoming-path refactor (#1148–#1153): stale comments and docs brought in line with the new receive seam, dead code removed, and two naming problems fixed — the log helper family that no longer had handler callers, and the `Write*` prefix meaning both "write an HTTP response" and "write to the database".

## Changes

**Naming: `Write*` now means the database, `Respond*` means the request**
- Handler interface methods renamed: `WriteMsgSuccessResponse`/`WriteStatusSuccessResponse`/`WriteRequestError`/`WriteRequestIgnored` → `RespondMsgs`/`RespondStatuses`/`RespondError`/`RespondIgnored`, dropping the redundant suffixes.
- Package helpers follow: `RespondEvents`, `RespondReceived`, `RespondData`, and `RespondRequestError` (formerly `WriteAndLogRequestError` — its main purpose is the response; the request-level log is a side effect that no longer claims the name).
- `core/channels/doc.go` states the convention: writing means the database, a request is answered by the Respond functions.

**Log helpers collapsed into the server**
- `LogMsgReceived`/`LogMsgStatusReceived`/`LogChannelEventReceived` existed so each handler could log events as it wrote them; the server was their only caller and already type-switches over the same events for stats, so the debug logs now live inline there. `LogRequestHandled` had no callers at all. What remains in `core/channels/log.go` is what the seam uses: `LogRequestIgnored` and `LogRequestError`.
- Courier-side failures were logged twice — once at error by the server, again at info on the response path. Now once.

**Unknown-status errors generated from the status map**
- New `handlers.UnknownStatusError` formats the "must be one of …" list from the map's keys, so the message can't drift from what the handler accepts. The hand-maintained lists had drifted in several handlers: one listed a different provider's statuses entirely, another omitted a status it accepts, and one handler's two status endpoints share a single map that neither hand-written list described. `NewExternalIDStatusHandler` uses it too, so its error now names the accepted values.

**Dead code removed**
- `WriteChannelEventSuccess` (no callers), meta's unreachable payload guards in `receiveEvents` (`GetChannel` decodes the same body and rejects those requests first), kaleyra's nil-check on a constructor that can't return nil, and clickatell's leftover form tags on JSON-decoded payloads (now explicit `json:` tags instead of relying on case-insensitive matching).

**Comment sweep**
- 60 receive functions no longer described as "HTTP handler functions", 46 `Initialize` docs no longer reference a nonexistent "engine", ~23 "write our status"/"create and write the message" comments removed (the seam writes, handlers add to the batch), references to the removed backend concept dropped, `HandleFunc` documented as the raw route form alongside `ReceiveFunc`, plus assorted swapped/misnamed doc comments and typos.

## Behavior examples

| | before | after |
|---|---|---|
| unknown status response (messagebird) | `unknown status 'x', must be one of 'queued', 'failed', 'sent', 'delivered', or 'undelivered'` | `unknown status 'x', must be one of 'buffered', 'delivered', 'delivery_failed', 'expired', 'scheduled', 'sent'` |
| `NewExternalIDStatusHandler` unknown status | `unknown status value 'x'` | `unknown status 'x', must be one of 'delivered', 'failed', 'sent'` |
| courier-side handler failure | logged at error and again at info | logged once at error |

Everything else is rename/comment/dead-code only — no wire or database behavior changes.

## Test plan

- [x] full suite green (`go test -p=1 ./...`, 62 packages)
- [x] test expectations updated for the four handlers that asserted exact unknown-status strings
- [x] meta's tests pass unchanged with the unreachable guards removed, confirming they were dead