### PR TITLE
Share the WhatsApp payload parser between Cloud API and 360dialog

### DIFF
--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -4,11 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -92,119 +90,23 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *
 	return h.parseWhatsAppPayload(channel, payload, r, in, clog)
 }
 
-// parseWhatsAppPayload turns a notification into the set of things it contained, without writing any of them -
-// which is what lets the whole batch be written together, and keeps a failure part way through it from leaving
-// a response that describes more than we actually did. It still does I/O, since resolving a message's media
-// means asking the provider for its URL, but it makes no changes.
+// parseWhatsAppPayload hands the notification's changes to the shared WhatsApp parser, which fills in the batch.
+// Media is resolved with the channel's own token against the provider's base URL.
+//
+// A malformed payload is answered as ignored rather than as an error: unlike the Cloud API handler, this one
+// doesn't force a 200 on error responses, and 360dialog would retry a payload that can't parse any better the
+// second time.
 func (h *handler) parseWhatsAppPayload(channel *models.Channel, payload *Notifications, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
+	resolveMedia := func(mediaID string) (string, error) { return h.resolveMediaURL(channel, mediaID, clog) }
 
-	seenMsgIDs := make(map[string]bool)
-	contactNames := make(map[string]string)
-
-	// for each entry
+	var changes []whatsapp.Change
 	for _, entry := range payload.Entry {
-		if len(entry.Changes) == 0 {
-			continue
-		}
-
-		for _, change := range entry.Changes {
-
-			// contacts are keyed by both identifiers they can carry, as a message from a user with a username may
-			// only reference them by their user_id
-			for _, contact := range change.Value.Contacts {
-				if contact.WaID != "" {
-					contactNames[contact.WaID] = contact.Profile.Name
-				}
-				if contact.UserID != "" {
-					contactNames[contact.UserID] = contact.Profile.Name
-				}
-			}
-
-			for _, waMsg := range change.Value.Messages {
-				if seenMsgIDs[waMsg.ID] {
-					continue
-				}
-
-				if waMsg.GroupID != "" {
-					in.Ignored("ignoring group message")
-					continue
-				}
-
-				date, urn, text, mediaURL, mediaID, err, finalErr := waMsg.ExtractData(clog)
-				if finalErr != nil {
-					return channels.Ignore("%s", finalErr.Error())
-				}
-
-				if err != nil {
-					channels.LogRequestError(r, channel, err)
-					continue
-				}
-
-				if mediaID != "" && mediaURL == "" {
-					mediaURL, err = h.resolveMediaURL(channel, mediaID, clog)
-					// we had an error downloading media
-					if err != nil {
-						channels.LogRequestError(r, channel, err)
-					}
-				}
-
-				// create our message
-				event := models.NewIncomingMsg(channel, urn, text, waMsg.ID, clog).WithReceivedOn(date).WithContactName(contactNames[waMsg.Identifier()])
-
-				if mediaURL != "" {
-					event.WithAttachment(mediaURL)
-				}
-
-				if payload := waMsg.ExtractPayload(); payload != nil {
-					event.WithPayload(payload)
-				} else if waMsg.Interactive.Type == "nfm_reply" && waMsg.Interactive.NFMReply.ResponseJSON != "" {
-					channels.LogRequestError(r, channel, errors.New("nfm_reply response_json is not a valid JSON object"))
-				}
-
-				// if we have a user_id, add it as a secondary whatsapp URN (unless it's already the primary URN)
-				if waMsg.FromUserID != "" {
-					userIDURN, urnErr := urns.New(urns.WhatsApp, waMsg.FromUserID)
-					if urnErr == nil {
-						if userIDURN != urn {
-							event.WithNewURN(userIDURN, models.NewURNAppend)
-						}
-					} else {
-						channels.LogRequestError(r, channel, fmt.Errorf("invalid user_id for whatsapp URN: %w", urnErr))
-					}
-				}
-
-				in.Msg(event)
-				seenMsgIDs[waMsg.ID] = true
-			}
-
-			for _, status := range change.Value.Statuses {
-
-				msgStatus, found := whatsapp.StatusMapping[status.Status]
-				if !found {
-					if whatsapp.IgnoreStatuses[status.Status] {
-						in.Ignored(fmt.Sprintf("ignoring status: %s", status.Status))
-					} else {
-						channels.LogRequestIgnored(r, channel, fmt.Sprintf("unknown status: %s", status.Status))
-						in.Ignored(fmt.Sprintf("unknown status: %s", status.Status))
-					}
-					continue
-				}
-
-				for _, statusError := range status.Errors {
-					clog.Error(models.ErrorExternal(strconv.Itoa(statusError.Code), statusError.Title))
-				}
-
-				in.Status(models.NewStatusUpdateByExternalID(channel, status.ID, msgStatus, clog))
-			}
-
-			for _, chError := range change.Value.Errors {
-				clog.Error(models.ErrorExternal(strconv.Itoa(chError.Code), chError.Title))
-			}
-
-		}
-
+		changes = append(changes, entry.Changes...)
 	}
 
+	if err := whatsapp.ParseChanges(channel, changes, resolveMedia, r, in, clog); err != nil {
+		return channels.Ignore("%s", err.Error())
+	}
 	return nil
 }
 

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -225,122 +225,23 @@ func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, r 
 	return h.parseWhatsAppPayload(channel, payload, r, in, clog)
 }
 
-// parseWhatsAppPayload turns a notification into the set of things it contained, without writing any of them -
-// which is what lets the whole batch be written together, and keeps a failure part way through it from leaving
-// a response that describes more than we actually did. It still does I/O, since resolving a message's media
-// means asking the provider for its URL, but it makes no changes.
+// parseWhatsAppPayload hands the notification's changes to the shared WhatsApp parser, which fills in the batch.
+// Media is resolved with the system user token, since a Cloud API channel's media lives behind Meta's graph.
 func (h *handler) parseWhatsAppPayload(channel *models.Channel, payload *Notifications, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
-
 	token := h.Runtime().Config.WhatsappAdminSystemUserToken
+	resolveMedia := func(mediaID string) (string, error) { return h.resolveMediaURL(mediaID, token, clog) }
 
-	seenMsgIDs := make(map[string]bool, 2)
-	contactNames := make(map[string]string)
+	return whatsapp.ParseChanges(channel, whatsAppChanges(payload), resolveMedia, r, in, clog)
+}
 
-	// for each entry
+// whatsAppChanges flattens the changes across a notification's entries, which are parsed as one batch so that a
+// contact named in one entry is known to a message in the next.
+func whatsAppChanges(payload *Notifications) []whatsapp.Change {
+	var changes []whatsapp.Change
 	for _, entry := range payload.Entry {
-		if len(entry.Changes) == 0 {
-			continue
-		}
-
-		for _, change := range entry.Changes {
-
-			// contacts are keyed by both identifiers they can carry, as a message from a user with a username may
-			// only reference them by their user_id
-			for _, contact := range change.Value.Contacts {
-				if contact.WaID != "" {
-					contactNames[contact.WaID] = contact.Profile.Name
-				}
-				if contact.UserID != "" {
-					contactNames[contact.UserID] = contact.Profile.Name
-				}
-			}
-
-			for _, waMsg := range change.Value.Messages {
-				if seenMsgIDs[waMsg.ID] {
-					continue
-				}
-
-				if waMsg.GroupID != "" {
-					in.Ignored("ignoring group message")
-					continue
-				}
-
-				date, urn, text, mediaURL, mediaID, err, finalErr := waMsg.ExtractData(clog)
-				if finalErr != nil {
-					return finalErr
-				}
-
-				if err != nil {
-					channels.LogRequestError(r, channel, err)
-					continue
-				}
-
-				if mediaID != "" && mediaURL == "" {
-					mediaURL, err = h.resolveMediaURL(mediaID, token, clog)
-					// we had an error downloading media
-					if err != nil {
-						channels.LogRequestError(r, channel, err)
-					}
-				}
-
-				// create our message
-				event := models.NewIncomingMsg(channel, urn, text, waMsg.ID, clog).WithReceivedOn(date).WithContactName(contactNames[waMsg.Identifier()])
-
-				if mediaURL != "" {
-					event.WithAttachment(mediaURL)
-				}
-
-				if payload := waMsg.ExtractPayload(); payload != nil {
-					event.WithPayload(payload)
-				} else if waMsg.Interactive.Type == "nfm_reply" && waMsg.Interactive.NFMReply.ResponseJSON != "" {
-					channels.LogRequestError(r, channel, errors.New("nfm_reply response_json is not a valid JSON object"))
-				}
-
-				// if we have a user_id, add it as a secondary whatsapp URN (unless it's already the primary URN)
-				if waMsg.FromUserID != "" {
-					userIDURN, urnErr := urns.New(urns.WhatsApp, waMsg.FromUserID)
-					if urnErr == nil {
-						if userIDURN != urn {
-							event.WithNewURN(userIDURN, models.NewURNAppend)
-						}
-					} else {
-						channels.LogRequestError(r, channel, fmt.Errorf("invalid user_id for whatsapp URN: %w", urnErr))
-					}
-				}
-
-				in.Msg(event)
-				seenMsgIDs[waMsg.ID] = true
-			}
-
-			for _, status := range change.Value.Statuses {
-
-				msgStatus, found := whatsapp.StatusMapping[status.Status]
-				if !found {
-					if whatsapp.IgnoreStatuses[status.Status] {
-						in.Ignored(fmt.Sprintf("ignoring status: %s", status.Status))
-					} else {
-						channels.LogRequestError(r, channel, fmt.Errorf("unknown status: %s", status.Status))
-						in.Ignored(fmt.Sprintf("unknown status: %s", status.Status))
-					}
-					continue
-				}
-
-				for _, statusError := range status.Errors {
-					statusError.ErrorChannelLog(clog)
-				}
-
-				in.Status(models.NewStatusUpdateByExternalID(channel, status.ID, msgStatus, clog))
-			}
-
-			for _, chError := range change.Value.Errors {
-				chError.ErrorChannelLog(clog)
-			}
-
-		}
-
+		changes = append(changes, entry.Changes...)
 	}
-
-	return nil
+	return changes
 }
 
 // parseFacebookInstagramPayload turns a notification into the set of things it contained, without writing any

--- a/handlers/meta/whatsapp/incoming.go
+++ b/handlers/meta/whatsapp/incoming.go
@@ -1,0 +1,126 @@
+package whatsapp
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/nyaruka/courier/v26/core/channels"
+	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/gocommon/urns"
+)
+
+// ResolveMediaFunc asks the provider for the URL of a message's media, given its ID. It's the one thing that
+// differs between the channel types that deliver WhatsApp payloads - who they ask, and with whose credentials.
+type ResolveMediaFunc func(mediaID string) (string, error)
+
+// ParseChanges turns the changes carried by a WhatsApp notification into the messages and statuses they
+// contained, adding them to the given batch without writing any of them - which is what lets the whole batch be
+// written together, and keeps a failure part way through it from leaving a response that describes more than we
+// actually did. It still does I/O, since resolving a message's media means asking the provider for its URL, but
+// it makes no changes.
+//
+// A returned error means the payload itself is malformed - a message we can't read a timestamp or a sender from
+// - so asking for it again wouldn't get any further. Callers whose provider retries on an error response answer
+// it as ignored instead.
+func ParseChanges(channel *models.Channel, changes []Change, resolveMedia ResolveMediaFunc, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
+	seenMsgIDs := make(map[string]bool, 2)
+	contactNames := make(map[string]string)
+
+	for _, change := range changes {
+		// contacts are keyed by both identifiers they can carry, as a message from a user with a username may
+		// only reference them by their user_id
+		for _, contact := range change.Value.Contacts {
+			if contact.WaID != "" {
+				contactNames[contact.WaID] = contact.Profile.Name
+			}
+			if contact.UserID != "" {
+				contactNames[contact.UserID] = contact.Profile.Name
+			}
+		}
+
+		for _, waMsg := range change.Value.Messages {
+			if seenMsgIDs[waMsg.ID] {
+				continue
+			}
+
+			if waMsg.GroupID != "" {
+				in.Ignored("ignoring group message")
+				continue
+			}
+
+			date, urn, text, mediaURL, mediaID, err, finalErr := waMsg.ExtractData(clog)
+			if finalErr != nil {
+				return finalErr
+			}
+
+			if err != nil {
+				channels.LogRequestError(r, channel, err)
+				continue
+			}
+
+			if mediaID != "" && mediaURL == "" {
+				mediaURL, err = resolveMedia(mediaID)
+				// we had an error downloading media
+				if err != nil {
+					channels.LogRequestError(r, channel, err)
+				}
+			}
+
+			// create our message
+			event := models.NewIncomingMsg(channel, urn, text, waMsg.ID, clog).WithReceivedOn(date).WithContactName(contactNames[waMsg.Identifier()])
+
+			if mediaURL != "" {
+				event.WithAttachment(mediaURL)
+			}
+
+			if payload := waMsg.ExtractPayload(); payload != nil {
+				event.WithPayload(payload)
+			} else if waMsg.Interactive.Type == "nfm_reply" && waMsg.Interactive.NFMReply.ResponseJSON != "" {
+				channels.LogRequestError(r, channel, errors.New("nfm_reply response_json is not a valid JSON object"))
+			}
+
+			// if we have a user_id, add it as a secondary whatsapp URN (unless it's already the primary URN)
+			if waMsg.FromUserID != "" {
+				userIDURN, urnErr := urns.New(urns.WhatsApp, waMsg.FromUserID)
+				if urnErr == nil {
+					if userIDURN != urn {
+						event.WithNewURN(userIDURN, models.NewURNAppend)
+					}
+				} else {
+					channels.LogRequestError(r, channel, fmt.Errorf("invalid user_id for whatsapp URN: %w", urnErr))
+				}
+			}
+
+			in.Msg(event)
+			seenMsgIDs[waMsg.ID] = true
+		}
+
+		for _, status := range change.Value.Statuses {
+			msgStatus, found := StatusMapping[status.Status]
+			if !found {
+				if IgnoreStatuses[status.Status] {
+					in.Ignored(fmt.Sprintf("ignoring status: %s", status.Status))
+				} else {
+					// a status in neither map is one WhatsApp has added since we last looked, so it's logged
+					// where we'll see it rather than only at debug
+					channels.LogRequestError(r, channel, fmt.Errorf("unknown status: %s", status.Status))
+					in.Ignored(fmt.Sprintf("unknown status: %s", status.Status))
+				}
+				continue
+			}
+
+			for _, statusError := range status.Errors {
+				statusError.ErrorChannelLog(clog)
+			}
+
+			in.Status(models.NewStatusUpdateByExternalID(channel, status.ID, msgStatus, clog))
+		}
+
+		for _, chError := range change.Value.Errors {
+			chError.ErrorChannelLog(clog)
+		}
+	}
+
+	return nil
+}

--- a/handlers/meta/whatsapp/incoming_test.go
+++ b/handlers/meta/whatsapp/incoming_test.go
@@ -1,0 +1,80 @@
+package whatsapp_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nyaruka/courier/v26/core/channels"
+	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/handlers/meta/whatsapp"
+	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseChanges runs the shared parser over the given changes JSON, with a media resolver that resolves every
+// id to the same URL, and returns the batch it filled in along with any error.
+func parseChanges(t *testing.T, changesJSON string) (*channels.Received, error) {
+	t.Helper()
+
+	ch := test.NewMockChannel("dbc126ed-66bc-4e28-b67b-81dc3327c95d", "WAC", "12345", "US", []string{urns.WhatsApp.Prefix}, nil)
+	clog := models.NewChannelLog(models.ChannelLogTypeMultiReceive, ch, nil, nil)
+	in := channels.NewReceived(ch)
+	r := httptest.NewRequest("POST", "/c/wac/dbc126ed-66bc-4e28-b67b-81dc3327c95d/receive", nil)
+
+	var changes []whatsapp.Change
+	require.NoError(t, json.Unmarshal([]byte(changesJSON), &changes))
+
+	resolveMedia := func(mediaID string) (string, error) { return "https://example.com/" + mediaID + ".jpg", nil }
+
+	return in, whatsapp.ParseChanges(ch, changes, resolveMedia, r, in, clog)
+}
+
+func TestParseChanges(t *testing.T) {
+	// a message and a status from one change both land in the batch
+	in, err := parseChanges(t, `[{"field":"messages","value":{
+		"contacts":[{"profile":{"name":"Jim"},"wa_id":"250788123123"}],
+		"messages":[{"id":"wamid.1","from":"250788123123","timestamp":"1454119029","type":"text","text":{"body":"hello"}}],
+		"statuses":[{"id":"wamid.9","status":"sent","timestamp":"1454119029"}]
+	}}]`)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, in.Len())
+
+	// the same message id twice is only taken once, including across changes
+	in, err = parseChanges(t, `[{"field":"messages","value":{
+		"messages":[{"id":"wamid.1","from":"250788123123","timestamp":"1454119029","type":"text","text":{"body":"hello"}}]
+	}},{"field":"messages","value":{
+		"messages":[{"id":"wamid.1","from":"250788123123","timestamp":"1454119029","type":"text","text":{"body":"hello"}}]
+	}}]`)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, in.Len())
+
+	// a group message is noted as ignored rather than received
+	in, err = parseChanges(t, `[{"field":"messages","value":{
+		"messages":[{"id":"wamid.1","from":"250788123123","group_id":"g1","timestamp":"1454119029","type":"text","text":{"body":"hello"}}]
+	}}]`)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, in.Len())
+
+	// a status we deliberately ignore, and one we don't recognize at all, are both noted as ignored
+	in, err = parseChanges(t, `[{"field":"messages","value":{
+		"statuses":[{"id":"wamid.9","status":"deleted","timestamp":"1454119029"},{"id":"wamid.8","status":"in_orbit","timestamp":"1454119029"}]
+	}}]`)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, in.Len())
+
+	// a message whose timestamp can't be read fails the whole batch, because asking for it again wouldn't get
+	// any further - this is the error each handler answers in the way its provider needs
+	_, err = parseChanges(t, `[{"field":"messages","value":{
+		"messages":[{"id":"wamid.1","from":"250788123123","timestamp":"notatimestamp","type":"text","text":{"body":"hello"}}]
+	}}]`)
+	assert.EqualError(t, err, "invalid timestamp: notatimestamp")
+
+	// as does one we can't read a sender from
+	_, err = parseChanges(t, `[{"field":"messages","value":{
+		"messages":[{"id":"wamid.1","timestamp":"1454119029","type":"text","text":{"body":"hello"}}]
+	}}]`)
+	assert.EqualError(t, err, "invalid whatsapp id")
+}


### PR DESCRIPTION
## Summary

The Cloud API (`handlers/meta`) and 360dialog (`handlers/dialog360`) handlers each carried their own copy of the same ~110 line loop for turning a WhatsApp notification into messages and statuses. They now share one parser, with the genuinely channel-specific part passed in.

## Changes

**New `handlers/meta/whatsapp/incoming.go`** — `ParseChanges(channel, changes, resolveMedia, r, in, clog)` holds the loop both handlers had: contact-name collection keyed by both identifiers, group-message and duplicate skipping, `ExtractData`, media resolution, `nfm_reply` payloads, the secondary `user_id` URN, status mapping and channel errors.

The two `Notifications` types stay where they are — they differ (Meta's entries also carry Facebook/Instagram `messaging`), but the WhatsApp part of both is the same shared `whatsapp.Change`, so the parser takes those rather than the whole payload.

**`resolveMedia`** is the one real difference, passed as a `ResolveMediaFunc`: the Cloud API resolves media with the system user token against Meta's graph, 360dialog with the channel's own token against its base URL.

**Each handler keeps a thin adapter** that flattens its entries' changes and supplies its resolver.

## The difference that turned out not to be one

The handlers disagreed on a malformed payload — one returned the error, the other wrapped it in `Ignore`. Both are after the same thing: a payload with an unreadable timestamp or sender won't parse any better on a retry, so neither wants the provider to send it again. They just got there differently, because the Cloud API handler overrides `RespondError` to answer 200 while 360dialog doesn't and would otherwise return a 400 that 360dialog retries.

Both behaviors are preserved, now as one visible line at 360dialog's call site with a comment, rather than a divergence buried in duplicated code.

## Behavior examples

| | Cloud API | 360dialog |
|---|---|---|
| malformed payload (before) | 200, error body | 200, ignored body |
| malformed payload (after) | 200, error body | 200, ignored body |
| unrecognized status (before) | 200 `Events Handled` + info, logged at info | 200 `Events Handled` + info, logged at **debug** |
| unrecognized status (after) | 200 `Events Handled` + info, logged at info | 200 `Events Handled` + info, logged at **info** |

The only change is that log level. A status in neither `StatusMapping` nor `IgnoreStatuses` is one WhatsApp has added since we last looked, so it's worth seeing rather than hiding at debug. Responses are unchanged.

## Test plan

- [x] full suite green (`go test -p=1 ./...`, 62 packages)
- [x] no existing test expectations needed changing
- [x] both handlers already cover the malformed-payload paths (`invalid whatsapp id`, `invalid timestamp`) and the unknown-status path, each asserting the exact response body and a 200 — those passing unchanged is what confirms the two response behaviors survived
- [x] new `incoming_test.go` covers the shared parser directly, rather than only through the two handlers: duplicate ids across changes, group messages, deliberately-ignored and unrecognized statuses, and the malformed-payload error that each handler answers in its provider's terms