### PR TITLE
Add FormPayload and XMLPayload to match JSONPayload

### DIFF
--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -42,22 +42,15 @@ type moForm struct {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.AddReceive(h, http.MethodPost, "callback", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.AddReceive(h, http.MethodPost, "delivery", models.ChannelLogTypeMsgStatus, h.receiveStatus)
-	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "callback", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "delivery", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
+	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
 	return nil
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	// get our params
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	// create our date from the timestamp
 	// 2017-05-03T06:04:45Z
 	date, err := time.Parse("2006-01-02T15:04:05Z", form.Date)
@@ -96,14 +89,7 @@ var statusMapping = map[string]models.MsgStatus{
 }
 
 // receiveStatus is our receive function for status updates
-func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	// get our params
-	form := &statusForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
 		return handlers.UnknownStatusError(statusMapping, form.Status)

--- a/handlers/clickmobile/handler.go
+++ b/handlers/clickmobile/handler.go
@@ -39,8 +39,8 @@ func newHandler() channels.Handler {
 }
 
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, handlers.XMLPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.XMLPayload(h.receiveMessage))
 	return nil
 }
 
@@ -60,13 +60,7 @@ type moPayload struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	payload := &moPayload{}
-	err := handlers.DecodeAndValidateXML(payload, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.Mobile == "" || payload.Shortcode == "" {
 		return fmt.Errorf("missing parameters, must have 'mobile' and 'shortcode'")
 	}

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -51,8 +51,8 @@ func init() {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.AddReceive(h, http.MethodGet, "delivered", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodGet, "delivered", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
 	return nil
 }
 
@@ -64,13 +64,7 @@ type moForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	if form.Original == "" || form.SendTo == "" {
 		return fmt.Errorf("missing required parameters original and sendto")
 	}
@@ -97,13 +91,7 @@ type statusForm struct {
 }
 
 // receiveStatus is our receive function for status updates
-func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &statusForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
 	if form.Status == "" || form.MessageID == "" {
 		return fmt.Errorf("parameters messageid and status should not be empty")
 	}

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -34,8 +34,8 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
 	return nil
 }
 
@@ -47,14 +47,7 @@ type moForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	// get our params
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	// create our date from the timestamp "2017-10-26T15:51:32.906335+00:00"
 	date, err := time.Parse("2006-01-02T15:04:05.999999-07:00", form.TStamp)
 	if err != nil {
@@ -88,14 +81,7 @@ var statusMapping = map[string]models.MsgStatus{
 }
 
 // receiveStatus is our receive function for status updates
-func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	// get our params
-	form := &statusForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
 		return handlers.UnknownStatusError(statusMapping, form.Status)

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -82,8 +82,9 @@ func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodGet, "failed", models.ChannelLogTypeMsgStatus, failedHandler)
 	r.AddReceive(h, http.MethodPost, "failed", models.ChannelLogTypeMsgStatus, failedHandler)
 
-	r.AddReceive(h, http.MethodPost, "stopped", models.ChannelLogTypeEventReceive, h.receiveStopContact)
-	r.AddReceive(h, http.MethodGet, "stopped", models.ChannelLogTypeEventReceive, h.receiveStopContact)
+	stopHandler := handlers.FormPayload(h.receiveStopContact)
+	r.AddReceive(h, http.MethodPost, "stopped", models.ChannelLogTypeEventReceive, stopHandler)
+	r.AddReceive(h, http.MethodGet, "stopped", models.ChannelLogTypeEventReceive, stopHandler)
 
 	return nil
 }
@@ -92,15 +93,10 @@ type stopContactForm struct {
 	From string `name:"from" validate:"required"`
 }
 
-func (h *handler) receiveStopContact(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &stopContactForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStopContact(ctx context.Context, channel *models.Channel, r *http.Request, form *stopContactForm, in *channels.Received, clog *models.ChannelLog) error {
 	// create our URN
-	urn := urns.NilURN
+	var urn urns.URN
+	var err error
 	if channel.Schemes()[0] == urns.Phone.Prefix {
 		urn, err = urns.ParsePhone(form.From, channel.Country(), true, false)
 	} else {
@@ -232,9 +228,9 @@ func (h *handler) RespondMsgs(ctx context.Context, w http.ResponseWriter, msgs [
 
 // buildStatusHandler deals with building a receive function that takes what status is received in the URL
 func (h *handler) buildStatusHandler(status string) channels.ReceiveFunc {
-	return func(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-		return h.receiveStatus(ctx, status, channel, r, in, clog)
-	}
+	return handlers.FormPayload(func(ctx context.Context, channel *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
+		return h.receiveStatus(ctx, status, channel, r, form, in, clog)
+	})
 }
 
 type statusForm struct {
@@ -249,13 +245,7 @@ var statusMappings = map[string]models.MsgStatus{
 }
 
 // receiveStatus is our receive function for status updates
-func (h *handler) receiveStatus(ctx context.Context, statusString string, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &statusForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStatus(ctx context.Context, statusString string, channel *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
 	if form.ID == "" && form.UUID == "" {
 		return fmt.Errorf("parameters id or uuid should not be empty")
 	}

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -50,7 +50,7 @@ func newHandler() channels.Handler {
 }
 
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
 	r.Add(h, http.MethodPost, "register", models.ChannelLogTypeEventReceive, h.registerContact)
 	return nil
 }
@@ -64,15 +64,10 @@ type receiveForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &receiveForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *receiveForm, in *channels.Received, clog *models.ChannelLog) error {
 	date := time.Now().UTC()
 	if form.Date != "" {
+		var err error
 		date, err = time.Parse("2006-01-02T15:04:05.000", form.Date)
 		if err != nil {
 			return fmt.Errorf("unable to parse date: %s", form.Date)

--- a/handlers/generic.go
+++ b/handlers/generic.go
@@ -71,14 +71,33 @@ func NewExternalIDStatusHandler(statuses map[string]models.MsgStatus, externalID
 	}
 }
 
-// JSONReceiveFunc is a receive function for a provider that sends JSON, which is decoded and validated for it
-type JSONReceiveFunc[T any] func(context.Context, *models.Channel, *http.Request, *T, *channels.Received, *models.ChannelLog) error
+// PayloadReceiveFunc is a receive function for a provider whose request body is decoded and validated into a
+// payload struct before the handler sees it. JSONPayload, FormPayload and XMLPayload each adapt one into a
+// plain receive function, differing only in how they decode.
+type PayloadReceiveFunc[T any] func(context.Context, *models.Channel, *http.Request, *T, *channels.Received, *models.ChannelLog) error
 
-// JSONPayload adapts a JSONReceiveFunc into a plain receive function
-func JSONPayload[T any](fn JSONReceiveFunc[T]) channels.ReceiveFunc {
+// JSONPayload adapts a receive function for a provider that sends JSON, decoding and validating it first
+func JSONPayload[T any](fn PayloadReceiveFunc[T]) channels.ReceiveFunc {
+	return withPayload(fn, DecodeAndValidateJSON)
+}
+
+// FormPayload adapts a receive function for a provider that sends form values, decoding and validating them
+// first. Handlers that must check a signature over the raw body decode for themselves instead.
+func FormPayload[T any](fn PayloadReceiveFunc[T]) channels.ReceiveFunc {
+	return withPayload(fn, DecodeAndValidateForm)
+}
+
+// XMLPayload adapts a receive function for a provider that sends XML, decoding and validating it first
+func XMLPayload[T any](fn PayloadReceiveFunc[T]) channels.ReceiveFunc {
+	return withPayload(fn, DecodeAndValidateXML)
+}
+
+// withPayload is the shared shape of the three adapters above: decode into a new T, then hand it to the
+// receive function - which never has to consider a request it couldn't be parsed from.
+func withPayload[T any](fn PayloadReceiveFunc[T], decode func(any, *http.Request) error) channels.ReceiveFunc {
 	return func(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 		payload := new(T)
-		if err := DecodeAndValidateJSON(payload, r); err != nil {
+		if err := decode(payload, r); err != nil {
 			return err
 		}
 		return fn(ctx, c, r, payload, in, clog)

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -34,8 +34,8 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
 	return nil
 }
 
@@ -48,15 +48,10 @@ type moForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	date := time.Now()
 	if form.ReceiveDate != "" {
+		var err error
 		date, err = time.Parse("2006-01-02T15:04:05", form.ReceiveDate)
 		if err != nil {
 			return err
@@ -105,13 +100,7 @@ var statusMapping = map[int]models.MsgStatus{
 }
 
 // receiveStatus is our receive function for status updates
-func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &statusForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
 		return handlers.UnknownStatusError(statusMapping, form.Status)

--- a/handlers/hormuud/handler.go
+++ b/handlers/hormuud/handler.go
@@ -39,7 +39,7 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
 	return nil
 }
 
@@ -51,13 +51,7 @@ type moPayload struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	payload := &moPayload{}
-	err := handlers.DecodeAndValidateForm(payload, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	urn, err := urns.ParsePhone(payload.Sender, c.Country(), true, false)
 	if err != nil {
 		return err

--- a/handlers/i2sms/handler.go
+++ b/handlers/i2sms/handler.go
@@ -3,17 +3,14 @@ package i2sms
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/gocommon/httpx"
-	"github.com/nyaruka/gocommon/urns"
 )
 
 const (
@@ -39,32 +36,7 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receive)
-	return nil
-}
-
-// receive is our handler for MO messages
-func (h *handler) receive(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	err := r.ParseForm()
-	if err != nil {
-		return err
-	}
-
-	body := r.Form.Get("message")
-	from := r.Form.Get("mobile")
-	if from == "" {
-		return fmt.Errorf("missing required field 'mobile'")
-	}
-
-	// create our URN
-	urn, err := urns.ParsePhone(from, c.Country(), true, false)
-	if err != nil {
-		return err
-	}
-
-	// build our msg
-	msg := models.NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(time.Now().UTC())
-	in.Msg(msg)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.NewTelReceiveHandler("mobile", "message"))
 	return nil
 }
 

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -34,8 +34,8 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
 	return nil
 }
 
@@ -57,13 +57,7 @@ var statusMapping = map[string]models.MsgStatus{
 }
 
 // receiveStatus is our receive function for status updates
-func (h *handler) receiveStatus(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &statusForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStatus(ctx context.Context, c *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
 	// prefer message_status when present; otherwise require either dlvrd or err to be set
 	var reqStatus models.MsgStatus
 	msgStatus, found := statusMapping[form.MessageStatus]
@@ -91,14 +85,7 @@ type moForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	// get our params
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	// create our URN
 	urn, err := urns.ParsePhone(form.From, c.Country(), true, false)
 	if err != nil {

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -43,8 +43,8 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMsg)
-	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMsg))
+	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
 	return nil
 }
 
@@ -63,13 +63,7 @@ type moStatusForm struct {
 }
 
 // receiveMsg is our receive function for incoming messages
-func (h *handler) receiveMsg(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &moMsgForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMsg(ctx context.Context, channel *models.Channel, r *http.Request, form *moMsgForm, in *channels.Received, clog *models.ChannelLog) error {
 	// invalid type? ignore this
 	if form.Type != "text" && form.Type != "image" && form.Type != "video" && form.Type != "voice" && form.Type != "document" {
 		return channels.Ignore("ignoring request, unknown message type")
@@ -111,13 +105,7 @@ var statusMapping = map[string]models.MsgStatus{
 }
 
 // receiveStatus is our receive function for status updates
-func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &moStatusForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, form *moStatusForm, in *channels.Received, clog *models.ChannelLog) error {
 	// unknown status? ignore this
 	msgStatus, found := statusMapping[form.Status]
 	if !found {

--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -44,8 +44,8 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
 	return nil
 }
 
@@ -57,14 +57,7 @@ type moForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	// get our params
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	// create our date from the timestamp
 	date := time.Unix(form.TS, 0).UTC()
 
@@ -95,14 +88,7 @@ type statusForm struct {
 }
 
 // receiveStatus is our receive function for status updates
-func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	// get our params
-	form := &statusForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
 		clog.Error(models.ErrorExternal(fmt.Sprintf("dlr:%d", form.Status), fmt.Sprintf("unknown delivery report status '%d'", form.Status)))

--- a/handlers/m3tech/handler.go
+++ b/handlers/m3tech/handler.go
@@ -6,13 +6,11 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/gocommon/gsm7"
-	"github.com/nyaruka/gocommon/urns"
 )
 
 var (
@@ -34,31 +32,7 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	return nil
-}
-
-// receiveMessage takes care of handling incoming messages
-func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	err := r.ParseForm()
-	if err != nil {
-		return err
-	}
-
-	body := r.Form.Get("text")
-	from := r.Form.Get("from")
-	if from == "" {
-		return fmt.Errorf("missing required field 'from'")
-	}
-
-	// create our URN
-	urn, err := urns.ParsePhone(from, c.Country(), true, false)
-	if err != nil {
-		return err
-	}
-
-	msg := models.NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(time.Now().UTC())
-	in.Msg(msg)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.NewTelReceiveHandler("from", "text"))
 	return nil
 }
 

--- a/handlers/macrokiosk/handler.go
+++ b/handlers/macrokiosk/handler.go
@@ -42,10 +42,10 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
-	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
-	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
+	r.AddReceive(h, http.MethodGet, "status", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
+	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
 	return nil
 }
 
@@ -62,13 +62,7 @@ var statusMapping = map[string]models.MsgStatus{
 }
 
 // receiveStatus is our receive function for status updates
-func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &statusForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
 		return channels.Ignore("ignoring unknown status '%s'", form.Status)
@@ -90,13 +84,7 @@ type moForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	recipient := form.Longcode
 	sender := form.MSISDN
 	if form.Shortcode != "" {

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -97,12 +97,11 @@ func (h *handler) Initialize(r *channels.Routes) error {
 	return nil
 }
 
+// this one decodes for itself rather than using FormPayload, because it answers a decode failure as ignored
+// rather than as an error - which keeps a malformed status callback from being retried at us
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-
-	// get our params
 	receivedStatus := &ReceivedStatus{}
-	err := handlers.DecodeAndValidateForm(receivedStatus, r)
-	if err != nil {
+	if err := handlers.DecodeAndValidateForm(receivedStatus, r); err != nil {
 		return channels.Ignore("no msg status, ignoring")
 	}
 
@@ -115,7 +114,7 @@ func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r 
 	var status *models.StatusUpdate
 	if receivedStatus.Reference != "" {
 		if !uuids.Is(receivedStatus.Reference) {
-			slog.Error("error converting Messagebird status reference to UUID", "error", err, "uuid", receivedStatus.Reference)
+			slog.Error("error converting Messagebird status reference to UUID", "uuid", receivedStatus.Reference)
 		} else {
 			status = models.NewStatusUpdate(channel, models.MsgUUID(receivedStatus.Reference), msgStatus, clog)
 		}

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -121,6 +121,8 @@ var statusMappings = map[string]models.MsgStatus{
 
 // receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
+	// this one decodes for itself rather than using FormPayload, because it tolerates a partial decode - it
+	// checks the fields it needs below and ignores the request if they're missing
 	form := &statusForm{}
 	handlers.DecodeAndValidateForm(form, r)
 
@@ -152,6 +154,7 @@ type moForm struct {
 
 // receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
+	// decodes for itself for the same reason as receiveStatus above
 	form := &moForm{}
 	handlers.DecodeAndValidateForm(form, r)
 

--- a/handlers/playmobile/handler.go
+++ b/handlers/playmobile/handler.go
@@ -43,7 +43,7 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.XMLPayload(h.receiveMessage))
 	return nil
 }
 
@@ -94,14 +94,7 @@ type mtResponse struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	payload := &mtResponse{}
-	err := handlers.DecodeAndValidateXML(payload, r)
-
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, payload *mtResponse, in *channels.Received, clog *models.ChannelLog) error {
 	if len(payload.Message) == 0 {
 		return channels.Ignore("no messages, ignored")
 	}

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -50,8 +50,8 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
 	return nil
 }
 
@@ -72,13 +72,7 @@ var statusMapping = map[string]models.MsgStatus{
 }
 
 // receiveStatus is our receive function for status updates
-func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &statusForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
 		return channels.Ignore("ignoring unknown status '%s'", form.Status)
@@ -106,13 +100,7 @@ type moForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	if strings.TrimPrefix(channel.Address(), "+") != strings.TrimPrefix(form.To, "+") {
 		return fmt.Errorf("invalid to number [%s], expecting [%s]", strings.TrimPrefix(form.To, "+"), strings.TrimPrefix(channel.Address(), "+"))
 	}

--- a/handlers/smscentral/handler.go
+++ b/handlers/smscentral/handler.go
@@ -33,7 +33,7 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
 	return nil
 }
 
@@ -43,13 +43,7 @@ type moForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	// create our URN
 	urn, err := urns.ParsePhone(form.Mobile, channel.Country(), true, false)
 	if err != nil {

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -40,7 +40,7 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.XMLPayload(h.receiveMessage))
 	return nil
 }
 
@@ -58,13 +58,7 @@ type moPayload struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	payload := &moPayload{}
-	err := handlers.DecodeAndValidateXML(payload, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.Service.RequestID == "" || payload.From == "" || payload.To == "" {
 		return fmt.Errorf("missing parameters, must have 'request_id', 'to' and 'body'")
 	}

--- a/handlers/telesom/handler.go
+++ b/handlers/telesom/handler.go
@@ -35,8 +35,8 @@ func newHandler() channels.Handler {
 }
 
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
 	return nil
 }
 
@@ -46,12 +46,7 @@ type moForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	// create our URN
 	urn, err := urns.ParsePhone(form.Mobile, channel.Country(), true, false)
 	if err != nil {

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -39,8 +39,8 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
-	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, h.receiveStatus)
+	r.AddReceive(h, http.MethodPost, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "status", models.ChannelLogTypeMsgStatus, handlers.FormPayload(h.receiveStatus))
 	return nil
 }
 
@@ -57,14 +57,7 @@ type moForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	// get our params
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	// create our URN
 	urn, err := urns.ParsePhone(form.From, channel.Country(), true, false)
 	if err != nil {
@@ -111,14 +104,7 @@ var statusMapping = map[string]models.MsgStatus{
 }
 
 // receiveStatus is our receive function for status updates
-func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	// get our params
-	form := &statusForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
 		return fmt.Errorf("unknown status: '%s'", form.Status)

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -55,7 +55,7 @@ func newHandler() channels.Handler {
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
-	r.AddReceive(h, http.MethodPost, "", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.AddReceive(h, http.MethodPost, "", models.ChannelLogTypeMsgReceive, handlers.XMLPayload(h.receiveMessage))
 	return nil
 }
 
@@ -108,13 +108,7 @@ type moPayload struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	payload := &moPayload{}
-	err := handlers.DecodeAndValidateXML(payload, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.MsgID == "" && payload.Event == "" {
 		return fmt.Errorf("missing parameters, must have either 'MsgId' or 'Event'")
 	}

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -40,7 +40,7 @@ func newHandler() channels.Handler {
 }
 
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, h.receiveMessage)
+	r.AddReceive(h, http.MethodGet, "receive", models.ChannelLogTypeMsgReceive, handlers.FormPayload(h.receiveMessage))
 	return nil
 }
 
@@ -53,13 +53,7 @@ type moForm struct {
 }
 
 // receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-	form := &moForm{}
-	err := handlers.DecodeAndValidateForm(form, r)
-	if err != nil {
-		return err
-	}
-
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
 	// must have one of from or sender set, error if neither
 	sender := form.Sender
 	if sender == "" {
@@ -77,6 +71,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 
 	date := time.Now()
 	if dateString != "" {
+		var err error
 		date, err = time.Parse(time.RFC3339Nano, dateString)
 		if err != nil {
 			return errors.New("invalid date format, must be RFC 3339")


### PR DESCRIPTION
## Summary

Handlers whose provider sends form values or XML each opened their receive functions with the same four lines of decode-and-check boilerplate, while the JSON handlers had `JSONPayload` doing it for them. This adds the two missing adapters so every payload-carrying receive function declares what it expects and lets the adapter decode it.

## Changes

**`handlers/generic.go`**
- `FormPayload[T]` and `XMLPayload[T]` join `JSONPayload[T]`, sharing one implementation (`withPayload`) that differs only by which decoder it calls — the three `DecodeAndValidate*` functions already share a signature.
- `JSONReceiveFunc[T]` becomes `PayloadReceiveFunc[T]`, since three adapters use it now.

**~30 receive functions across 20 handlers** take their payload as a parameter instead of decoding it:
- Form: africastalking, dart, dmark, external, firebase, highconnection, hormuud, jasmin, kaleyra, kannel, macrokiosk, plivo, smscentral, telesom, thinq, yo
- XML: clickmobile, playmobile, start, wechat

**i2sms and m3tech** had reimplemented `NewTelReceiveHandler` line for line — same form parsing, same required-field error text, same received-on stamp — and now call it with their own field names.

## Not converted, deliberately

Some receive functions decode for themselves, each with a comment saying why:

- **messagebird `receiveStatus`** answers a decode failure as `Ignore` (200) rather than as an error. Under the adapter it would return 400, which the provider may retry against us.
- **nexmo** `receiveStatus`/`receiveMessage` discard the decode error and check the fields they need afterwards. `statusForm.ErrCode` is an `int`, so an empty or non-numeric `err-code` would newly fail the request.
- **twiml**, **messagebird `receiveMessage`** validate a signature over the request before decoding.
- **external `receiveMessage`** branches on channel config between XPath-over-raw-body and form parsing, so it has no single payload struct.
- The raw `HandleFunc` routes (jiochat/wechat `VerifyURL`, firebase `registerContact`) own their whole response.

The first two are pre-existing error-handling quirks worth settling on their own terms; changing what a provider sees isn't this refactor's business.

## Behavior examples

No wire behavior changes. A converted handler answers a malformed body exactly as before — the same `DecodeAndValidateForm`/`XML` error, at the same point in the request:

| | before | after |
|---|---|---|
| valid request | handler decodes, then acts | adapter decodes, handler acts |
| undecodable body | handler returns decode error | adapter returns the same decode error |

## Test plan

- [x] full suite green (`go test -p=1 ./...`, 62 packages)
- [x] no test expectations needed changing — the decode errors and their messages are identical
- [x] i2sms and m3tech tests pass unchanged, which is what confirms their hand-rolled versions were equivalent to `NewTelReceiveHandler`