### PR TITLE
Name receive functions after the kind their route registers

### DIFF
--- a/core/channels/doc.go
+++ b/core/channels/doc.go
@@ -29,6 +29,12 @@
 // contact is one type, because a message and a channel event are not worth telling apart in a list when the
 // log's own request and response say which it was.
 //
+// Receive functions are named after the kind their route registers: receiveMessage, receiveStatus,
+// receiveEvent, and receiveAny for a route serving several. A handler with two routes of one kind says which
+// in the name instead - receiveSentStatus beside receiveDeliveredStatus. Narrowing with As() doesn't change
+// the name, because a message endpoint where one particular message means a contact stopped is still a
+// message endpoint; a function serving routes of genuinely different kinds is the case receiveAny covers.
+//
 // Everything else in core/models is a handler's to use directly. Models owns the data - the types, the
 // constants and the database access - and handlers lean on it constantly, building a models.MsgIn, reading
 // models.ConfigAuthToken, looking a channel up with models.GetChannel. The line is drawn around incoming

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -45,7 +45,7 @@ func newHandler() channels.Handler {
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
-	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, h.statusMessage)
+	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, h.receiveStatus)
 	return nil
 }
 
@@ -123,8 +123,8 @@ var statusMapping = map[string]models.MsgStatus{
 	"message-failed":    models.MsgStatusFailed,
 }
 
-// statusMessage is our receive function for status updates
-func (h *handler) statusMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
+// receiveStatus is our receive function for status updates
+func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	var payload []moStatusData
 	body, err := handlers.ReadBody(r, 1000000)
 	if err != nil {

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -43,7 +43,7 @@ func newWAHandler(channelType models.ChannelType, name string) channels.Handler 
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveEvent))
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
 	return nil
 }
 
@@ -73,8 +73,8 @@ type Notifications struct {
 	} `json:"entry"`
 }
 
-// receiveEvent is our receive function for incoming messages and status updates
-func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *http.Request, payload *Notifications, in *channels.Received, clog *models.ChannelLog) error {
+// receiveAny is our receive function for the single URL 360dialog delivers both messages and status updates through
+func (h *handler) receiveAny(ctx context.Context, channel *models.Channel, r *http.Request, payload *Notifications, in *channels.Received, clog *models.ChannelLog) error {
 	// is not a 'whatsapp_business_account' object? ignore it
 	if payload.Object != "whatsapp_business_account" {
 		return channels.Ignore("ignoring request")

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -64,7 +64,7 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveEvents))
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
 	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
 	return nil
 }
@@ -206,8 +206,9 @@ type moPayload struct {
 	} `json:"entry"`
 }
 
-// receiveEvents is our receive function for incoming messages and status updates
-func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
+// receiveAny is our receive function for the single URL Facebook delivers messages, status updates and events
+// through
+func (h *handler) receiveAny(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	// not a page object? ignore
 	if payload.Object != "page" {
 		return channels.Ignore("ignoring non-page request")

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -34,7 +34,7 @@ func newHandler() channels.Handler {
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
-	r.AddReceive(h, http.MethodPost, "delivered", channels.ReceiveKindStatus, handlers.JSONPayload(h.statusMessage))
+	r.AddReceive(h, http.MethodPost, "delivered", channels.ReceiveKindStatus, handlers.JSONPayload(h.receiveStatus))
 	return nil
 }
 
@@ -56,8 +56,8 @@ type ibStatus struct {
 	} `validate:"required" json:"status"`
 }
 
-// statusMessage is our receive function for status updates
-func (h *handler) statusMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *statusPayload, in *channels.Received, clog *models.ChannelLog) error {
+// receiveStatus is our receive function for status updates
+func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, payload *statusPayload, in *channels.Received, clog *models.ChannelLog) error {
 
 	for _, s := range payload.Results {
 		msgStatus, found := statusMapping[s.Status.GroupName]

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -55,9 +55,9 @@ func newHandler() channels.Handler {
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
-	r.AddReceive(h, http.MethodPost, "rcv/msg/message", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
-	r.AddReceive(h, http.MethodPost, "rcv/event/menu", channels.ReceiveKindEvent, handlers.JSONPayload(h.receiveMessage))
-	r.AddReceive(h, http.MethodPost, "rcv/event/follow", channels.ReceiveKindEvent, handlers.JSONPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "rcv/msg/message", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveAny))
+	r.AddReceive(h, http.MethodPost, "rcv/event/menu", channels.ReceiveKindEvent, handlers.JSONPayload(h.receiveAny))
+	r.AddReceive(h, http.MethodPost, "rcv/event/follow", channels.ReceiveKindEvent, handlers.JSONPayload(h.receiveAny))
 	return nil
 }
 
@@ -109,8 +109,8 @@ type moPayload struct {
 	MediaID      string `json:"MediaId"`
 }
 
-// receiveMessage is our receive function for incoming messages
-func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
+// receiveAny serves all three of this channel's receive routes, sorting messages from events by payload type
+func (h *handler) receiveAny(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.MsgID == "" && payload.Event == "" {
 		return fmt.Errorf("missing parameters, must have either 'MsgId' or 'Event'")
 	}

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -38,7 +38,7 @@ func init() {
 // Initialize implements channels.Handler
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
-	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.JSONPayload(h.statusMessage))
+	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.JSONPayload(h.receiveStatus))
 	return nil
 }
 
@@ -133,7 +133,7 @@ var statusMapping = map[string]models.MsgStatus{
 	"failed":      models.MsgStatusFailed,
 }
 
-func (h *handler) statusMessage(ctx context.Context, c *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
+func (h *handler) receiveStatus(ctx context.Context, c *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.Data.Type != "sms" || payload.Data.Direction != "O" {
 		return channels.Ignore("Ignoring request, no message")
 	}

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -43,7 +43,7 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMsg))
+	r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodGet, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
 	return nil
 }
@@ -62,8 +62,8 @@ type moStatusForm struct {
 	Status string `name:"status" validate:"required"`
 }
 
-// receiveMsg is our receive function for incoming messages
-func (h *handler) receiveMsg(ctx context.Context, channel *models.Channel, r *http.Request, form *moMsgForm, in *channels.Received, clog *models.ChannelLog) error {
+// receiveMessage is our receive function for incoming messages
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moMsgForm, in *channels.Received, clog *models.ChannelLog) error {
 	// invalid type? ignore this
 	if form.Type != "text" && form.Type != "image" && form.Type != "video" && form.Type != "voice" && form.Type != "document" {
 		return channels.Ignore("ignoring request, unknown message type")

--- a/handlers/mblox/handler.go
+++ b/handlers/mblox/handler.go
@@ -36,7 +36,7 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveEvent))
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
 	return nil
 }
 
@@ -60,8 +60,8 @@ var statusMapping = map[string]models.MsgStatus{
 	"Expired":    models.MsgStatusFailed,
 }
 
-// receiveEvent is our receive function for incoming messages
-func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *http.Request, payload *eventPayload, in *channels.Received, clog *models.ChannelLog) error {
+// receiveAny is our receive function for the single URL Mblox delivers both messages and delivery reports through
+func (h *handler) receiveAny(ctx context.Context, channel *models.Channel, r *http.Request, payload *eventPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.Type == "recipient_delivery_report_sms" {
 		in.As(channels.ReceiveKindStatus)
 

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -78,7 +78,7 @@ type handler struct {
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveEvents))
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
 	return nil
 }
 
@@ -213,8 +213,8 @@ func (h *handler) resolveMediaURL(mediaID string, token string, clog *models.Cha
 	return mediaURL, err
 }
 
-// receiveEvents is our receive function for incoming messages and status updates
-func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, r *http.Request, payload *Notifications, in *channels.Received, clog *models.ChannelLog) error {
+// receiveAny is our receive function for the single URL Meta delivers messages, status updates and events through
+func (h *handler) receiveAny(ctx context.Context, channel *models.Channel, r *http.Request, payload *Notifications, in *channels.Received, clog *models.ChannelLog) error {
 	if err := h.validateSignature(r); err != nil {
 		return err
 	}

--- a/handlers/mtarget/handler.go
+++ b/handlers/mtarget/handler.go
@@ -45,15 +45,15 @@ var statusMapping = map[string]models.MsgStatus{
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMsg)
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
 
 	statusHandler := handlers.NewExternalIDStatusHandler(statusMapping, "MsgId", "Status")
 	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, statusHandler)
 	return nil
 }
 
-// receiveMsg handles both MO messages and Stop commands
-func (h *handler) receiveMsg(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
+// receiveMessage handles both MO messages and Stop commands
+func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	err := r.ParseForm()
 	if err != nil {
 		return err

--- a/handlers/mtn/handler.go
+++ b/handlers/mtn/handler.go
@@ -45,7 +45,7 @@ func newHandler() channels.Handler {
 
 // Initialize implements channels.Handler
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveEvent))
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
 	return nil
 }
 
@@ -74,8 +74,8 @@ type moPayload struct {
 	DeliveryStatus string `json:"deliveryStatus"`
 }
 
-// receiveEvent is our receive function for incoming messages
-func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
+// receiveAny is our receive function for the single URL MTN delivers both messages and status reports through
+func (h *handler) receiveAny(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.Message != "" {
 		in.As(channels.ReceiveKindMsg)
 

--- a/handlers/slack/handler.go
+++ b/handlers/slack/handler.go
@@ -47,11 +47,11 @@ func newHandler() channels.Handler {
 }
 
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveEvent))
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
 	return nil
 }
 
-func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
+func (h *handler) receiveAny(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if payload.Type == "url_verification" {
 		in.As(channels.ReceiveKindVerify)
 

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -54,7 +54,7 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveEvents))
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
 
 	return nil
 }
@@ -146,8 +146,8 @@ type eventsPayload struct {
 	} `json:"statuses"`
 }
 
-// receiveEvents is our receive function for incoming messages and status updates
-func (h *handler) receiveEvents(ctx context.Context, channel *models.Channel, r *http.Request, payload *eventsPayload, in *channels.Received, clog *models.ChannelLog) error {
+// receiveAny is our receive function for the single URL Turn delivers both messages and status updates through
+func (h *handler) receiveAny(ctx context.Context, channel *models.Channel, r *http.Request, payload *eventsPayload, in *channels.Received, clog *models.ChannelLog) error {
 	// a failure here is in the payload itself, so asking for it again wouldn't get any further. The seam writes
 	// whatever was parsed ahead of it rather than dropping it.
 	return h.parseEvents(channel, payload, r, in, clog)

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -74,7 +74,7 @@ func newHandler() channels.Handler {
 
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveEvent))
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
 	return nil
 }
 
@@ -116,8 +116,9 @@ type welcomeMessagePayload struct {
 	Sender       map[string]string `json:"sender,omitempty"`
 }
 
-// receiveEvent is our receive function for incoming messages
-func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *http.Request, payload *eventPayload, in *channels.Received, clog *models.ChannelLog) error {
+// receiveAny is our receive function for the single URL Viber delivers messages, statuses, contact events and
+// its verification handshake through
+func (h *handler) receiveAny(ctx context.Context, channel *models.Channel, r *http.Request, payload *eventPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if err := h.validateSignature(channel, r); err != nil {
 		return channels.Unauthenticated(err)
 	}

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -94,7 +94,7 @@ func newHandler() channels.Handler {
 }
 
 func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveEvent))
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
 	return nil
 }
 
@@ -196,8 +196,9 @@ type mediaUploadInfoPayload struct {
 	OwnerId int64 `json:"owner_id"`
 }
 
-// receiveEvent handles request event type
-func (h *handler) receiveEvent(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
+// receiveAny is our receive function for the single URL VK delivers both messages and its verification
+// handshake through
+func (h *handler) receiveAny(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	// check shared secret key before proceeding
 	secret := channel.StringConfigForKey(models.ConfigSecret, "")
 

--- a/handlers/wavy/handler.go
+++ b/handlers/wavy/handler.go
@@ -34,9 +34,9 @@ func init() {
 // Initialize registers the routes this handler serves
 func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
-	r.AddReceive(h, http.MethodPost, "sent", channels.ReceiveKindStatus, handlers.JSONPayload(h.sentStatusMessage))
+	r.AddReceive(h, http.MethodPost, "sent", channels.ReceiveKindStatus, handlers.JSONPayload(h.receiveSentStatus))
 	r.AddReceive(h, http.MethodPost, "delivered", channels.ReceiveKindStatus,
-		handlers.JSONPayload(h.deliveredStatusMessage))
+		handlers.JSONPayload(h.receiveDeliveredStatus))
 	return nil
 }
 
@@ -61,8 +61,9 @@ type sentStatusPayload struct {
 	SentStatusCode int    `json:"sentStatusCode"   validate:"required"`
 }
 
-// sentStatusMessage is our receive function for status updates
-func (h *handler) sentStatusMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *sentStatusPayload, in *channels.Received, clog *models.ChannelLog) error {
+// receiveSentStatus is our receive function for the sent callback, which Wavy delivers separately from the
+// delivered one below
+func (h *handler) receiveSentStatus(ctx context.Context, channel *models.Channel, r *http.Request, payload *sentStatusPayload, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[payload.SentStatusCode]
 	if !found {
 		return handlers.UnknownStatusError(statusMapping, payload.SentStatusCode)
@@ -78,8 +79,9 @@ type deliveredStatusPayload struct {
 	DeliveredStatusCode int    `json:"deliveredStatusCode"    validate:"required"`
 }
 
-// deliveredStatusMessage is our receive function for status updates
-func (h *handler) deliveredStatusMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *deliveredStatusPayload, in *channels.Received, clog *models.ChannelLog) error {
+// receiveDeliveredStatus is our receive function for the delivered callback, which carries a different payload
+// from the sent one above
+func (h *handler) receiveDeliveredStatus(ctx context.Context, channel *models.Channel, r *http.Request, payload *deliveredStatusPayload, in *channels.Received, clog *models.ChannelLog) error {
 	msgStatus, found := statusMapping[payload.DeliveredStatusCode]
 	if !found {
 		return handlers.UnknownStatusError(statusMapping, payload.DeliveredStatusCode)

--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -61,7 +61,7 @@ func (h *handler) Initialize(r *channels.Routes) error {
 
 	// this can't use AddReceive because the CORS headers have to wrap the seam rather than sit inside it, so
 	// the kind is named twice - once for what the route serves, once for what its log is called
-	receive := channels.Receive(h, channels.ReceiveKindMsg, handlers.JSONPayload(h.receive))
+	receive := channels.Receive(h, channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
 	r.Add(h, http.MethodPost, "receive", channels.ReceiveKindMsg.LogType(), withCORS(receive))
 
 	// the chat widget runs on arbitrary third-party websites, so both endpoints need CORS preflight support
@@ -224,8 +224,8 @@ type receivePayload struct {
 	Text string `json:"text" validate:"required,max=1000"`
 }
 
-// receive is our receive function for incoming messages
-func (h *handler) receive(ctx context.Context, channel *models.Channel, r *http.Request, payload *receivePayload, in *channels.Received, clog *models.ChannelLog) error {
+// receiveMessage is our receive function for incoming messages
+func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *receivePayload, in *channels.Received, clog *models.ChannelLog) error {
 	urn, err := urns.NewFromParts(urns.WebChat.Prefix, payload.ChatID, nil, "")
 	if err != nil {
 		return fmt.Errorf("invalid chat id: %s", payload.ChatID)


### PR DESCRIPTION
## Summary

Receive-function names had drifted: the same job had several names, and one name meant two different jobs. This makes the name follow the kind the route registers, and writes the rule down so it doesn't drift again.

Pure rename plus comments — no behavior change of any kind.

## The collision worth fixing

`receiveEvent` was used by six handlers for the route that serves *everything* — which is precisely the name a genuine channel-event route wants. Three more handlers called that identical job `receiveEvents`, leaving two distinct concepts one trailing `s` apart.

All nine are now `receiveAny`, matching `ReceiveKindAny` on their own registration line:

```go
r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
```

## Changes

| Handler | Was | Now | Why |
|---|---|---|---|
| mtn, vk, mblox, viber, slack, dialog360 | `receiveEvent` | `receiveAny` | route is `ReceiveKindAny` |
| meta, turn, facebook_legacy | `receiveEvents` | `receiveAny` | same job, different name |
| jiochat | `receiveMessage` | `receiveAny` | serves a msg route **and** two event routes |
| mtarget, kaleyra | `receiveMsg` | `receiveMessage` | 38 others already |
| infobip, bandwidth, justcall | `statusMessage` | `receiveStatus` | 19 others already |
| wavy | `sentStatusMessage`, `deliveredStatusMessage` | `receiveSentStatus`, `receiveDeliveredStatus` | two status routes need distinguishing |
| webchat | `receive` | `receiveMessage` | route is `ReceiveKindMsg` |

Doc comments the rename dragged along were rewritten where they had become wrong — several `receiveAny` functions still claimed to be "for incoming messages" while handling statuses and events, and wavy's two both read "for status updates", which distinguished nothing.

## The rule, now in `core/channels/doc.go`

- Name follows the kind the route registers: `receiveMessage`, `receiveStatus`, `receiveEvent`, `receiveAny`.
- Two routes of one kind say which in the name — `receiveSentStatus` beside `receiveDeliveredStatus`.
- **Narrowing with `As()` does not change the name.** mtarget, wechat and telegram each have a message endpoint where one particular message means a contact stopped. They're still message endpoints, and renaming them would lose that. jiochat was different — its function served routes of genuinely *different declared kinds*, so its name contradicted two of its three registrations.

## Final distribution

```
38  receiveMessage      2  receiveVerify (raw HandleFuncs, not ReceiveFuncs)
19  receiveStatus       1  receiveStopContact
10  receiveAny          1  receiveSentStatus / 1 receiveDeliveredStatus
```

`receiveHandler` / `statusHandler` / `sentHandler` and friends are untouched — they're local variables holding funcs from shared constructors like `NewTelReceiveHandler`, a different construct from a handler's own receive method.

## Test plan

- [x] Full suite green (`go test -p=1 ./...`)
- [x] Renames applied per-package with word boundaries; verified no handler defined both a source and target name before renaming
- [x] `gofmt` clean; no line lengthened past the limit (the long `ReceiveFunc` signatures were already over it and are marginally shorter now)