### PR TITLE
Replace handler SetRuntime/Initialize with runtime-aware constructors

### DIFF
--- a/core/channels/handler.go
+++ b/core/channels/handler.go
@@ -28,11 +28,6 @@ type HandleFunc func(context.Context, *models.Channel, http.ResponseWriter, *htt
 
 // Handler is the interface all channel handlers must satisfy
 type Handler interface {
-	// SetRuntime is called before Initialize to give the handler the runtime it should use. Handlers embedding
-	// handlers.BaseHandler get it from there rather than implementing it themselves.
-	SetRuntime(*runtime.Runtime)
-
-	Initialize(*Routes) error
 	Runtime() *runtime.Runtime
 	ChannelType() models.ChannelType
 	ChannelName() string
@@ -65,9 +60,25 @@ type AttachmentRequestBuilder interface {
 	BuildAttachmentRequest(context.Context, *models.Channel, string, *models.ChannelLog) (*http.Request, error)
 }
 
-// RegisterHandler adds a new handler for a channel type, this is called by individual handlers when they are initialized
-func RegisterHandler(handler Handler) {
-	registeredHandlers[handler.ChannelType()] = handler
+// HandlerCtor constructs a handler with the runtime it should use, registering the routes it serves as it goes.
+// Handlers register one from their package init(), and the server invokes them all at startup once the runtime
+// exists.
+type HandlerCtor func(*runtime.Runtime, *Routes) Handler
+
+// RegisterHandler adds a new handler constructor, called by individual handler packages from init()
+func RegisterHandler(ctor HandlerCtor) {
+	registeredCtors = append(registeredCtors, ctor)
+}
+
+// RegisteredCtors returns the handler constructors compiled into this build, for the server to invoke at startup
+func RegisteredCtors() []HandlerCtor {
+	return registeredCtors
+}
+
+// ActivateHandler marks a constructed handler as one this instance is serving, making it available to lookups
+// by channel type
+func ActivateHandler(handler Handler) {
+	activeHandlers[handler.ChannelType()] = handler
 
 	// handlers which can describe URNs are registered with the models package so contact creation can use them
 	if describer, ok := handler.(models.URNDescriber); ok {
@@ -75,32 +86,13 @@ func RegisterHandler(handler Handler) {
 	}
 }
 
-// GetHandler returns the handler for the passed in channel type, or nil if not found
+// GetHandler returns the handler this instance is serving for the given channel type, or nil if not found -
+// which is how sending fails fast for a channel this instance doesn't handle.
 func GetHandler(ct models.ChannelType) Handler {
-	return registeredHandlers[ct]
-}
-
-// RegisteredHandlers returns all the handlers compiled into this build, for the server to initialize
-func RegisteredHandlers() []Handler {
-	hs := make([]Handler, 0, len(registeredHandlers))
-	for _, h := range registeredHandlers {
-		hs = append(hs, h)
-	}
-	return hs
-}
-
-// ActivateHandler marks a handler as one this instance is serving, i.e. it was included by config and initialized
-func ActivateHandler(handler Handler) {
-	activeHandlers[handler.ChannelType()] = handler
-}
-
-// GetActiveHandler returns the handler this instance is serving for the given channel type, or nil if that channel
-// type isn't being served - which is how sending fails fast for a channel this instance doesn't handle.
-func GetActiveHandler(ct models.ChannelType) Handler {
 	return activeHandlers[ct]
 }
 
-var registeredHandlers = make(map[models.ChannelType]Handler)
+var registeredCtors []HandlerCtor
 var activeHandlers = make(map[models.ChannelType]Handler)
 
 // Route is an HTTP route a channel handler serves, added during its initialization

--- a/core/channels/handler.go
+++ b/core/channels/handler.go
@@ -60,19 +60,19 @@ type AttachmentRequestBuilder interface {
 	BuildAttachmentRequest(context.Context, *models.Channel, string, *models.ChannelLog) (*http.Request, error)
 }
 
-// HandlerCtor constructs a handler with the runtime it should use, registering the routes it serves as it goes.
+// NewHandlerFunc constructs a handler with the runtime it should use, registering the routes it serves as it goes.
 // Handlers register one from their package init(), and the server invokes them all at startup once the runtime
 // exists.
-type HandlerCtor func(*runtime.Runtime, *Routes) Handler
+type NewHandlerFunc func(*runtime.Runtime, *Routes) Handler
 
 // RegisterHandler adds a new handler constructor, called by individual handler packages from init()
-func RegisterHandler(ctor HandlerCtor) {
-	registeredCtors = append(registeredCtors, ctor)
+func RegisterHandler(newFn NewHandlerFunc) {
+	registeredHandlerFuncs = append(registeredHandlerFuncs, newFn)
 }
 
-// RegisteredCtors returns the handler constructors compiled into this build, for the server to invoke at startup
-func RegisteredCtors() []HandlerCtor {
-	return registeredCtors
+// RegisteredHandlerFuncs returns the handler constructors compiled into this build, for the server to invoke at startup
+func RegisteredHandlerFuncs() []NewHandlerFunc {
+	return registeredHandlerFuncs
 }
 
 // ActivateHandler marks a constructed handler as one this instance is serving, making it available to lookups
@@ -92,7 +92,7 @@ func GetHandler(ct models.ChannelType) Handler {
 	return activeHandlers[ct]
 }
 
-var registeredCtors []HandlerCtor
+var registeredHandlerFuncs []NewHandlerFunc
 var activeHandlers = make(map[models.ChannelType]Handler)
 
 // Route is an HTTP route a channel handler serves, added during its initialization

--- a/core/sender/sender.go
+++ b/core/sender/sender.go
@@ -193,7 +193,7 @@ func (w *Sender) sendMessage(msg *models.MsgOut) {
 	var status *models.StatusUpdate
 	var res *channels.SendResult
 	var redactValues []string
-	handler := channels.GetActiveHandler(msg.Channel().ChannelType())
+	handler := channels.GetHandler(msg.Channel().ChannelType())
 	if handler != nil {
 		redactValues = handler.RedactValues(msg.Channel())
 	}

--- a/handlers/africastalking/handler.go
+++ b/handlers/africastalking/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -21,15 +22,21 @@ const configIsShared = "is_shared"
 var defaultSendURL = "https://api.africastalking.com/version1/messaging"
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("AT"), "Africas Talking")}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("AT"), "Africas Talking")}
+
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "callback", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "delivery", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
+	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
+	return h
 }
 
 type moForm struct {
@@ -38,15 +45,6 @@ type moForm struct {
 	From string `name:"from" validate:"required"`
 	To   string `name:"to"   validate:"required"`
 	Date string `name:"date" validate:"required"`
-}
-
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
-	r.AddReceive(h, http.MethodPost, "callback", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
-	r.AddReceive(h, http.MethodPost, "delivery", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
-	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
-	return nil
 }
 
 // receiveMessage is our receive function for incoming messages

--- a/handlers/africastalking/handler_test.go
+++ b/handlers/africastalking/handler_test.go
@@ -106,7 +106,7 @@ func TestIncoming(t *testing.T) {
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "AT", "2020", "US", []string{urns.Phone.Prefix}, nil),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler(), incomingCases)
+	RunIncomingTestCases(t, chs, newHandler, incomingCases)
 }
 
 var outgoingCases = []OutgoingTestCase{
@@ -248,7 +248,7 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigSendURL:  "https://other.example.com/send",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), outgoingCases, []string{"KEY"}, nil)
-	RunOutgoingTestCases(t, sharedChannel, newHandler(), sharedOutgoingCases, []string{"KEY"}, nil)
-	RunOutgoingTestCases(t, customSendURLChannel, newHandler(), customSendURLCases, []string{"KEY"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, outgoingCases, []string{"KEY"}, nil)
+	RunOutgoingTestCases(t, sharedChannel, newHandler, sharedOutgoingCases, []string{"KEY"}, nil)
+	RunOutgoingTestCases(t, customSendURLChannel, newHandler, customSendURLCases, []string{"KEY"}, nil)
 }

--- a/handlers/arabiacell/handler.go
+++ b/handlers/arabiacell/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 )
 
 const (
@@ -23,22 +24,19 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("AC"), "Arabia Cell")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("AC"), "Arabia Cell")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	receiveHandler := handlers.NewTelReceiveHandler("M", "B")
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, receiveHandler)
-	return nil
+	return h
 }
 
 // <response>

--- a/handlers/arabiacell/handler_test.go
+++ b/handlers/arabiacell/handler_test.go
@@ -40,7 +40,7 @@ func TestIncoming(t *testing.T) {
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "AC", "2020", "US", []string{urns.Phone.Prefix}, nil),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler(), incomingCases)
+	RunIncomingTestCases(t, chs, newHandler, incomingCases)
 }
 
 var outgoingCases = []OutgoingTestCase{
@@ -125,5 +125,5 @@ func TestOutgoing(t *testing.T) {
 			configChargingLevel:   "0",
 		})
 
-	RunOutgoingTestCases(t, ch, newHandler(), outgoingCases, []string{"pass1"}, nil)
+	RunOutgoingTestCases(t, ch, newHandler, outgoingCases, []string{"pass1"}, nil)
 }

--- a/handlers/bandwidth/handler.go
+++ b/handlers/bandwidth/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/jsonx"
@@ -31,22 +32,19 @@ const (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("BW"), "Bandwidth")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("BW"), "Bandwidth")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
 	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, h.receiveStatus)
-	return nil
+	return h
 }
 
 type moMessageData struct {

--- a/handlers/bandwidth/handler_test.go
+++ b/handlers/bandwidth/handler_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
-	. "github.com/nyaruka/courier/v26/handlers"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/gocommon/httpx"
@@ -244,7 +243,7 @@ func TestIncoming(t *testing.T) {
 		),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler(), incomingCases)
+	RunIncomingTestCases(t, chs, newHandler, incomingCases)
 }
 
 var outgoingCases = []OutgoingTestCase{
@@ -383,7 +382,7 @@ func TestOutgoing(t *testing.T) {
 		map[string]any{models.ConfigUsername: "user1", models.ConfigPassword: "pass1", configAccountID: "accound-id", configMsgApplicationID: "application-id"},
 	)
 
-	RunOutgoingTestCases(t, ch, newHandler(), outgoingCases, []string{httpx.BasicAuth("user1", "pass1")}, nil)
+	RunOutgoingTestCases(t, ch, newHandler, outgoingCases, []string{httpx.BasicAuth("user1", "pass1")}, nil)
 }
 
 func TestBuildAttachmentRequest(t *testing.T) {
@@ -392,7 +391,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 		map[string]any{models.ConfigUsername: "user1", models.ConfigPassword: "pass1", configAccountID: "accound-id", configMsgApplicationID: "application-id"},
 	)
 
-	bwHandler := &handler{NewBaseHandler(models.ChannelType("BW"), "Bandwidth")}
+	bwHandler := newHandler(nil, channels.NewRoutes()).(*handler)
 	req, _ := bwHandler.BuildAttachmentRequest(context.Background(), ch, "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Basic dXNlcjE6cGFzczE=", req.Header.Get("Authorization"))

--- a/handlers/base.go
+++ b/handlers/base.go
@@ -28,8 +28,9 @@ type BaseHandler struct {
 }
 
 // NewBaseHandler returns a newly constructed BaseHandler with the passed in parameters
-func NewBaseHandler(channelType models.ChannelType, name string, options ...func(*BaseHandler)) BaseHandler {
+func NewBaseHandler(rt *runtime.Runtime, channelType models.ChannelType, name string, options ...func(*BaseHandler)) BaseHandler {
 	h := &BaseHandler{
+		rt:                 rt,
 		channelType:        channelType,
 		name:               name,
 		uuidChannelRouting: true,
@@ -60,11 +61,6 @@ func WithRedactConfigKeys(keys ...string) func(*BaseHandler) {
 	return func(s *BaseHandler) {
 		s.redactConfigKeys = keys
 	}
-}
-
-// SetRuntime gives the handler the runtime it should use, and is called before Initialize
-func (h *BaseHandler) SetRuntime(rt *runtime.Runtime) {
-	h.rt = rt
 }
 
 // Runtime returns the runtime instance on the BaseHandler

--- a/handlers/base_test.go
+++ b/handlers/base_test.go
@@ -44,8 +44,7 @@ func TestRequestHTTP(t *testing.T) {
 
 	server := web.NewServer(rt)
 
-	h := handlers.NewBaseHandler("NX", "Test")
-	h.SetRuntime(server.Runtime())
+	h := handlers.NewBaseHandler(server.Runtime(), "NX", "Test")
 
 	req, _ := http.NewRequest("POST", "https://api.messages.com/send.json", nil)
 	resp, respBody, err := h.RequestHTTP(req, clog)

--- a/handlers/burstsms/handler.go
+++ b/handlers/burstsms/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/httpx"
 )
 
@@ -26,25 +27,22 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("BS"), "Burst SMS")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("BS"), "Burst SMS")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	receiveHandler := handlers.NewTelReceiveHandler("mobile", "response")
 	r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, receiveHandler)
 
 	statusHandler := handlers.NewExternalIDStatusHandler(statusMap, "message_id", "status")
 	r.AddReceive(h, http.MethodGet, "status", channels.ReceiveKindStatus, statusHandler)
-	return nil
+	return h
 }
 
 //	{

--- a/handlers/burstsms/handler_test.go
+++ b/handlers/burstsms/handler_test.go
@@ -52,7 +52,7 @@ func TestIncoming(t *testing.T) {
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "BS", "2020", "US", []string{urns.Phone.Prefix}, nil),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler(), testCases)
+	RunIncomingTestCases(t, chs, newHandler, testCases)
 }
 
 var outgoingCases = []OutgoingTestCase{
@@ -165,5 +165,5 @@ func TestOutgoing(t *testing.T) {
 		map[string]any{models.ConfigUsername: "user1", models.ConfigPassword: "pass1"},
 	)
 
-	RunOutgoingTestCases(t, ch, newHandler(), outgoingCases, []string{httpx.BasicAuth("user1", "pass1")}, nil)
+	RunOutgoingTestCases(t, ch, newHandler, outgoingCases, []string{httpx.BasicAuth("user1", "pass1")}, nil)
 }

--- a/handlers/clickatell/handler.go
+++ b/handlers/clickatell/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -25,22 +26,19 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("CT"), "Clickatell")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("CT"), "Clickatell")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.JSONPayload(h.receiveStatus))
-	return nil
+	return h
 }
 
 type statusPayload struct {

--- a/handlers/clickatell/handler_test.go
+++ b/handlers/clickatell/handler_test.go
@@ -149,7 +149,7 @@ func TestIncoming(t *testing.T) {
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "CT", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{models.ConfigAPIKey: "12345"}),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler(), incomingCases)
+	RunIncomingTestCases(t, chs, newHandler, incomingCases)
 }
 
 var successSendResponse = `{"messages":[{"apiMessageId":"id1002","accepted":true,"to":"12067799299","error":null}],"error":null}`
@@ -247,5 +247,5 @@ func TestOutgoing(t *testing.T) {
 	maxMsgLength = 160
 	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "CT", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{models.ConfigAPIKey: "API-KEY"})
 
-	RunOutgoingTestCases(t, ch, newHandler(), outgoingCases, []string{"API-KEY"}, nil)
+	RunOutgoingTestCases(t, ch, newHandler, outgoingCases, []string{"API-KEY"}, nil)
 }

--- a/handlers/clickmobile/handler.go
+++ b/handlers/clickmobile/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
@@ -27,21 +28,19 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("CM"), "Click Mobile")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("CM"), "Click Mobile")}
 
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, handlers.XMLPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.XMLPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 //  <request>

--- a/handlers/clickmobile/handler_test.go
+++ b/handlers/clickmobile/handler_test.go
@@ -137,7 +137,7 @@ func TestIncoming(t *testing.T) {
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "CM", "2020", "MW", []string{urns.Phone.Prefix}, nil),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler(), incomingCases)
+	RunIncomingTestCases(t, chs, newHandler, incomingCases)
 }
 
 var outgoingCases = []OutgoingTestCase{
@@ -258,5 +258,5 @@ func TestOutgoing(t *testing.T) {
 	// mock time so we can have predictable MD5 hashes
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2018, 4, 11, 18, 24, 30, 123456000, time.UTC)))
 
-	RunOutgoingTestCases(t, ch, newHandler(), outgoingCases, []string{"Password"}, nil)
+	RunOutgoingTestCases(t, ch, newHandler, outgoingCases, []string{"Password"}, nil)
 }

--- a/handlers/clicksend/handler.go
+++ b/handlers/clicksend/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/jsonx"
 )
@@ -19,21 +20,18 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("CS"), "ClickSend")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("CS"), "ClickSend")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.NewTelReceiveHandler("from", "body"))
-	return nil
+	return h
 }
 
 //	{

--- a/handlers/clicksend/handler_test.go
+++ b/handlers/clicksend/handler_test.go
@@ -41,7 +41,7 @@ func TestIncoming(t *testing.T) {
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "CS", "2020", "US", []string{urns.Phone.Prefix}, nil),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler(), incomingCases)
+	RunIncomingTestCases(t, chs, newHandler, incomingCases)
 }
 
 const successResponse = `{
@@ -260,5 +260,5 @@ func TestOutgoing(t *testing.T) {
 		map[string]any{"username": "Aladdin", "password": "open sesame"},
 	)
 
-	RunOutgoingTestCases(t, ch, newHandler(), outgoingCases, []string{httpx.BasicAuth("Aladdin", "open sesame")}, nil)
+	RunOutgoingTestCases(t, ch, newHandler, outgoingCases, []string{httpx.BasicAuth("Aladdin", "open sesame")}, nil)
 }

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/stringsx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
@@ -36,24 +37,22 @@ type handler struct {
 	maxLength int
 }
 
-// NewHandler returns a new DartMedia ready to be registered
-func NewHandler(channelType string, name string, sendURL string, maxLength int) channels.Handler {
-	return &handler{
-		handlers.NewBaseHandler(models.ChannelType(channelType), name),
-		sendURL,
-		maxLength,
+// NewHandler returns a new DartMedia handler constructor ready to be registered
+func NewHandler(channelType string, name string, sendURL string, maxLength int) channels.HandlerCtor {
+	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+		h := &handler{
+			handlers.NewBaseHandler(rt, models.ChannelType(channelType), name),
+			sendURL,
+			maxLength,
+		}
+		r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
+		r.AddReceive(h, http.MethodGet, "delivered", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
+		return h
 	}
 }
 
 func init() {
 	channels.RegisterHandler(NewHandler("DA", "DartMedia", sendURL, maxMsgLength))
-}
-
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
-	r.AddReceive(h, http.MethodGet, "delivered", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
-	return nil
 }
 
 type moForm struct {

--- a/handlers/dart/handler.go
+++ b/handlers/dart/handler.go
@@ -38,7 +38,7 @@ type handler struct {
 }
 
 // NewHandler returns a new DartMedia handler constructor ready to be registered
-func NewHandler(channelType string, name string, sendURL string, maxLength int) channels.HandlerCtor {
+func NewHandler(channelType string, name string, sendURL string, maxLength int) channels.NewHandlerFunc {
 	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
 		h := &handler{
 			handlers.NewBaseHandler(rt, models.ChannelType(channelType), name),

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -38,7 +38,7 @@ type handler struct {
 	handlers.BaseHandler
 }
 
-func newWAHandler(channelType models.ChannelType, name string) channels.HandlerCtor {
+func newWAHandler(channelType models.ChannelType, name string) channels.NewHandlerFunc {
 	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
 		h := &handler{handlers.NewBaseHandler(rt, channelType, name)}
 		r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))

--- a/handlers/dialog360/handler.go
+++ b/handlers/dialog360/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/handlers/meta/whatsapp"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/core/events"
@@ -37,14 +38,12 @@ type handler struct {
 	handlers.BaseHandler
 }
 
-func newWAHandler(channelType models.ChannelType, name string) channels.Handler {
-	return &handler{handlers.NewBaseHandler(channelType, name)}
-}
-
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
-	return nil
+func newWAHandler(channelType models.ChannelType, name string) channels.HandlerCtor {
+	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+		h := &handler{handlers.NewBaseHandler(rt, channelType, name)}
+		r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
+		return h
+	}
 }
 
 //	{

--- a/handlers/dialog360/handler_test.go
+++ b/handlers/dialog360/handler_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
-	. "github.com/nyaruka/courier/v26/handlers"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
@@ -378,7 +377,7 @@ func TestIncoming(t *testing.T) {
 }
 
 func TestBuildAttachmentRequest(t *testing.T) {
-	d3CHandler := &handler{NewBaseHandler(models.ChannelType("D3C"), "360Dialog")}
+	d3CHandler := newWAHandler(models.ChannelType("D3C"), "360Dialog")(nil, channels.NewRoutes()).(*handler)
 	req, _ := d3CHandler.BuildAttachmentRequest(context.Background(), testChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "the-auth-token", req.Header.Get("D360-API-KEY"))
@@ -1054,8 +1053,7 @@ func TestSendEvent(t *testing.T) {
 
 	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
-	h := newWAHandler(models.ChannelType("D3C"), "360Dialog").(*handler)
-	s.MountHandler(h)
+	h := s.MountHandler(newWAHandler(models.ChannelType("D3C"), "360Dialog")).(*handler)
 
 	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://waba-v2.360dialog.io/messages": {

--- a/handlers/dmark/handler.go
+++ b/handlers/dmark/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -21,22 +22,19 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("DK"), "dmark")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("DK"), "dmark")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
-	return nil
+	return h
 }
 
 type moForm struct {

--- a/handlers/dmark/handler_test.go
+++ b/handlers/dmark/handler_test.go
@@ -86,7 +86,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -179,5 +179,5 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigAuthToken: "Authy",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"Authy"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Authy"}, nil)
 }

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/gsm7"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
@@ -54,19 +55,16 @@ var contentTypeMappings = map[string]string{
 }
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("EX"), "External")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("EX"), "External")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
 	r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, h.receiveMessage)
 
@@ -85,8 +83,7 @@ func (h *handler) Initialize(r *channels.Routes) error {
 	stopHandler := handlers.FormPayload(h.receiveStopContact)
 	r.AddReceive(h, http.MethodPost, "stopped", channels.ReceiveKindEvent, stopHandler)
 	r.AddReceive(h, http.MethodGet, "stopped", channels.ReceiveKindEvent, stopHandler)
-
-	return nil
+	return h
 }
 
 type stopContactForm struct {

--- a/handlers/external/handler_test.go
+++ b/handlers/external/handler_test.go
@@ -297,12 +297,12 @@ var extReceiveTestCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), handleTestCases)
-	RunIncomingTestCases(t, testSOAPReceiveChannels, newHandler(), handleSOAPReceiveTestCases)
-	RunIncomingTestCases(t, gmChannels, newHandler(), gmTestCases)
-	RunIncomingTestCases(t, customChannels, newHandler(), customTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
+	RunIncomingTestCases(t, testSOAPReceiveChannels, newHandler, handleSOAPReceiveTestCases)
+	RunIncomingTestCases(t, gmChannels, newHandler, gmTestCases)
+	RunIncomingTestCases(t, customChannels, newHandler, customTestCases)
 
-	RunIncomingTestCases(t, extChannels, newHandler(), extReceiveTestCases)
+	RunIncomingTestCases(t, extChannels, newHandler, extReceiveTestCases)
 }
 
 var longSendTestCases = []OutgoingTestCase{
@@ -970,16 +970,16 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigSendMethod:  http.MethodPut,
 		})
 
-	RunOutgoingTestCases(t, getChannel, newHandler(), getSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, getSmartChannel, newHandler(), getSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, getSmartChannel, newHandler(), getSendSmartEncodingTestCases, nil, nil)
-	RunOutgoingTestCases(t, postChannel, newHandler(), postSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, postChannelCustomContentType, newHandler(), postSendCustomContentTypeTestCases, nil, nil)
-	RunOutgoingTestCases(t, postSmartChannel, newHandler(), postSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, postSmartChannel, newHandler(), postSendSmartEncodingTestCases, nil, nil)
-	RunOutgoingTestCases(t, jsonChannel, newHandler(), jsonSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, xmlChannel, newHandler(), xmlSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, xmlChannelWithResponseContent, newHandler(), xmlSendWithResponseContentTestCases, nil, nil)
+	RunOutgoingTestCases(t, getChannel, newHandler, getSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, getSmartChannel, newHandler, getSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, getSmartChannel, newHandler, getSendSmartEncodingTestCases, nil, nil)
+	RunOutgoingTestCases(t, postChannel, newHandler, postSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, postChannelCustomContentType, newHandler, postSendCustomContentTypeTestCases, nil, nil)
+	RunOutgoingTestCases(t, postSmartChannel, newHandler, postSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, postSmartChannel, newHandler, postSendSmartEncodingTestCases, nil, nil)
+	RunOutgoingTestCases(t, jsonChannel, newHandler, jsonSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, xmlChannel, newHandler, xmlSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, xmlChannelWithResponseContent, newHandler, xmlSendWithResponseContentTestCases, nil, nil)
 
 	var getChannel30IntLength = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
 		[]string{urns.Phone.Prefix},
@@ -1017,10 +1017,10 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigSendHeaders: map[string]any{"Authorization": "Token ABCDEF", "foo": "bar"},
 		})
 
-	RunOutgoingTestCases(t, getChannel30IntLength, newHandler(), longSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, getChannel30StrLength, newHandler(), longSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, jsonChannel30IntLength, newHandler(), jsonLongSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, xmlChannel30IntLength, newHandler(), xmlLongSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, getChannel30IntLength, newHandler, longSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, getChannel30StrLength, newHandler, longSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, jsonChannel30IntLength, newHandler, jsonLongSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, xmlChannel30IntLength, newHandler, xmlLongSendTestCases, nil, nil)
 
 	var nationalChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
 		[]string{urns.Phone.Prefix},
@@ -1029,7 +1029,7 @@ func TestOutgoing(t *testing.T) {
 			"use_national":          true,
 			models.ConfigSendMethod: http.MethodGet})
 
-	RunOutgoingTestCases(t, nationalChannel, newHandler(), nationalGetSendTestCases, nil, nil)
+	RunOutgoingTestCases(t, nationalChannel, newHandler, nationalGetSendTestCases, nil, nil)
 
 	var jsonChannelWithSendAuthorization = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
 		[]string{urns.Phone.Prefix},
@@ -1040,5 +1040,5 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigSendMethod:        http.MethodPost,
 			models.ConfigSendAuthorization: "Token ABCDEF",
 		})
-	RunOutgoingTestCases(t, jsonChannelWithSendAuthorization, newHandler(), jsonSendTestCases, []string{"Token ABCDEF"}, nil)
+	RunOutgoingTestCases(t, jsonChannelWithSendAuthorization, newHandler, jsonSendTestCases, []string{"Token ABCDEF"}, nil)
 }

--- a/handlers/facebook_legacy/handler.go
+++ b/handlers/facebook_legacy/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
@@ -51,22 +52,19 @@ const (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("FB"), "Facebook")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("FB"), "Facebook")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
 	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
-	return nil
+	return h
 }
 
 // receiveVerify handles Facebook's webhook verification callback

--- a/handlers/facebook_legacy/handler_test.go
+++ b/handlers/facebook_legacy/handler_test.go
@@ -696,8 +696,7 @@ func TestDescribeURN(t *testing.T) {
 	defer fbGraph.Close()
 
 	channel := testChannels[0]
-	handler := newHandler()
-	web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(handler)
+	handler := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(newHandler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, channel, nil, handler.RedactValues(channel))
 
 	tcs := []struct {
@@ -717,7 +716,7 @@ func TestDescribeURN(t *testing.T) {
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 func TestVerify(t *testing.T) {
@@ -742,7 +741,7 @@ func TestVerify(t *testing.T) {
 	subscribeURL = server.URL
 	subscribeTimeout = time.Millisecond
 
-	RunIncomingTestCases(t, testChannels, newHandler(), []IncomingTestCase{
+	RunIncomingTestCases(t, testChannels, newHandler, []IncomingTestCase{
 		{
 			Label:              "Receive Message",
 			URL:                receiveURL,
@@ -987,5 +986,5 @@ func TestSending(t *testing.T) {
 	maxMsgLength = 100
 	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "FB", "2020", "US", []string{urns.Facebook.Prefix}, map[string]any{models.ConfigAuthToken: "access_token"})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"access_token"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"access_token"}, nil)
 }

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"golang.org/x/oauth2/google"
@@ -33,7 +34,7 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
@@ -42,17 +43,15 @@ type handler struct {
 	fetchTokenMutex sync.Mutex
 }
 
-func newHandler() channels.Handler {
-	return &handler{
-		BaseHandler:     handlers.NewBaseHandler(models.ChannelType("FCM"), "Firebase", handlers.WithRedactConfigKeys(configKey)),
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{
+		BaseHandler:     handlers.NewBaseHandler(rt, models.ChannelType("FCM"), "Firebase", handlers.WithRedactConfigKeys(configKey)),
 		fetchTokenMutex: sync.Mutex{},
 	}
-}
 
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
 	r.Add(h, http.MethodPost, "register", models.ChannelLogTypeReceive, h.registerContact)
-	return nil
+	return h
 }
 
 type receiveForm struct {

--- a/handlers/firebase/handler_test.go
+++ b/handlers/firebase/handler_test.go
@@ -116,7 +116,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var notificationSendTestCases = []OutgoingTestCase{
@@ -319,6 +319,6 @@ func setupBackend(t *testing.T, rt *runtime.Runtime) {
 
 func TestOutgoing(t *testing.T) {
 
-	RunOutgoingTestCases(t, testChannels[0], newHandler(), sendTestCases, []string{}, setupBackend)
-	RunOutgoingTestCases(t, testChannels[1], newHandler(), notificationSendTestCases, []string{}, setupBackend)
+	RunOutgoingTestCases(t, testChannels[0], newHandler, sendTestCases, []string{}, setupBackend)
+	RunOutgoingTestCases(t, testChannels[1], newHandler, notificationSendTestCases, []string{}, setupBackend)
 }

--- a/handlers/freshchat/handler.go
+++ b/handlers/freshchat/handler.go
@@ -40,7 +40,7 @@ type handler struct {
 	validateSignatures bool
 }
 
-func newHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.HandlerCtor {
+func newHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.NewHandlerFunc {
 	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
 		h := &handler{handlers.NewBaseHandler(rt, channelType, name), validateSignatures}
 		r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))

--- a/handlers/freshchat/handler.go
+++ b/handlers/freshchat/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -39,14 +40,12 @@ type handler struct {
 	validateSignatures bool
 }
 
-func newHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("FC"), "FreshChat"), validateSignatures}
-}
-
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
-	return nil
+func newHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.HandlerCtor {
+	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+		h := &handler{handlers.NewBaseHandler(rt, channelType, name), validateSignatures}
+		r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
+		return h
+	}
 }
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {
 	if err := h.validateSignature(channel, r); err != nil {

--- a/handlers/globe/handler.go
+++ b/handlers/globe/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -27,21 +28,18 @@ const (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("GL"), "Globe Labs", handlers.WithRedactConfigKeys(configPassphrase, configAppSecret))}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("GL"), "Globe Labs", handlers.WithRedactConfigKeys(configPassphrase, configAppSecret))}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 //	{

--- a/handlers/globe/handler_test.go
+++ b/handlers/globe/handler_test.go
@@ -160,7 +160,7 @@ var handleTestCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), handleTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
 }
 
 var sendTestCases = []OutgoingTestCase{
@@ -258,5 +258,5 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), sendTestCases, []string{"mysecret", "opensesame"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, sendTestCases, []string{"mysecret", "opensesame"}, nil)
 }

--- a/handlers/handlertest/handlertest.go
+++ b/handlers/handlertest/handlertest.go
@@ -169,7 +169,7 @@ func newServer(rt *runtime.Runtime) *web.Server {
 }
 
 // RunIncomingTestCases runs all the passed in tests cases for the passed in channel configurations
-func RunIncomingTestCases(t *testing.T, chs []*models.Channel, ctor channels.HandlerCtor, testCases []IncomingTestCase) {
+func RunIncomingTestCases(t *testing.T, chs []*models.Channel, newFn channels.NewHandlerFunc, testCases []IncomingTestCase) {
 	_, rt := testsuite.Runtime(t)
 
 	// state is reset once for the whole run rather than per case because handlers can carry state between
@@ -195,7 +195,7 @@ func RunIncomingTestCases(t *testing.T, chs []*models.Channel, ctor channels.Han
 		testsuite.InsertChannel(t, rt, ch)
 	}
 
-	s.MountHandler(ctor)
+	s.MountHandler(newFn)
 
 	// capture the events and channel logs of each handled request
 	var handledEvents []channels.Event
@@ -454,7 +454,7 @@ func (tc *OutgoingTestCase) Msg(ch *models.Channel) *models.MsgOut {
 }
 
 // RunOutgoingTestCases runs all the passed in test cases against the channel
-func RunOutgoingTestCases(t *testing.T, channel *models.Channel, ctor channels.HandlerCtor, testCases []OutgoingTestCase, checkRedacted []string, setup func(*testing.T, *runtime.Runtime)) {
+func RunOutgoingTestCases(t *testing.T, channel *models.Channel, newFn channels.NewHandlerFunc, testCases []OutgoingTestCase, checkRedacted []string, setup func(*testing.T, *runtime.Runtime)) {
 	ctx, rt := testsuite.Runtime(t)
 
 	testsuite.ResetDB(t, rt)
@@ -474,7 +474,7 @@ func RunOutgoingTestCases(t *testing.T, channel *models.Channel, ctor channels.H
 
 	s := newServer(rt)
 	testsuite.InsertChannel(t, rt, channel)
-	handler := s.MountHandler(ctor)
+	handler := s.MountHandler(newFn)
 
 	for _, tc := range testCases {
 		t.Run(tc.Label, func(t *testing.T) {

--- a/handlers/handlertest/handlertest.go
+++ b/handlers/handlertest/handlertest.go
@@ -169,7 +169,7 @@ func newServer(rt *runtime.Runtime) *web.Server {
 }
 
 // RunIncomingTestCases runs all the passed in tests cases for the passed in channel configurations
-func RunIncomingTestCases(t *testing.T, chs []*models.Channel, handler channels.Handler, testCases []IncomingTestCase) {
+func RunIncomingTestCases(t *testing.T, chs []*models.Channel, ctor channels.HandlerCtor, testCases []IncomingTestCase) {
 	_, rt := testsuite.Runtime(t)
 
 	// state is reset once for the whole run rather than per case because handlers can carry state between
@@ -195,10 +195,7 @@ func RunIncomingTestCases(t *testing.T, chs []*models.Channel, handler channels.
 		testsuite.InsertChannel(t, rt, ch)
 	}
 
-	// re-register the handler under test so that lookups by channel type - e.g. the URN describer used when
-	// creating a contact - resolve to this instance rather than the uninitialized one from its init()
-	channels.RegisterHandler(handler)
-	require.NoError(t, s.MountHandler(handler))
+	s.MountHandler(ctor)
 
 	// capture the events and channel logs of each handled request
 	var handledEvents []channels.Event
@@ -457,7 +454,7 @@ func (tc *OutgoingTestCase) Msg(ch *models.Channel) *models.MsgOut {
 }
 
 // RunOutgoingTestCases runs all the passed in test cases against the channel
-func RunOutgoingTestCases(t *testing.T, channel *models.Channel, handler channels.Handler, testCases []OutgoingTestCase, checkRedacted []string, setup func(*testing.T, *runtime.Runtime)) {
+func RunOutgoingTestCases(t *testing.T, channel *models.Channel, ctor channels.HandlerCtor, testCases []OutgoingTestCase, checkRedacted []string, setup func(*testing.T, *runtime.Runtime)) {
 	ctx, rt := testsuite.Runtime(t)
 
 	testsuite.ResetDB(t, rt)
@@ -477,7 +474,7 @@ func RunOutgoingTestCases(t *testing.T, channel *models.Channel, handler channel
 
 	s := newServer(rt)
 	testsuite.InsertChannel(t, rt, channel)
-	require.NoError(t, s.MountHandler(handler))
+	handler := s.MountHandler(ctor)
 
 	for _, tc := range testCases {
 		t.Run(tc.Label, func(t *testing.T) {

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -21,22 +22,19 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("HX"), "High Connection")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("HX"), "High Connection")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodGet, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
-	return nil
+	return h
 }
 
 type moForm struct {

--- a/handlers/highconnection/handler_test.go
+++ b/handlers/highconnection/handler_test.go
@@ -82,7 +82,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -255,5 +255,5 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigUsername: "Username",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"Password"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Password"}, nil)
 }

--- a/handlers/hormuud/handler.go
+++ b/handlers/hormuud/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -26,21 +27,18 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("HM"), "Hormuud")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("HM"), "Hormuud")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 type moPayload struct {

--- a/handlers/hormuud/handler_test.go
+++ b/handlers/hormuud/handler_test.go
@@ -68,7 +68,7 @@ var handleTestCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), handleTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
 }
 
 var sendTestCases = []OutgoingTestCase{
@@ -253,7 +253,7 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	h := newHandler()
+	h := newHandler
 	RunOutgoingTestCases(t, defaultChannel, h, sendTestCases, []string{"sesame"}, nil)
 
 	// ensure the token cached by the previous cases is cleared so these cases fetch a new one

--- a/handlers/i2sms/handler.go
+++ b/handlers/i2sms/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/httpx"
 )
 
@@ -23,22 +24,19 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("I2"), "I2SMS", handlers.WithRedactConfigKeys(models.ConfigPassword, configChannelHash))}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("I2"), "I2SMS", handlers.WithRedactConfigKeys(models.ConfigPassword, configChannelHash))}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg,
 		handlers.NewTelReceiveHandler("mobile", "message"))
-	return nil
+	return h
 }
 
 //	{

--- a/handlers/i2sms/handler_test.go
+++ b/handlers/i2sms/handler_test.go
@@ -40,7 +40,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -160,5 +160,5 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigPassword: "pass1",
 			configChannelHash:     "hash123",
 		})
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{httpx.BasicAuth("user1", "pass1"), "hash123"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{httpx.BasicAuth("user1", "pass1"), "hash123"}, nil)
 }

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -20,22 +21,19 @@ import (
 const configTransliteration = "transliteration"
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("IB"), "Infobip")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("IB"), "Infobip")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "delivered", channels.ReceiveKindStatus, handlers.JSONPayload(h.receiveStatus))
-	return nil
+	return h
 }
 
 var statusMapping = map[string]models.MsgStatus{

--- a/handlers/infobip/handler_test.go
+++ b/handlers/infobip/handler_test.go
@@ -332,7 +332,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -505,7 +505,7 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigUsername: "Username",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{httpx.BasicAuth("Username", "Password")}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{httpx.BasicAuth("Username", "Password")}, nil)
 
 	var transChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "IB", "2020", "US",
 		[]string{urns.Phone.Prefix},
@@ -515,7 +515,7 @@ func TestOutgoing(t *testing.T) {
 			configTransliteration: "COLOMBIAN",
 		})
 
-	RunOutgoingTestCases(t, transChannel, newHandler(), transSendTestCases, []string{httpx.BasicAuth("Username", "Password")}, nil)
+	RunOutgoingTestCases(t, transChannel, newHandler, transSendTestCases, []string{httpx.BasicAuth("Username", "Password")}, nil)
 
 	var apiKeyChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "IB", "2020", "US",
 		[]string{urns.Phone.Prefix},
@@ -523,5 +523,5 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigAPIKey: "test-api-key",
 		})
 
-	RunOutgoingTestCases(t, apiKeyChannel, newHandler(), apiKeySendTestCases, []string{"App test-api-key"}, nil)
+	RunOutgoingTestCases(t, apiKeyChannel, newHandler, apiKeySendTestCases, []string{"App test-api-key"}, nil)
 }

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/gsm7"
 	"github.com/nyaruka/gocommon/urns"
 	"golang.org/x/text/encoding/unicode"
@@ -21,22 +22,19 @@ import (
 var idRegex = regexp.MustCompile(`Success \"(.*)\"`)
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("JS"), "Jasmin")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("JS"), "Jasmin")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
-	return nil
+	return h
 }
 
 type statusForm struct {

--- a/handlers/jasmin/handler_test.go
+++ b/handlers/jasmin/handler_test.go
@@ -96,7 +96,7 @@ var handleTestCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), handleTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -265,5 +265,5 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigSendURL: "http://example.com/send",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"Password"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Password"}, nil)
 }

--- a/handlers/jiochat/handler.go
+++ b/handlers/jiochat/handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
@@ -36,7 +37,7 @@ const (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
@@ -45,20 +46,17 @@ type handler struct {
 	fetchTokenMutex sync.Mutex
 }
 
-func newHandler() channels.Handler {
-	return &handler{
-		BaseHandler:     handlers.NewBaseHandler(models.ChannelType("JC"), "Jiochat"),
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{
+		BaseHandler:     handlers.NewBaseHandler(rt, models.ChannelType("JC"), "Jiochat"),
 		fetchTokenMutex: sync.Mutex{},
 	}
-}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
 	r.AddReceive(h, http.MethodPost, "rcv/msg/message", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveAny))
 	r.AddReceive(h, http.MethodPost, "rcv/event/menu", channels.ReceiveKindEvent, handlers.JSONPayload(h.receiveAny))
 	r.AddReceive(h, http.MethodPost, "rcv/event/follow", channels.ReceiveKindEvent, handlers.JSONPayload(h.receiveAny))
-	return nil
+	return h
 }
 
 type verifyForm struct {

--- a/handlers/jiochat/handler_test.go
+++ b/handlers/jiochat/handler_test.go
@@ -234,7 +234,7 @@ func TestIncoming(t *testing.T) {
 	JCAPI := buildMockJCAPI()
 	defer JCAPI.Close()
 
-	RunIncomingTestCases(t, testChannels, newHandler(), incomingCases())
+	RunIncomingTestCases(t, testChannels, newHandler, incomingCases())
 }
 
 // mocks the call to the Jiochat API
@@ -292,8 +292,7 @@ func TestDescribeURN(t *testing.T) {
 	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 
 	s := web.NewServer(rt)
-	handler := newHandler().(*handler)
-	s.MountHandler(handler)
+	handler := s.MountHandler(newHandler).(*handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 
 	tcs := []struct {
@@ -330,8 +329,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"access_token": "SESAME"}`)),
 		},
 	})
-	handler := newHandler().(*handler)
-	s.MountHandler(handler)
+	handler := s.MountHandler(newHandler).(*handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 
 	// check that request has the fetched access token
@@ -456,5 +454,5 @@ func TestOutgoing(t *testing.T) {
 	maxMsgLength = 160
 	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "JC", "2020", "US", []string{urns.JioChat.Prefix}, map[string]any{configAppSecret: "secret123", configAppID: "app-id"})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"secret123"}, setupBackend)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"secret123"}, setupBackend)
 }

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -27,19 +28,16 @@ type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("JCL"), "JustCall")}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("JCL"), "JustCall")}
+
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
+	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.JSONPayload(h.receiveStatus))
+	return h
 }
 
 func init() {
-	channels.RegisterHandler(newHandler())
-}
-
-// Initialize implements channels.Handler
-func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
-	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.JSONPayload(h.receiveStatus))
-	return nil
+	channels.RegisterHandler(newHandler)
 }
 
 //	{

--- a/handlers/justcall/handler_test.go
+++ b/handlers/justcall/handler_test.go
@@ -263,7 +263,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -406,5 +406,5 @@ var defaultSendTestCases = []OutgoingTestCase{
 func TestOutgoing(t *testing.T) {
 	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "JCL", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{models.ConfigAPIKey: "api_key", models.ConfigSecret: "api_secret"})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"api_key", "api_secret"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"api_key", "api_secret"}, nil)
 }

--- a/handlers/kaleyra/handler.go
+++ b/handlers/kaleyra/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -30,22 +31,19 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("KWA"), "Kaleyra WhatsApp")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("KWA"), "Kaleyra WhatsApp")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodGet, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
-	return nil
+	return h
 }
 
 type moMsgForm struct {

--- a/handlers/kaleyra/handler_test.go
+++ b/handlers/kaleyra/handler_test.go
@@ -97,7 +97,7 @@ func TestIncoming(t *testing.T) {
 		),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler(), incomingCases)
+	RunIncomingTestCases(t, chs, newHandler, incomingCases)
 }
 
 var sendTestCases = []OutgoingTestCase{
@@ -219,5 +219,5 @@ func TestOutgoing(t *testing.T) {
 		map[string]any{configAccountSID: "SID", configApiKey: "123456"},
 	)
 
-	RunOutgoingTestCases(t, ch, newHandler(), sendTestCases, []string{"123456"}, nil)
+	RunOutgoingTestCases(t, ch, newHandler, sendTestCases, []string{"123456"}, nil)
 }

--- a/handlers/kannel/handler.go
+++ b/handlers/kannel/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/gsm7"
 	"github.com/nyaruka/gocommon/urns"
 	"golang.org/x/text/encoding/unicode"
@@ -31,22 +32,19 @@ const (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("KN"), "Kannel")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("KN"), "Kannel")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodGet, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
-	return nil
+	return h
 }
 
 type moForm struct {

--- a/handlers/kannel/handler_test.go
+++ b/handlers/kannel/handler_test.go
@@ -131,8 +131,8 @@ var ignoreTestCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), handleTestCases)
-	RunIncomingTestCases(t, ignoreChannels, newHandler(), ignoreTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
+	RunIncomingTestCases(t, ignoreChannels, newHandler, ignoreTestCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -404,7 +404,7 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigSendURL: "http://example.com/send",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"Password"}, nil)
-	RunOutgoingTestCases(t, customParamsChannel, newHandler(), customParamsTestCases, []string{"Password"}, nil)
-	RunOutgoingTestCases(t, nationalChannel, newHandler(), nationalSendTestCases, []string{"Password"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Password"}, nil)
+	RunOutgoingTestCases(t, customParamsChannel, newHandler, customParamsTestCases, []string{"Password"}, nil)
+	RunOutgoingTestCases(t, nationalChannel, newHandler, nationalSendTestCases, []string{"Password"}, nil)
 }

--- a/handlers/line/handler.go
+++ b/handlers/line/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/core/events"
@@ -44,21 +45,18 @@ var mediaSupport = map[handlers.MediaType]handlers.MediaTypeSupport{
 }
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("LN"), "Line")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("LN"), "Line")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 //	{

--- a/handlers/line/handler_test.go
+++ b/handlers/line/handler_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
-	. "github.com/nyaruka/courier/v26/handlers"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
@@ -400,7 +399,7 @@ func addInvalidSignature(r *http.Request) {
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), handleTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -707,11 +706,11 @@ func TestOutgoing(t *testing.T) {
 	maxMsgLength = 160
 	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "LN", "2020", "US", []string{urns.Line.Prefix}, map[string]any{"auth_token": "AccessToken"})
 
-	RunOutgoingTestCases(t, ch, newHandler(), defaultSendTestCases, []string{"AccessToken"}, setupMedia)
+	RunOutgoingTestCases(t, ch, newHandler, defaultSendTestCases, []string{"AccessToken"}, setupMedia)
 }
 
 func TestBuildAttachmentRequest(t *testing.T) {
-	lnHandler := &handler{NewBaseHandler(models.ChannelType("LN"), "Line")}
+	lnHandler := newHandler(nil, channels.NewRoutes()).(*handler)
 	req, _ := lnHandler.BuildAttachmentRequest(context.Background(), testChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer the-auth-token", req.Header.Get("Authorization"))
@@ -721,8 +720,7 @@ func TestSendEvent(t *testing.T) {
 	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "LN", "2020", "US", []string{urns.Line.Prefix}, map[string]any{"auth_token": "AccessToken"})
 
 	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
-	h := newHandler().(*handler)
-	s.MountHandler(h)
+	h := s.MountHandler(newHandler).(*handler)
 
 	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://api.line.me/v2/bot/chat/loading/start": {

--- a/handlers/m3tech/handler.go
+++ b/handlers/m3tech/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/gsm7"
 )
 
@@ -19,21 +20,18 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("M3"), "M3Tech")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("M3"), "M3Tech")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.NewTelReceiveHandler("from", "text"))
-	return nil
+	return h
 }
 
 // RespondMsgs writes a success response for the messages

--- a/handlers/m3tech/handler_test.go
+++ b/handlers/m3tech/handler_test.go
@@ -43,7 +43,7 @@ var handleTestCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), handleTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -181,5 +181,5 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"Password"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Password"}, nil)
 }

--- a/handlers/macrokiosk/handler.go
+++ b/handlers/macrokiosk/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/gsm7"
 	"github.com/nyaruka/gocommon/urns"
 
@@ -29,24 +30,21 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("MK"), "Macrokiosk")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("MK"), "Macrokiosk")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
 	r.AddReceive(h, http.MethodGet, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
 	r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 type statusForm struct {

--- a/handlers/macrokiosk/handler_test.go
+++ b/handlers/macrokiosk/handler_test.go
@@ -72,7 +72,7 @@ var incomingTestCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), incomingTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, incomingTestCases)
 }
 
 var outgoingTestCases = []OutgoingTestCase{
@@ -201,5 +201,5 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), outgoingTestCases, []string{"Password"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, outgoingTestCases, []string{"Password"}, nil)
 }

--- a/handlers/mblox/handler.go
+++ b/handlers/mblox/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -23,21 +24,18 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("MB"), "Mblox")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("MB"), "Mblox")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
-	return nil
+	return h
 }
 
 type eventPayload struct {

--- a/handlers/mblox/handler_test.go
+++ b/handlers/mblox/handler_test.go
@@ -129,7 +129,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -261,5 +261,5 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"Password"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Password"}, nil)
 }

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -86,7 +86,7 @@ type handler struct {
 	validateSignatures bool
 }
 
-func newHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.HandlerCtor {
+func newHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.NewHandlerFunc {
 	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
 		h := &handler{handlers.NewBaseHandler(rt, channelType, name), validateSignatures}
 		r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)

--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
@@ -85,16 +86,13 @@ type handler struct {
 	validateSignatures bool
 }
 
-func newHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("MBD"), "Messagebird"), validateSignatures}
-}
-
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
-	r.AddReceive(h, http.MethodGet, "status", channels.ReceiveKindStatus, h.receiveStatus)
-
-	return nil
+func newHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.HandlerCtor {
+	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+		h := &handler{handlers.NewBaseHandler(rt, channelType, name), validateSignatures}
+		r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
+		r.AddReceive(h, http.MethodGet, "status", channels.ReceiveKindStatus, h.receiveStatus)
+		return h
+	}
 }
 
 // this one decodes for itself rather than using FormPayload, because it answers a decode failure as ignored

--- a/handlers/messangi/handler.go
+++ b/handlers/messangi/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 )
 
@@ -28,22 +29,19 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("MG"), "Messangi")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("MG"), "Messangi")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	receiveHandler := handlers.NewTelReceiveHandler("mobile", "mo")
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, receiveHandler)
-	return nil
+	return h
 }
 
 // <response>

--- a/handlers/messangi/handler_test.go
+++ b/handlers/messangi/handler_test.go
@@ -37,7 +37,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -141,5 +141,5 @@ func TestOutgoing(t *testing.T) {
 			"instance_id": 7,
 			"carrier_id":  2,
 		})
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"my-private-key"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"my-private-key"}, nil)
 }

--- a/handlers/meta/facebook_test.go
+++ b/handlers/meta/facebook_test.go
@@ -281,8 +281,7 @@ func TestFacebookDescribeURN(t *testing.T) {
 	defer fbGraph.Close()
 
 	channel := facebookTestChannels[0]
-	handler := newHandler("FBA", "Facebook")
-	web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(handler)
+	handler := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(newHandler("FBA", "Facebook"))
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, channel, nil, handler.RedactValues(channel))
 
 	tcs := []struct {
@@ -608,8 +607,7 @@ func TestFacebookSendEvent(t *testing.T) {
 
 	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
-	h := newHandler("FBA", "Facebook").(*handler)
-	s.MountHandler(h)
+	h := s.MountHandler(newHandler("FBA", "Facebook")).(*handler)
 
 	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://graph.facebook.com/v25.0/me/messages*": {
@@ -623,7 +621,7 @@ func TestFacebookSendEvent(t *testing.T) {
 	// typing events are supported on both Facebook and Instagram channels, including explicit stop
 	expected := map[string]time.Duration{events.TypeTypingStarted: 15 * time.Second, events.TypeTypingStopped: 0}
 	assert.Equal(t, expected, h.SendableEvents(channel))
-	assert.Equal(t, expected, newHandler("IG", "Instagram").(*handler).SendableEvents(channel))
+	assert.Equal(t, expected, newHandler("IG", "Instagram")(nil, channels.NewRoutes()).(*handler).SendableEvents(channel))
 
 	channelRef := assets.NewChannelReference("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "Facebook")
 
@@ -684,8 +682,7 @@ func TestSigning(t *testing.T) {
 func TestFacebookBuildAttachmentRequest(t *testing.T) {
 	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
-	handler := &handler{NewBaseHandler(models.ChannelType("FBA"), "Facebook", DisableUUIDRouting())}
-	s.MountHandler(handler)
+	handler := s.MountHandler(newHandler("FBA", "Facebook")).(*handler)
 	req, _ := handler.BuildAttachmentRequest(context.Background(), facebookTestChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, http.Header{}, req.Header)

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/handlers/meta/messenger"
 	"github.com/nyaruka/courier/v26/handlers/meta/whatsapp"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
@@ -60,8 +61,13 @@ const (
 	payloadKey    = "payload"
 )
 
-func newHandler(channelType models.ChannelType, name string) channels.Handler {
-	return &handler{handlers.NewBaseHandler(channelType, name, handlers.DisableUUIDRouting(), handlers.WithRedactConfigKeys(models.ConfigAuthToken))}
+func newHandler(channelType models.ChannelType, name string) channels.HandlerCtor {
+	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+		h := &handler{handlers.NewBaseHandler(rt, channelType, name, handlers.DisableUUIDRouting(), handlers.WithRedactConfigKeys(models.ConfigAuthToken))}
+		r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
+		r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
+		return h
+	}
 }
 
 func init() {
@@ -73,13 +79,6 @@ func init() {
 
 type handler struct {
 	handlers.BaseHandler
-}
-
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
-	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
-	return nil
 }
 
 // https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components#notification-payload-object

--- a/handlers/meta/handlers.go
+++ b/handlers/meta/handlers.go
@@ -61,7 +61,7 @@ const (
 	payloadKey    = "payload"
 )
 
-func newHandler(channelType models.ChannelType, name string) channels.HandlerCtor {
+func newHandler(channelType models.ChannelType, name string) channels.NewHandlerFunc {
 	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
 		h := &handler{handlers.NewBaseHandler(rt, channelType, name, handlers.DisableUUIDRouting(), handlers.WithRedactConfigKeys(models.ConfigAuthToken))}
 		r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeWebhookVerify, h.receiveVerify)

--- a/handlers/meta/instagram_test.go
+++ b/handlers/meta/instagram_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
-	. "github.com/nyaruka/courier/v26/handlers"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
@@ -460,8 +459,7 @@ func TestInstagramDescribeURN(t *testing.T) {
 	defer fbGraph.Close()
 
 	channel := instgramTestChannels[0]
-	handler := newHandler("IG", "Instagram")
-	web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(handler)
+	handler := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(newHandler("IG", "Instagram"))
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, channel, nil, handler.RedactValues(channel))
 
 	tcs := []struct {
@@ -483,8 +481,7 @@ func TestInstagramDescribeURN(t *testing.T) {
 func TestInstagramBuildAttachmentRequest(t *testing.T) {
 	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
-	handler := &handler{NewBaseHandler(models.ChannelType("IG"), "Instagram", DisableUUIDRouting())}
-	s.MountHandler(handler)
+	handler := s.MountHandler(newHandler("IG", "Instagram")).(*handler)
 	req, _ := handler.BuildAttachmentRequest(context.Background(), facebookTestChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, http.Header{}, req.Header)

--- a/handlers/meta/whataspp_test.go
+++ b/handlers/meta/whataspp_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
-	. "github.com/nyaruka/courier/v26/handlers"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
@@ -1350,8 +1349,7 @@ func TestWhatsAppOutgoing(t *testing.T) {
 
 func TestWhatsAppDescribeURN(t *testing.T) {
 	channel := whatsappTestChannels[0]
-	handler := newHandler("WAC", "Cloud API WhatsApp")
-	newServerWithWAC().MountHandler(handler)
+	handler := newServerWithWAC().MountHandler(newHandler("WAC", "Cloud API WhatsApp"))
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, channel, nil, handler.RedactValues(channel))
 
 	tcs := []struct {
@@ -1372,8 +1370,7 @@ func TestWhatsAppDescribeURN(t *testing.T) {
 
 func TestWhatsAppBuildAttachmentRequest(t *testing.T) {
 	s := newServerWithWAC()
-	handler := &handler{NewBaseHandler(models.ChannelType("WAC"), "WhatsApp Cloud", DisableUUIDRouting())}
-	s.MountHandler(handler)
+	handler := s.MountHandler(newHandler("WAC", "WhatsApp Cloud")).(*handler)
 	req, _ := handler.BuildAttachmentRequest(context.Background(), whatsappTestChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer wac_admin_system_user_token", req.Header.Get("Authorization"))
@@ -1396,8 +1393,7 @@ func TestWhatsAppSendEvent(t *testing.T) {
 	cfg.WhatsappAdminSystemUserToken = "wac_admin_system_user_token"
 	s := web.NewServer(runtime.NewTestRuntime(cfg))
 
-	h := newHandler("WAC", "WhatsApp Cloud").(*handler)
-	s.MountHandler(h)
+	h := s.MountHandler(newHandler("WAC", "WhatsApp Cloud")).(*handler)
 
 	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://graph.facebook.com/12345_ID/messages": {

--- a/handlers/mtarget/handler.go
+++ b/handlers/mtarget/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -23,15 +24,21 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("MT"), "Mtarget")}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("MT"), "Mtarget")}
+
+	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
+
+	statusHandler := handlers.NewExternalIDStatusHandler(statusMapping, "MsgId", "Status")
+	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, statusHandler)
+	return h
 }
 
 var statusMapping = map[string]models.MsgStatus{
@@ -41,15 +48,6 @@ var statusMapping = map[string]models.MsgStatus{
 	"3": models.MsgStatusDelivered,
 	"4": models.MsgStatusFailed,
 	"6": models.MsgStatusFailed,
-}
-
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
-
-	statusHandler := handlers.NewExternalIDStatusHandler(statusMapping, "MsgId", "Status")
-	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, statusHandler)
-	return nil
 }
 
 // receiveMessage handles both MO messages and Stop commands

--- a/handlers/mtarget/handler_test.go
+++ b/handlers/mtarget/handler_test.go
@@ -117,7 +117,7 @@ func TestIncoming(t *testing.T) {
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MT", "2020", "FR", []string{urns.Phone.Prefix}, nil),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler(), incomingCases)
+	RunIncomingTestCases(t, chs, newHandler, incomingCases)
 }
 
 var outgoingCases = []OutgoingTestCase{
@@ -208,5 +208,5 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), outgoingCases, []string{"Password"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, outgoingCases, []string{"Password"}, nil)
 }

--- a/handlers/mtn/handler.go
+++ b/handlers/mtn/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -27,7 +28,7 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
@@ -36,17 +37,14 @@ type handler struct {
 	fetchTokenMutex sync.Mutex
 }
 
-func newHandler() channels.Handler {
-	return &handler{
-		BaseHandler:     handlers.NewBaseHandler(models.ChannelType("MTN"), "MTN Developer Portal"),
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{
+		BaseHandler:     handlers.NewBaseHandler(rt, models.ChannelType("MTN"), "MTN Developer Portal"),
 		fetchTokenMutex: sync.Mutex{},
 	}
-}
 
-// Initialize implements channels.Handler
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
-	return nil
+	return h
 }
 
 var statusMapping = map[string]models.MsgStatus{

--- a/handlers/mtn/handler_test.go
+++ b/handlers/mtn/handler_test.go
@@ -164,7 +164,7 @@ func TestIncoming(t *testing.T) {
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MTN", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{models.ConfigAuthToken: "customer-secret123", models.ConfigAPIKey: "customer-key"}),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler(), incomingCases)
+	RunIncomingTestCases(t, chs, newHandler, incomingCases)
 }
 
 var outgoingCases = []OutgoingTestCase{
@@ -288,8 +288,8 @@ func setupBackend(t *testing.T, rt *runtime.Runtime) {
 
 func TestOutgoing(t *testing.T) {
 	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MTN", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{models.ConfigAuthToken: "customer-secret123", models.ConfigAPIKey: "customer-key"})
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), outgoingCases, []string{"customer-key", "customer-secret123"}, setupBackend)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, outgoingCases, []string{"customer-key", "customer-secret123"}, setupBackend)
 
 	var cpAddressChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MTN", "2020", "US", []string{urns.Phone.Prefix}, map[string]any{models.ConfigAuthToken: "customer-secret123", models.ConfigAPIKey: "customer-key", configCPAddress: "FOO"})
-	RunOutgoingTestCases(t, cpAddressChannel, newHandler(), cpAddressOutgoingCases, []string{"customer-key", "customer-secret123"}, setupBackend)
+	RunOutgoingTestCases(t, cpAddressChannel, newHandler, cpAddressOutgoingCases, []string{"customer-key", "customer-secret123"}, setupBackend)
 }

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/gsm7"
 	"github.com/nyaruka/gocommon/urns"
 
@@ -81,24 +82,21 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("NX"), "Nexmo", handlers.WithRedactConfigKeys(configNexmoAPISecret, configNexmoAppPrivateKey))}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("NX"), "Nexmo", handlers.WithRedactConfigKeys(configNexmoAPISecret, configNexmoAppPrivateKey))}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, h.receiveMessage)
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
 	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, h.receiveStatus)
 	r.AddReceive(h, http.MethodGet, "status", channels.ReceiveKindStatus, h.receiveStatus)
-	return nil
+	return h
 }
 
 // https://developer.vonage.com/messaging/sms/guides/delivery-receipts

--- a/handlers/nexmo/handler_test.go
+++ b/handlers/nexmo/handler_test.go
@@ -115,7 +115,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -268,5 +268,5 @@ func TestOutgoing(t *testing.T) {
 			configNexmoAppPrivateKey: "nexmo-app-private-key",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"nexmo-api-secret", "nexmo-app-private-key"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"nexmo-api-secret", "nexmo-app-private-key"}, nil)
 }

--- a/handlers/novo/handler.go
+++ b/handlers/novo/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -28,21 +29,18 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("NV"), "Novo")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("NV"), "Novo")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
-	return nil
+	return h
 }
 
 // receiveMessage is our receive function for incoming messages

--- a/handlers/novo/handler_test.go
+++ b/handlers/novo/handler_test.go
@@ -55,7 +55,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -158,5 +158,5 @@ func TestOutgoing(t *testing.T) {
 			"merchant_secret": "my-merchant-secret",
 			"secret":          "sesame",
 		})
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"my-merchant-secret", "sesame"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"my-merchant-secret", "sesame"}, nil)
 }

--- a/handlers/playmobile/handler.go
+++ b/handlers/playmobile/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
@@ -30,21 +31,18 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("PM"), "Play Mobile")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("PM"), "Play Mobile")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.XMLPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 // {

--- a/handlers/playmobile/handler_test.go
+++ b/handlers/playmobile/handler_test.go
@@ -125,7 +125,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -206,5 +206,5 @@ func TestOutgoing(t *testing.T) {
 			"base_url":  "http://example.com",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{httpx.BasicAuth("Username", "Password")}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{httpx.BasicAuth("Username", "Password")}, nil)
 }

--- a/handlers/plivo/handler.go
+++ b/handlers/plivo/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -37,22 +38,19 @@ const (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("PL"), "Plivo")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("PL"), "Plivo")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 type statusForm struct {

--- a/handlers/plivo/handler_test.go
+++ b/handlers/plivo/handler_test.go
@@ -62,7 +62,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -189,5 +189,5 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{httpx.BasicAuth("AuthID", "AuthToken")}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{httpx.BasicAuth("AuthID", "AuthToken")}, nil)
 }

--- a/handlers/rocketchat/handler.go
+++ b/handlers/rocketchat/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -24,21 +25,18 @@ const (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("RC"), "RocketChat")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("RC"), "RocketChat")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 type RCAttachment struct {

--- a/handlers/rocketchat/handler_test.go
+++ b/handlers/rocketchat/handler_test.go
@@ -100,7 +100,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var sendTestCases = []OutgoingTestCase{
@@ -206,5 +206,5 @@ var sendTestCases = []OutgoingTestCase{
 }
 
 func TestOutgoing(t *testing.T) {
-	RunOutgoingTestCases(t, testChannels[0], newHandler(), sendTestCases, []string{"123456789"}, nil)
+	RunOutgoingTestCases(t, testChannels[0], newHandler, sendTestCases, []string{"123456789"}, nil)
 }

--- a/handlers/slack/handler.go
+++ b/handlers/slack/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/svclogs"
 	"github.com/nyaruka/gocommon/urns"
@@ -35,20 +36,18 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("SL"), "Slack", handlers.WithRedactConfigKeys(configBotToken, configUserToken, configValidationToken))}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("SL"), "Slack", handlers.WithRedactConfigKeys(configBotToken, configUserToken, configValidationToken))}
 
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
-	return nil
+	return h
 }
 
 func (h *handler) receiveAny(ctx context.Context, channel *models.Channel, r *http.Request, payload *moPayload, in *channels.Received, clog *models.ChannelLog) error {

--- a/handlers/slack/handler_test.go
+++ b/handlers/slack/handler_test.go
@@ -330,19 +330,19 @@ func TestIncoming(t *testing.T) {
 	slackServiceMock := buildMockSlackService(handleTestCases)
 	defer slackServiceMock.Close()
 
-	RunIncomingTestCases(t, testChannels, newHandler(), handleTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
 }
 
 func TestOutgoing(t *testing.T) {
-	RunOutgoingTestCases(t, testChannels[0], newHandler(), defaultSendTestCases, []string{"xoxb-abc123", "one-long-verification-token"}, nil)
+	RunOutgoingTestCases(t, testChannels[0], newHandler, defaultSendTestCases, []string{"xoxb-abc123", "one-long-verification-token"}, nil)
 }
 
 func TestSendFiles(t *testing.T) {
-	RunOutgoingTestCases(t, testChannels[0], newHandler(), fileSendTestCases, []string{"xoxb-abc123", "one-long-verification-token"}, nil)
+	RunOutgoingTestCases(t, testChannels[0], newHandler, fileSendTestCases, []string{"xoxb-abc123", "one-long-verification-token"}, nil)
 }
 
 func TestVerification(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), []IncomingTestCase{
+	RunIncomingTestCases(t, testChannels, newHandler, []IncomingTestCase{
 		{Label: "Valid token", URL: receiveURL, ExpectedRespStatus: 200, ExpectedBodyContains: "challenge123",
 			Data:    `{"token":"one-long-verification-token","challenge":"challenge123","type":"url_verification"}`,
 			Headers: map[string]string{"content-type": "text/plain"},
@@ -415,8 +415,7 @@ func TestDescribeURN(t *testing.T) {
 	server := buildMockSlackService([]IncomingTestCase{})
 	defer server.Close()
 
-	handler := newHandler()
-	web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(handler)
+	handler := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(newHandler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 	urn, _ := urns.New(urns.Slack, "U012345")
 

--- a/handlers/smscentral/handler.go
+++ b/handlers/smscentral/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -20,21 +21,18 @@ mobile=9779811781111&message=Msg
 var sendURL = "http://smail.smscentral.com.np/bp/ApiSms.php"
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("SC"), "SMS Central")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("SC"), "SMS Central")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 type moForm struct {

--- a/handlers/smscentral/handler_test.go
+++ b/handlers/smscentral/handler_test.go
@@ -65,7 +65,7 @@ var handleTestCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), handleTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -148,5 +148,5 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigUsername: "Username",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"Password"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Password"}, nil)
 }

--- a/handlers/start/handler.go
+++ b/handlers/start/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -27,21 +28,18 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("ST"), "Start Mobile")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("ST"), "Start Mobile")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.XMLPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 type moPayload struct {

--- a/handlers/start/handler_test.go
+++ b/handlers/start/handler_test.go
@@ -153,7 +153,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -298,5 +298,5 @@ var defaultSendTestCases = []OutgoingTestCase{
 func TestOutgoing(t *testing.T) {
 	maxMsgLength = 160
 	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ST", "2020", "UA", []string{urns.Phone.Prefix}, map[string]any{"username": "Username", "password": "Password"})
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{httpx.BasicAuth("Username", "Password")}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{httpx.BasicAuth("Username", "Password")}, nil)
 }

--- a/handlers/telegram/handler.go
+++ b/handlers/telegram/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/svclogs"
@@ -35,21 +36,18 @@ var mediaSupport = map[handlers.MediaType]handlers.MediaTypeSupport{
 }
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("TG"), "Telegram")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("TG"), "Telegram")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 // receiveMessage is our receive function for incoming messages

--- a/handlers/telegram/handler_test.go
+++ b/handlers/telegram/handler_test.go
@@ -863,7 +863,7 @@ func TestIncoming(t *testing.T) {
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c568c", "TG", "2020", "US", []string{urns.Telegram.Prefix}, map[string]any{"auth_token": "a123"}),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler(), testCases)
+	RunIncomingTestCases(t, chs, newHandler, testCases)
 }
 
 var outgoingCases = []OutgoingTestCase{
@@ -1242,7 +1242,7 @@ func TestOutgoing(t *testing.T) {
 		map[string]any{models.ConfigAuthToken: "auth_token"},
 	)
 
-	RunOutgoingTestCases(t, ch, newHandler(), outgoingCases, []string{"auth_token"}, nil)
+	RunOutgoingTestCases(t, ch, newHandler, outgoingCases, []string{"auth_token"}, nil)
 }
 
 func TestSendEvent(t *testing.T) {
@@ -1252,8 +1252,7 @@ func TestSendEvent(t *testing.T) {
 
 	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
-	h := newHandler().(*handler)
-	s.MountHandler(h)
+	h := s.MountHandler(newHandler).(*handler)
 
 	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://api.telegram.org/botauth_token/sendChatAction": {

--- a/handlers/telesom/handler.go
+++ b/handlers/telesom/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/svclogs"
 	"github.com/nyaruka/gocommon/urns"
@@ -23,21 +24,19 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("TS"), "Telesom")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("TS"), "Telesom")}
 
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 type moForm struct {

--- a/handlers/telesom/handler_test.go
+++ b/handlers/telesom/handler_test.go
@@ -79,7 +79,7 @@ var handleTestCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), handleTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
 }
 
 var defaultSendTestCases = []OutgoingTestCase{
@@ -203,5 +203,5 @@ func TestOutgoing(t *testing.T) {
 	// mock time so we can have predictable MD5 hashes
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2018, 4, 11, 18, 24, 30, 123456000, time.UTC)))
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"Password", "secret"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Password", "secret"}, nil)
 }

--- a/handlers/thinq/handler.go
+++ b/handlers/thinq/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -26,22 +27,19 @@ var sendURL = "https://api.thinq.com/account/%s/product/origination/sms/send"
 var sendMMSURL = "https://api.thinq.com/account/%s/product/origination/mms/send"
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("TQ"), "ThinQ")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("TQ"), "ThinQ")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.FormPayload(h.receiveStatus))
-	return nil
+	return h
 }
 
 // see https://apidocs.thinq.com/#829c8863-8a47-4273-80fb-d962aa64c901

--- a/handlers/thinq/handler_test.go
+++ b/handlers/thinq/handler_test.go
@@ -90,7 +90,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var sendTestCases = []OutgoingTestCase{
@@ -227,5 +227,5 @@ func TestOutgoing(t *testing.T) {
 			configAPITokenUser: "user1",
 			configAPIToken:     "sesame",
 		})
-	RunOutgoingTestCases(t, channel, newHandler(), sendTestCases, []string{httpx.BasicAuth("user1", "sesame")}, nil)
+	RunOutgoingTestCases(t, channel, newHandler, sendTestCases, []string{httpx.BasicAuth("user1", "sesame")}, nil)
 }

--- a/handlers/turn/handler.go
+++ b/handlers/turn/handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/handlers/meta/whatsapp"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/cache"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/i18n"
@@ -38,7 +39,7 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 
 	failedMediaCache = cache.NewLocal[string, bool](nil, 15*time.Minute)
 	failedMediaCache.Start()
@@ -48,15 +49,11 @@ type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("TRN"), "Turn.io WhatsApp")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("TRN"), "Turn.io WhatsApp")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
-
-	return nil
+	return h
 }
 
 //	{

--- a/handlers/turn/handler_test.go
+++ b/handlers/turn/handler_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
-	. "github.com/nyaruka/courier/v26/handlers"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/gocommon/httpx"
@@ -816,11 +815,11 @@ var testCasesTurn = []IncomingTestCase{
 
 func TestIncoming(t *testing.T) {
 
-	RunIncomingTestCases(t, testChannels, newHandler(), testCasesTurn)
+	RunIncomingTestCases(t, testChannels, newHandler, testCasesTurn)
 }
 
 func TestBuildAttachmentRequest(t *testing.T) {
-	waHandler := &handler{NewBaseHandler(models.ChannelType("TRN"), "WhatsApp")}
+	waHandler := newHandler(nil, channels.NewRoutes()).(*handler)
 	req, _ := waHandler.BuildAttachmentRequest(context.Background(), testChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Bearer a123", req.Header.Get("Authorization"))
@@ -1860,9 +1859,9 @@ func TestWhatsAppOutgoing(t *testing.T) {
 	var channel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "TRN", "12345_ID", "", []string{urns.WhatsApp.Prefix},
 		map[string]any{models.ConfigAuthToken: "a123", "base_url": "https://example.org", "fb_namespace": "waba_namespace"})
 
-	RunOutgoingTestCases(t, channel, newHandler(), defaultSendTestCases, []string{"a123"}, nil)
+	RunOutgoingTestCases(t, channel, newHandler, defaultSendTestCases, []string{"a123"}, nil)
 	failedMediaCache.Clear()
-	RunOutgoingTestCases(t, channel, newHandler(), mediaCacheSendTestCases, []string{"a123"}, nil)
+	RunOutgoingTestCases(t, channel, newHandler, mediaCacheSendTestCases, []string{"a123"}, nil)
 	failedMediaCache.Clear()
 }
 

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/i18n"
@@ -74,8 +75,13 @@ type handler struct {
 	validateSignatures bool
 }
 
-func newTWIMLHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.Handler {
-	return &handler{handlers.NewBaseHandler(channelType, name), validateSignatures}
+func newTWIMLHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.HandlerCtor {
+	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+		h := &handler{handlers.NewBaseHandler(rt, channelType, name), validateSignatures}
+		r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
+		r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, h.receiveStatus)
+		return h
+	}
 }
 
 func init() {
@@ -84,13 +90,6 @@ func init() {
 	channels.RegisterHandler(newTWIMLHandler("TMS", "Twilio Messaging Service", true))
 	channels.RegisterHandler(newTWIMLHandler("TWA", "Twilio Whatsapp", true))
 	channels.RegisterHandler(newTWIMLHandler("SW", "SignalWire", false))
-}
-
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)
-	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, h.receiveStatus)
-	return nil
 }
 
 type moForm struct {

--- a/handlers/twiml/handlers.go
+++ b/handlers/twiml/handlers.go
@@ -75,7 +75,7 @@ type handler struct {
 	validateSignatures bool
 }
 
-func newTWIMLHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.HandlerCtor {
+func newTWIMLHandler(channelType models.ChannelType, name string, validateSignatures bool) channels.NewHandlerFunc {
 	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
 		h := &handler{handlers.NewBaseHandler(rt, channelType, name), validateSignatures}
 		r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, h.receiveMessage)

--- a/handlers/twiml/handlers_test.go
+++ b/handlers/twiml/handlers_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
-	. "github.com/nyaruka/courier/v26/handlers"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
@@ -1514,7 +1513,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 			configAccountSID:       "accountSID",
 			models.ConfigAuthToken: "authToken"})
 
-	twHandler := &handler{NewBaseHandler(models.ChannelType("T"), "Twilio"), true}
+	twHandler := newTWIMLHandler("T", "Twilio", true)(nil, channels.NewRoutes()).(*handler)
 	req, _ := twHandler.BuildAttachmentRequest(context.Background(), defaultChannel, "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "Basic YWNjb3VudFNJRDphdXRoVG9rZW4=", req.Header.Get("Authorization"))
@@ -1526,7 +1525,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 			models.ConfigAuthToken: "authToken",
 			configSendURL:          "BASE_URL",
 		})
-	swHandler := &handler{NewBaseHandler(models.ChannelType("SW"), "SignalWire"), false}
+	swHandler := newTWIMLHandler("SW", "SignalWire", false)(nil, channels.NewRoutes()).(*handler)
 	req, _ = swHandler.BuildAttachmentRequest(context.Background(), swChannel, "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, "", req.Header.Get("Authorization"))
@@ -1543,8 +1542,7 @@ func TestSendEvent(t *testing.T) {
 
 	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
 
-	h := newTWIMLHandler("TWA", "Twilio Whatsapp", true).(*handler)
-	s.MountHandler(h)
+	h := s.MountHandler(newTWIMLHandler("TWA", "Twilio Whatsapp", true)).(*handler)
 
 	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://messaging.twilio.com/v3/Indicators/Typing.json": {
@@ -1556,7 +1554,7 @@ func TestSendEvent(t *testing.T) {
 
 	// typing indicators are supported on Twilio WhatsApp channels but no other TWIML channel types
 	assert.Equal(t, map[string]time.Duration{events.TypeTypingStarted: 20 * time.Second}, h.SendableEvents(channel))
-	assert.Nil(t, newTWIMLHandler("T", "Twilio", true).(*handler).SendableEvents(channel))
+	assert.Nil(t, newTWIMLHandler("T", "Twilio", true)(nil, channels.NewRoutes()).(*handler).SendableEvents(channel))
 
 	channelRef := assets.NewChannelReference("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "Twilio Whatsapp")
 	typing := events.NewTypingStarted(events.DirectionOutgoing, channelRef, "whatsapp:12065551212", "SMabcdef1234567890abcdef1234567890")

--- a/handlers/viber/handler.go
+++ b/handlers/viber/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -61,21 +62,18 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("VP"), "Viber")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("VP"), "Viber")}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
-	return nil
+	return h
 }
 
 type eventPayload struct {

--- a/handlers/viber/handler_test.go
+++ b/handlers/viber/handler_test.go
@@ -414,9 +414,9 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigAuthToken: "Token",
 			"button_layout":        map[string]any{"bg_color": "#f7bb3f", "text": "<font color=\"#ffffff\">*</font><br><br>", "text_size": "large"},
 		})
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"Token"}, nil)
-	RunOutgoingTestCases(t, invalidTokenChannel, newHandler(), invalidTokenSendTestCases, []string{"Token"}, nil)
-	RunOutgoingTestCases(t, buttonLayoutChannel, newHandler(), buttonLayoutSendTestCases, []string{"Token"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Token"}, nil)
+	RunOutgoingTestCases(t, invalidTokenChannel, newHandler, invalidTokenSendTestCases, []string{"Token"}, nil)
+	RunOutgoingTestCases(t, buttonLayoutChannel, newHandler, buttonLayoutSendTestCases, []string{"Token"}, nil)
 }
 
 var testChannels = []*models.Channel{
@@ -809,6 +809,6 @@ func addInvalidSignature(r *http.Request) {
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
-	RunIncomingTestCases(t, testChannelsWithWelcomeMessage, newHandler(), testWelcomeMessageCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
+	RunIncomingTestCases(t, testChannelsWithWelcomeMessage, newHandler, testWelcomeMessageCases)
 }

--- a/handlers/vk/handler.go
+++ b/handlers/vk/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
@@ -82,20 +83,18 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("VK"), "VK")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("VK"), "VK")}
 
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindAny, handlers.JSONPayload(h.receiveAny))
-	return nil
+	return h
 }
 
 // base body to callback API event

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -365,7 +365,7 @@ func TestIncoming(t *testing.T) {
 	server := buildMockVKService()
 	defer server.Close()
 
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 func buildMockVKService() *httptest.Server {
@@ -391,8 +391,7 @@ func TestDescribeURN(t *testing.T) {
 	server := buildMockVKService()
 	defer server.Close()
 
-	handler := newHandler()
-	web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(handler)
+	handler := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(newHandler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 	urn, _ := urns.New(urns.VK, "123456789")
 	data := map[string]string{"name": "John Doe"}
@@ -651,15 +650,14 @@ var outgoingCases = []OutgoingTestCase{
 }
 
 func TestOutgoing(t *testing.T) {
-	RunOutgoingTestCases(t, testChannels[0], newHandler(), outgoingCases, []string{"token123xyz", "abc123xyz"}, nil)
+	RunOutgoingTestCases(t, testChannels[0], newHandler, outgoingCases, []string{"token123xyz", "abc123xyz"}, nil)
 }
 
 func TestSendEvent(t *testing.T) {
 	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "VK", "2020", "US", []string{urns.VK.Prefix}, map[string]any{models.ConfigAuthToken: "token123xyz"})
 
 	s := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig()))
-	h := newHandler().(*handler)
-	s.MountHandler(h)
+	h := s.MountHandler(newHandler).(*handler)
 
 	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://api.vk.com/method/messages.setActivity.json*": {

--- a/handlers/wavy/handler.go
+++ b/handlers/wavy/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -23,21 +24,18 @@ type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("WV"), "Wavy")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("WV"), "Wavy")}
 
-func init() {
-	channels.RegisterHandler(newHandler())
-}
-
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
 	r.AddReceive(h, http.MethodPost, "sent", channels.ReceiveKindStatus, handlers.JSONPayload(h.receiveSentStatus))
 	r.AddReceive(h, http.MethodPost, "delivered", channels.ReceiveKindStatus,
 		handlers.JSONPayload(h.receiveDeliveredStatus))
-	return nil
+	return h
+}
+
+func init() {
+	channels.RegisterHandler(newHandler)
 }
 
 var statusMapping = map[int]models.MsgStatus{

--- a/handlers/wavy/handler_test.go
+++ b/handlers/wavy/handler_test.go
@@ -163,7 +163,7 @@ var testCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), testCases)
+	RunIncomingTestCases(t, testChannels, newHandler, testCases)
 }
 
 var outgoingCases = []OutgoingTestCase{
@@ -231,5 +231,5 @@ func TestOutgoing(t *testing.T) {
 			models.ConfigUsername:  "user1",
 			models.ConfigAuthToken: "token",
 		})
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), outgoingCases, []string{"token"}, nil)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, outgoingCases, []string{"token"}, nil)
 }

--- a/handlers/webchat/handler.go
+++ b/handlers/webchat/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/centrifugo"
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/jsonx"
@@ -41,22 +42,19 @@ const (
 var chatIDChars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
 	// webchat has no external provider - sends are publishes to our own realtime server and start/receive are
 	// our own public endpoints - so its channel logs would only describe internal infrastructure and aren't
 	// stored for users
-	return &handler{handlers.NewBaseHandler(models.ChannelType("WCH"), "WebChat", handlers.DisableChannelLogStorage())}
-}
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("WCH"), "WebChat", handlers.DisableChannelLogStorage())}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodPost, "start", models.ChannelLogTypeChatStart, withCORS(h.start))
 
 	// this can't use AddReceive because the CORS headers have to wrap the seam rather than sit inside it, so
@@ -67,7 +65,7 @@ func (h *handler) Initialize(r *channels.Routes) error {
 	// the chat widget runs on arbitrary third-party websites, so both endpoints need CORS preflight support
 	r.Add(h, http.MethodOptions, "start", models.ChannelLogTypeUnknown, h.preflight)
 	r.Add(h, http.MethodOptions, "receive", models.ChannelLogTypeUnknown, h.preflight)
-	return nil
+	return h
 }
 
 // GetChannel returns the channel - except for CORS preflight requests, which don't need it and shouldn't

--- a/handlers/webchat/handler_test.go
+++ b/handlers/webchat/handler_test.go
@@ -98,7 +98,7 @@ func TestIncoming(t *testing.T) {
 	random.SetSecureSource(random.NewSeededSource(1234))
 	defer random.SetSecureSource(random.DefaultSecureSource)
 
-	RunIncomingTestCases(t, testChannels, newHandler(), incomingCases)
+	RunIncomingTestCases(t, testChannels, newHandler, incomingCases)
 }
 
 // webchat traffic is internal to the platform so its channel logs are never stored - each visitor request
@@ -114,7 +114,7 @@ func TestChannelLogsNotStored(t *testing.T) {
 
 	s := web.NewServer(rt)
 	testsuite.InsertChannel(t, rt, testChannels[0])
-	require.NoError(t, s.MountHandler(newHandler()))
+	s.MountHandler(newHandler)
 
 	// capture the in-memory logs of handled requests
 	var clogs []*models.ChannelLog
@@ -152,7 +152,7 @@ func TestStartRateLimit(t *testing.T) {
 	s := web.NewServer(rt)
 	testsuite.InsertChannel(t, rt, testChannels[0])
 	testsuite.InsertChannel(t, rt, test.NewMockChannel(otherChannelUUID, "WCH", "", "", []string{urns.WebChat.Prefix}, nil))
-	require.NoError(t, s.MountHandler(newHandler()))
+	s.MountHandler(newHandler)
 
 	startOn := func(chURL, ip string) *httptest.ResponseRecorder {
 		req, _ := http.NewRequest(http.MethodPost, "https://localhost"+chURL, strings.NewReader(`{}`))
@@ -202,7 +202,7 @@ func TestCORS(t *testing.T) {
 
 	s := web.NewServer(rt)
 	testsuite.InsertChannel(t, rt, testChannels[0])
-	require.NoError(t, s.MountHandler(newHandler()))
+	s.MountHandler(newHandler)
 
 	// preflights on both endpoints are answered without needing the channel
 	for _, path := range []string{startURL, receiveURL} {
@@ -244,7 +244,7 @@ func TestAllowedDomains(t *testing.T) {
 	testsuite.InsertChannel(t, rt, test.NewMockChannel(cfgChannelUUID, "WCH", "", "", []string{urns.WebChat.Prefix},
 		map[string]any{"allowed_domains": []string{"example.com", "localhost:3000"}},
 	))
-	require.NoError(t, s.MountHandler(newHandler()))
+	s.MountHandler(newHandler)
 
 	request := func(path, origin string) *httptest.ResponseRecorder {
 		req, _ := http.NewRequest(http.MethodPost, "https://localhost"+path, strings.NewReader(`{}`))
@@ -322,8 +322,7 @@ func TestOutgoing(t *testing.T) {
 	ch := testChannels[0]
 	testsuite.InsertChannel(t, rt, ch)
 
-	h := newHandler()
-	h.SetRuntime(rt)
+	h := newHandler(rt, channels.NewRoutes())
 
 	msg := &models.MsgOut{
 		OrgID_:       ch.OrgID(),

--- a/handlers/wechat/handler.go
+++ b/handlers/wechat/handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/core/events"
@@ -36,7 +37,7 @@ const (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
@@ -45,18 +46,15 @@ type handler struct {
 	fetchTokenMutex sync.Mutex
 }
 
-func newHandler() channels.Handler {
-	return &handler{
-		BaseHandler:     handlers.NewBaseHandler(models.ChannelType("WC"), "WeChat"),
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{
+		BaseHandler:     handlers.NewBaseHandler(rt, models.ChannelType("WC"), "WeChat"),
 		fetchTokenMutex: sync.Mutex{},
 	}
-}
 
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.Add(h, http.MethodGet, "", models.ChannelLogTypeWebhookVerify, h.VerifyURL)
 	r.AddReceive(h, http.MethodPost, "", channels.ReceiveKindMsg, handlers.XMLPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 type verifyForm struct {

--- a/handlers/wechat/handler_test.go
+++ b/handlers/wechat/handler_test.go
@@ -187,7 +187,7 @@ func TestIncoming(t *testing.T) {
 	WCAPI := buildMockWCAPI()
 	defer WCAPI.Close()
 
-	RunIncomingTestCases(t, testChannels, newHandler(), incomingCases())
+	RunIncomingTestCases(t, testChannels, newHandler, incomingCases())
 }
 
 // mocks the call to the WeChat API
@@ -245,8 +245,7 @@ func TestDescribeURN(t *testing.T) {
 	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 
 	s := web.NewServer(rt)
-	handler := newHandler().(*handler)
-	s.MountHandler(handler)
+	handler := s.MountHandler(newHandler).(*handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 
 	tcs := []struct {
@@ -283,8 +282,7 @@ func TestBuildAttachmentRequest(t *testing.T) {
 			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"access_token": "SESAME"}`)),
 		},
 	})
-	handler := newHandler().(*handler)
-	s.MountHandler(handler)
+	handler := s.MountHandler(newHandler).(*handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 
 	// check that request has the fetched access token
@@ -321,8 +319,7 @@ func TestFetchAccessTokenThrottled(t *testing.T) {
 			httpx.NewMockResponse(429, nil, []byte(`{"errcode": 45009, "errmsg": "reach max api daily quota limit"}`)),
 		},
 	})
-	handler := newHandler().(*handler)
-	s.MountHandler(handler)
+	handler := s.MountHandler(newHandler).(*handler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 
 	// a rate limited token fetch is throttling rather than an empty token
@@ -437,7 +434,7 @@ func setupBackend(t *testing.T, rt *runtime.Runtime) {
 func TestOutgoing(t *testing.T) {
 	maxMsgLength = 160
 	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WC", "2020", "US", []string{urns.WeChat.Prefix}, map[string]any{configAppSecret: "secret123", configAppID: "app-id"})
-	RunOutgoingTestCases(t, defaultChannel, newHandler(), defaultSendTestCases, []string{"secret123"}, setupBackend)
+	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"secret123"}, setupBackend)
 }
 
 func TestSendEvent(t *testing.T) {
@@ -459,8 +456,7 @@ func TestSendEvent(t *testing.T) {
 	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 
 	s := web.NewServer(rt)
-	h := newHandler().(*handler)
-	s.MountHandler(h)
+	h := s.MountHandler(newHandler).(*handler)
 
 	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
 		"https://api.weixin.qq.com/cgi-bin/message/custom/typing*": {

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -28,20 +29,18 @@ var (
 )
 
 func init() {
-	channels.RegisterHandler(newHandler())
+	channels.RegisterHandler(newHandler)
 }
 
 type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler() channels.Handler {
-	return &handler{handlers.NewBaseHandler(models.ChannelType("YO"), "YO!")}
-}
+func newHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &handler{handlers.NewBaseHandler(rt, models.ChannelType("YO"), "YO!")}
 
-func (h *handler) Initialize(r *channels.Routes) error {
 	r.AddReceive(h, http.MethodGet, "receive", channels.ReceiveKindMsg, handlers.FormPayload(h.receiveMessage))
-	return nil
+	return h
 }
 
 type moForm struct {

--- a/handlers/yo/handler_test.go
+++ b/handlers/yo/handler_test.go
@@ -44,7 +44,7 @@ var handleTestCases = []IncomingTestCase{
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler(), handleTestCases)
+	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
 }
 
 var getSendTestCases = []OutgoingTestCase{
@@ -170,5 +170,5 @@ var getSendTestCases = []OutgoingTestCase{
 func TestOutgoing(t *testing.T) {
 	var getChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "YO", "2020", "UG", []string{urns.Phone.Prefix}, map[string]any{"username": "yo-username", "password": "yo-password"})
 
-	RunOutgoingTestCases(t, getChannel, newHandler(), getSendTestCases, []string{"yo-password"}, nil)
+	RunOutgoingTestCases(t, getChannel, newHandler, getSendTestCases, []string{"yo-password"}, nil)
 }

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -33,7 +33,7 @@ type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler(channelType models.ChannelType, name string) channels.HandlerCtor {
+func newHandler(channelType models.ChannelType, name string) channels.NewHandlerFunc {
 	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
 		h := &handler{handlers.NewBaseHandler(rt, channelType, name)}
 		r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))

--- a/handlers/zenvia/handlers.go
+++ b/handlers/zenvia/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
+	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -32,15 +33,13 @@ type handler struct {
 	handlers.BaseHandler
 }
 
-func newHandler(channelType models.ChannelType, name string) channels.Handler {
-	return &handler{handlers.NewBaseHandler(channelType, name)}
-}
-
-// Initialize registers the routes this handler serves
-func (h *handler) Initialize(r *channels.Routes) error {
-	r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
-	r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.JSONPayload(h.receiveStatus))
-	return nil
+func newHandler(channelType models.ChannelType, name string) channels.HandlerCtor {
+	return func(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+		h := &handler{handlers.NewBaseHandler(rt, channelType, name)}
+		r.AddReceive(h, http.MethodPost, "receive", channels.ReceiveKindMsg, handlers.JSONPayload(h.receiveMessage))
+		r.AddReceive(h, http.MethodPost, "status", channels.ReceiveKindStatus, handlers.JSONPayload(h.receiveStatus))
+		return h
+	}
 }
 
 type moContent struct {

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -50,12 +50,6 @@ type Config struct {
 	LogLevel           slog.Level `help:"the logging level courier should use"`
 	Version            string     `help:"the version that will be used in request and response headers"`
 
-	// IncludeChannels is the list of channels to enable, empty means include all
-	IncludeChannels []string
-
-	// ExcludeChannels is the list of channels to exclude, empty means exclude none
-	ExcludeChannels []string
-
 	// parsed values that can't be set directly
 	DisallowedIPs      []net.IP
 	DisallowedNets     []*net.IPNet

--- a/test/handler.go
+++ b/test/handler.go
@@ -17,7 +17,7 @@ import (
 )
 
 func init() {
-	channels.RegisterHandler(NewMockHandler())
+	channels.RegisterHandler(NewMockHandler)
 }
 
 type mockHandler struct {
@@ -25,12 +25,13 @@ type mockHandler struct {
 }
 
 // NewMockHandler returns a new mock handler
-func NewMockHandler() channels.Handler {
-	return &mockHandler{}
+func NewMockHandler(rt *runtime.Runtime, r *channels.Routes) channels.Handler {
+	h := &mockHandler{rt: rt}
+	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeReceive, h.receiveMsg)
+	return h
 }
 
 func (h *mockHandler) Runtime() *runtime.Runtime             { return h.rt }
-func (h *mockHandler) SetRuntime(rt *runtime.Runtime)        { h.rt = rt }
 func (h *mockHandler) ChannelName() string                   { return "Mock Handler" }
 func (h *mockHandler) ChannelType() models.ChannelType       { return models.ChannelType("MCK") }
 func (h *mockHandler) UseChannelRouteUUID() bool             { return true }
@@ -39,12 +40,6 @@ func (h *mockHandler) RedactValues(*models.Channel) []string { return []string{"
 
 func (h *mockHandler) GetChannel(ctx context.Context, r *http.Request) (*models.Channel, error) {
 	return models.GetChannel(ctx, "MCK", "e4bb1578-29da-4fa5-a214-9da19dd24230")
-}
-
-// Initialize registers the routes this handler serves
-func (h *mockHandler) Initialize(r *channels.Routes) error {
-	r.Add(h, http.MethodGet, "receive", models.ChannelLogTypeReceive, h.receiveMsg)
-	return nil
 }
 
 // Send sends the given message, logging any HTTP calls or errors

--- a/web/events.go
+++ b/web/events.go
@@ -83,7 +83,7 @@ func sendEvent(ctx context.Context, s *Server, r *http.Request) (*sendEventRespo
 		return nil, fmt.Errorf("error getting channel: %w", err)
 	}
 
-	handler := channels.GetActiveHandler(ch.ChannelType())
+	handler := channels.GetHandler(ch.ChannelType())
 	if handler == nil {
 		return &sendEventResponse{Supported: false}, nil
 	}

--- a/web/server.go
+++ b/web/server.go
@@ -195,8 +195,8 @@ type Server struct {
 
 // mounts the routes of every registered handler, so that a request for one of its channels reaches it
 func (s *Server) mountChannelHandlers() {
-	for _, ctor := range channels.RegisteredCtors() {
-		handler := s.MountHandler(ctor)
+	for _, newFn := range channels.RegisteredHandlerFuncs() {
+		handler := s.MountHandler(newFn)
 
 		slog.Info("handler initialized", "comp", "server", "handler", handler.ChannelName(), "handler_type", string(handler.ChannelType()))
 	}
@@ -204,9 +204,9 @@ func (s *Server) mountChannelHandlers() {
 
 // MountHandler constructs a handler and mounts the routes it registers, marking it as one this instance
 // serves. Tests use it to mount a single handler without starting the listeners.
-func (s *Server) MountHandler(ctor channels.HandlerCtor) channels.Handler {
+func (s *Server) MountHandler(newFn channels.NewHandlerFunc) channels.Handler {
 	routes := channels.NewRoutes()
-	handler := ctor(s.rt, routes)
+	handler := newFn(s.rt, routes)
 
 	for _, route := range routes.All() {
 		s.addRoute(route)

--- a/web/server.go
+++ b/web/server.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -72,12 +71,8 @@ func (s *Server) Start() error {
 		return fmt.Errorf("error binding internal listener on %s: %w", internalAddr, err)
 	}
 
-	// mount the routes of every handler this instance serves
-	if err := s.mountChannelHandlers(); err != nil {
-		internetLn.Close()
-		internalLn.Close()
-		return err
-	}
+	// mount the routes of every handler compiled into this build
+	s.mountChannelHandlers()
 
 	// internet listener — exposes /c/*, /
 	internetRouter := chi.NewRouter()
@@ -198,41 +193,27 @@ type Server struct {
 	stopped   bool
 }
 
-// mounts the routes of every handler included by config, so that a request for one of its channels reaches it
-func (s *Server) mountChannelHandlers() error {
-	includes := s.rt.Config.IncludeChannels
-	excludes := s.rt.Config.ExcludeChannels
+// mounts the routes of every registered handler, so that a request for one of its channels reaches it
+func (s *Server) mountChannelHandlers() {
+	for _, ctor := range channels.RegisteredCtors() {
+		handler := s.MountHandler(ctor)
 
-	for _, handler := range channels.RegisteredHandlers() {
-		channelType := string(handler.ChannelType())
-		if (includes == nil || slices.Contains(includes, channelType)) && (excludes == nil || !slices.Contains(excludes, channelType)) {
-			if err := s.MountHandler(handler); err != nil {
-				return err
-			}
-
-			slog.Info("handler initialized", "comp", "server", "handler", handler.ChannelName(), "handler_type", channelType)
-		}
+		slog.Info("handler initialized", "comp", "server", "handler", handler.ChannelName(), "handler_type", string(handler.ChannelType()))
 	}
-
-	return nil
 }
 
-// MountHandler initializes the given handler and mounts the routes it registers, marking it as one this instance
+// MountHandler constructs a handler and mounts the routes it registers, marking it as one this instance
 // serves. Tests use it to mount a single handler without starting the listeners.
-func (s *Server) MountHandler(handler channels.Handler) error {
-	handler.SetRuntime(s.rt)
-
+func (s *Server) MountHandler(ctor channels.HandlerCtor) channels.Handler {
 	routes := channels.NewRoutes()
-	if err := handler.Initialize(routes); err != nil {
-		return fmt.Errorf("error initializing handler %s: %w", handler.ChannelType(), err)
-	}
+	handler := ctor(s.rt, routes)
 
 	for _, route := range routes.All() {
 		s.addRoute(route)
 	}
 
 	channels.ActivateHandler(handler)
-	return nil
+	return handler
 }
 
 func (s *Server) channelHandleWrapper(handler channels.Handler, handlerFunc channels.HandleFunc, logType svclogs.Type) http.HandlerFunc {


### PR DESCRIPTION
## Summary

Collapses the two-step handler lifecycle (`SetRuntime` then `Initialize`) into a single constructor that receives the runtime and registers the handler's routes. Handlers now register a constructor at package init, and the server invokes them all at startup once the runtime exists — so a handler can never exist without a runtime.

## Changes

**`core/channels`**
- `Handler` loses `SetRuntime(*runtime.Runtime)` and `Initialize(*Routes) error`; `Runtime()` remains
- New `NewHandlerFunc func(*runtime.Runtime, *Routes) Handler`; `RegisterHandler` now takes a constructor
- `ActivateHandler` registers the constructed instance for lookups and hooks up its `URNDescriber` (previously done at registration)
- `GetHandler`/`GetActiveHandler` collapse into one `GetHandler`, since every registered handler is now served

**`web/server.go`**
- `MountHandler(ctor)` constructs the handler with the server's runtime, mounts its routes and returns it; the error path is gone since no constructor can fail
- Server startup mounts every registered constructor

**`runtime/config.go`**
- The unused `IncludeChannels`/`ExcludeChannels` options are removed; every compiled-in handler is always served

**Handlers (all 53 packages)**
- `newHandler(rt, r)` constructs the handler and registers its routes in one step; the `Initialize` bodies moved into the constructors
- Parametrized families (meta, twiml, zenvia, dart/hub9, dialog360, freshchat, messagebird) became curried constructors returning a `NewHandlerFunc`
- `handlers.NewBaseHandler` takes the runtime as its first argument; `BaseHandler.SetRuntime` is gone
- freshchat and messagebird now use their channel type/name parameters instead of shadowing them with identical hardcoded literals (no behavior change)

**Tests**
- `RunIncomingTestCases`/`RunOutgoingTestCases` take a `NewHandlerFunc`; the harness's re-register workaround is gone since mounting is now what populates the lookup map

This also fixes a latent nil-runtime hole: attachment fetching looks handlers up by channel type regardless of what the instance serves, and a handler that was registered but never mounted had a nil runtime — `BuildAttachmentRequest` implementations that read config would panic. Handlers are now always constructed with the runtime.

## Test plan

- [x] Full suite (`go test -p=1 ./...`) passes in the devcontainer — 62 packages
- [x] `go vet ./...` and `gofmt -l` clean
