### PR TITLE
Use UnknownStatusError in the three handlers that still hand-wrote it

### DIFF
--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -262,7 +262,7 @@ func (h *handler) receiveStatus(ctx context.Context, statusString string, channe
 	// get our status
 	msgStatus, found := statusMappings[strings.ToLower(statusString)]
 	if !found {
-		return fmt.Errorf("unknown status '%s', must be one failed, sent or delivered", statusString)
+		return handlers.UnknownStatusError(statusMappings, statusString)
 	}
 
 	in.Status(models.NewStatusUpdate(channel, models.MsgUUID(msgUUID), msgStatus, clog))

--- a/handlers/mtn/handler.go
+++ b/handlers/mtn/handler.go
@@ -98,7 +98,7 @@ func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *
 
 		msgStatus, found := statusMapping[payload.DeliveryStatus]
 		if !found {
-			return fmt.Errorf("unknown status '%s'", payload.DeliveryStatus)
+			return handlers.UnknownStatusError(statusMapping, payload.DeliveryStatus)
 		}
 
 		if msgStatus == models.MsgStatusWired {

--- a/handlers/mtn/handler_test.go
+++ b/handlers/mtn/handler_test.go
@@ -145,7 +145,7 @@ var incomingCases = []IncomingTestCase{
 		URL:                  receiveURL,
 		Data:                 uknownStatus,
 		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "unknown status",
+		ExpectedBodyContains: `unknown status 'blabla', must be one of 'DELIVRD', 'DeliveredToNetwork', 'DeliveredToTerminal', 'DeliveryImpossible', 'DeliveryNotificationNotSupported', 'DeliveryUncertain', 'EXPIRED', 'MessageWaiting'`,
 	},
 	{
 		// a body we can't even read is never classified, so it keeps the kind the route was registered with -

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -107,7 +107,7 @@ var statusMapping = map[string]models.MsgStatus{
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, form *statusForm, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[form.Status]
 	if !found {
-		return fmt.Errorf("unknown status: '%s'", form.Status)
+		return handlers.UnknownStatusError(statusMapping, form.Status)
 	}
 
 	status := models.NewStatusUpdateByExternalID(channel, form.GUID, msgStatus, clog)

--- a/handlers/thinq/handler_test.go
+++ b/handlers/thinq/handler_test.go
@@ -77,7 +77,7 @@ var testCases = []IncomingTestCase{
 		Data:                 "guid=1234&status=UN",
 		ExpectedRespStatus:   400,
 		ExpectedExternalID:   "1234",
-		ExpectedBodyContains: `"unknown status: 'UN'"`,
+		ExpectedBodyContains: `unknown status 'UN', must be one of 'DELETED', 'DELIVRD', 'EXPIRED', 'REJECTD', 'UNDELIV', 'UNKNOWN'`,
 	},
 	{
 		Label:                "Status Missing GUID",


### PR DESCRIPTION
## Summary

`handlers.UnknownStatusError` builds its "must be one of" list from the status map itself, so the message can't drift from the map. Three handlers still hand-wrote that error despite having a map right there — misses in the sweep that introduced the helper, not deliberate exceptions. This brings the count to 14.

## Changes

| Handler | Was | Now |
|---|---|---|
| [thinq](handlers/thinq/handler.go) | `unknown status: 'UN'` | lists all six of its values |
| [mtn](handlers/mtn/handler.go) | `unknown status 'blabla'` | lists all eight of its values |
| [external](handlers/external/handler.go) | `unknown status 'x', must be one failed, sent or delivered` | lists the three from the map |

Two were drifting in exactly the way the helper exists to prevent. thinq named no valid values at all, so a provider sending a bad status got no hint what a good one looks like. external's message was a hand-maintained copy of its map — and ungrammatical with it ("must be one failed").

## Behavior

Only the error text in a 400 response changes:

```
thinq, POST /status/ with status=UN

- {"message":"Error","data":[{"type":"error","error":"unknown status: 'UN'"}]}
+ {"message":"Error","data":[{"type":"error","error":"unknown status 'UN', must be one of 'DELETED', 'DELIVRD', 'EXPIRED', 'REJECTD', 'UNDELIV', 'UNKNOWN'"}]}
```

Status codes, which statuses are recognised, and what gets written are all unchanged.

## A note on external

Its branch is **unreachable from any request**. The status string comes from the route registration — `buildStatusHandler("sent")`, `("delivered")`, `("failed")` — and all three are in the map, so no HTTP request can miss it. It's a guard against a future registration naming a status the map doesn't have.

That's why this PR adds no test for it: there's no request that reaches the line. It gains message consistency, not coverage. Left in place rather than deleted because the guard is cheap and the mistake it catches is silent.

## What was deliberately left alone

Ten other sites mention an unknown status but answer with `channels.Ignore` or `Received.Ignored` rather than an error — macrokiosk, plivo, kannel, kaleyra, nexmo, and the WhatsApp/turn parse loops. `UnknownStatusError` returns an error, so adopting it there would turn a deliberate 200-ignored into a 400 and change what providers see. Different behavior, not the same omission.

## Test plan

- [x] Full suite green (`go test -p=1 ./...`)
- [x] thinq and mtn assertions tightened to the full generated message, so a change to either map that breaks the message is caught
- [x] Confirmed by audit that no other handler errors on a status-map miss without the helper
- [x] `gofmt` clean