### PR TITLE
Record a nexmo request we couldn't fully decode instead of discarding the error

### DIFF
--- a/core/models/channel_log.go
+++ b/core/models/channel_log.go
@@ -32,6 +32,13 @@ const (
 	ChannelLogTypeChatStart       svclogs.Type = "chat_start"
 )
 
+// ErrorRequestUnparseable is used when we couldn't fully decode an incoming request but carried on with what
+// we could read - the failure is recorded here rather than answered, so that it's visible without the provider
+// being told to retry a body we'll never be able to parse.
+func ErrorRequestUnparseable(err error) *svclogs.Error {
+	return &svclogs.Error{Code: "request_unparseable", Message: fmt.Sprintf("Unable to parse request: %s.", err)}
+}
+
 func ErrorResponseStatusCode() *svclogs.Error {
 	return &svclogs.Error{Code: "response_status_code", Message: "Unexpected response status code."}
 }

--- a/handlers/nexmo/handler.go
+++ b/handlers/nexmo/handler.go
@@ -120,9 +120,13 @@ var statusMappings = map[string]models.MsgStatus{
 // receiveStatus is our receive function for status updates
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// this one decodes for itself rather than using FormPayload, because it tolerates a partial decode - it
-	// checks the fields it needs below and ignores the request if they're missing
+	// checks the fields it needs below and ignores the request if they're missing. Answering a decode failure
+	// as an error instead would have Vonage retry a body we can never parse, once a minute for 24 hours, so
+	// the failure is recorded on the log rather than returned.
 	form := &statusForm{}
-	handlers.DecodeAndValidateForm(form, r)
+	if err := handlers.DecodeAndValidateForm(form, r); err != nil {
+		clog.Error(models.ErrorRequestUnparseable(err))
+	}
 
 	if form.MessageID == "" {
 		return channels.Ignore("no messageId parameter, ignored")
@@ -154,7 +158,9 @@ type moForm struct {
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	// decodes for itself for the same reason as receiveStatus above
 	form := &moForm{}
-	handlers.DecodeAndValidateForm(form, r)
+	if err := handlers.DecodeAndValidateForm(form, r); err != nil {
+		clog.Error(models.ErrorRequestUnparseable(err))
+	}
 
 	if form.To == "" {
 		return channels.Ignore("no to parameter, ignored")

--- a/handlers/nexmo/handler_test.go
+++ b/handlers/nexmo/handler_test.go
@@ -1,6 +1,7 @@
 package nexmo
 
 import (
+	"errors"
 	"net/url"
 	"testing"
 
@@ -111,6 +112,29 @@ var testCases = []IncomingTestCase{
 		URL:                  "/c/nx/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?to=2020&messageId=external1&status=unexpected",
 		ExpectedRespStatus:   200,
 		ExpectedBodyContains: "ignoring unknown status report",
+	},
+	{
+		// a field we can't convert doesn't cost us the rest of the report, but is recorded
+		Label:                "Status with unparseable error code",
+		URL:                  "/c/nx/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?to=2020&messageId=external1&status=delivered&err-code=nope",
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: `"status":"D"`,
+		ExpectedStatuses: []ExpectedStatus{
+			{ExternalID: "external1", Status: models.MsgStatusDelivered},
+		},
+		ExpectedErrors: []*svclogs.Error{
+			models.ErrorRequestUnparseable(errors.New(`schema: error converting value for "err-code"`)),
+		},
+	},
+	{
+		// a query string we can't parse at all leaves us with nothing to act on, but is still recorded
+		Label:                "Receive with unparseable query string",
+		URL:                  "/c/nx/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive?to=2020&msisdn=2349067554729&text=%zz",
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: "no to parameter, ignored",
+		ExpectedErrors: []*svclogs.Error{
+			models.ErrorRequestUnparseable(errors.New(`invalid URL escape "%zz"`)),
+		},
 	},
 }
 


### PR DESCRIPTION
## Summary

Both nexmo receive functions called `handlers.DecodeAndValidateForm` and threw the returned error away, so a genuinely malformed request body was indistinguishable from a well-formed one that simply didn't carry a field we wanted. Record the failure on the channel log instead. The response is unchanged.

## Changes

**`core/models/channel_log.go`** — new `ErrorRequestUnparseable(err)`. The existing constructors are all about responses we got back from a provider; this is the first about a request we received, for the case where we carried on with a partial decode rather than answering the failure.

**`handlers/nexmo/handler.go`** — `receiveStatus` and `receiveMessage` both keep the error and log it. Neither changes what it returns, so what the provider sees is identical.

These two decode for themselves rather than using `handlers.FormPayload` precisely because they tolerate a partial decode: they check the individual fields they need and ignore the request when those are missing. Answering the decode failure as an error instead — which is what `FormPayload` would do — would mean a non-2xx on a provider callback, and Vonage retries a delivery receipt once a minute for 24 hours. A body we can never parse would be retried in full and still never parse. The comment on `receiveStatus` now says so, so the next reader doesn't have to rediscover it.

**`handlers/nexmo/handler_test.go`** — cases for the two ways the decode can actually fail. Both were previously silent.

## Behavior examples

| request | before | after |
|---|---|---|
| `…/status?messageId=external1&status=delivered&err-code=nope` | 200, status recorded, error code silently dropped | 200, status recorded, `request_unparseable` on the channel log |
| `…/receive?to=2020&text=%zz` | 200 ignored, no trace of why | 200 ignored, `request_unparseable` on the channel log |
| any well-formed request | unchanged | unchanged |

The two failure modes differ because `gorilla/schema` accumulates per-field conversion errors while still populating the fields it could read, whereas a `ParseForm` failure returns before decoding and leaves the form empty. So the first still acts on the rest of the report; the second has nothing left to act on and ignores the request as it always did.

## Test plan

- [x] `go test -p=1 ./...` green
- [x] Both new cases verified to fail without the handler change (reverted it, confirmed red, restored) — they assert the logged error, not just the status code
- [x] `Status with unparseable error code` asserts the delivery receipt is *still* applied, so the partial-decode tolerance is covered rather than just the logging
- [x] Existing nexmo cases unchanged, including the two bare-URL checks that rely on an empty form decoding cleanly
- [x] `gofmt` clean
