### PR TITLE
Stop a messagebird field we can't convert discarding the whole status report

### DIFF
--- a/handlers/messagebird/handler.go
+++ b/handlers/messagebird/handler.go
@@ -45,14 +45,17 @@ type Message struct {
 	MediaURLs  []string `json:"mediaUrls,omitempty"`
 }
 
+// the decoder is configured to read `name` tags, so these have to be `name` rather than the `schema` that
+// gorilla/schema uses by default - tagged the other way they're inert, and the field names alone are what
+// the form gets matched against
 type ReceivedStatus struct {
-	ID              string    `schema:"id"`
-	Reference       string    `schema:"reference"`
-	Recipient       string    `schema:"recipient,required"`
-	Status          string    `schema:"status,required"`
-	StatusReason    string    `schema:"statusReason"`
-	StatusDatetime  time.Time `schema:"statusDatetime"`
-	StatusErrorCode int       `schema:"statusErrorCode"`
+	ID              string    `name:"id"`
+	Reference       string    `name:"reference"`
+	Recipient       string    `name:"recipient"`
+	Status          string    `name:"status"`
+	StatusReason    string    `name:"statusReason"`
+	StatusDatetime  time.Time `name:"statusDatetime"`
+	StatusErrorCode int       `name:"statusErrorCode"`
 }
 
 var statusMapping = map[string]models.MsgStatus{
@@ -95,11 +98,18 @@ func newHandler(channelType models.ChannelType, name string, validateSignatures 
 	}
 }
 
-// this one decodes for itself rather than using FormPayload, because it answers a decode failure as ignored
-// rather than as an error - which keeps a malformed status callback from being retried at us
+// this one decodes for itself rather than using FormPayload, because it tolerates a partial decode - a field
+// we can't convert costs us that field rather than the whole report, and the failure is recorded on the log
+// rather than answered. Answering it as an error instead would have MessageBird retry a body we can never
+// parse, and an endpoint that keeps failing is eventually paused at their end.
 func (h *handler) receiveStatus(ctx context.Context, channel *models.Channel, r *http.Request, in *channels.Received, clog *models.ChannelLog) error {
 	receivedStatus := &ReceivedStatus{}
 	if err := handlers.DecodeAndValidateForm(receivedStatus, r); err != nil {
+		clog.Error(models.ErrorRequestUnparseable(err))
+	}
+
+	// a callback carrying no status at all - a URL check, typically - is asking nothing of us
+	if receivedStatus.Status == "" {
 		return channels.Ignore("no msg status, ignoring")
 	}
 

--- a/handlers/messagebird/handler_test.go
+++ b/handlers/messagebird/handler_test.go
@@ -1,6 +1,7 @@
 package messagebird
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -191,6 +192,30 @@ var defaultReceiveTestCases = []IncomingTestCase{
 		URL:                  statusBaseURL + "&status=expiryttd",
 		ExpectedRespStatus:   400,
 		ExpectedBodyContains: `{"message":"Error","data":[{"type":"error","error":"unknown status 'expiryttd', must be one of 'buffered', 'delivered', 'delivery_failed', 'expired', 'scheduled', 'sent'"}]}`,
+	},
+	{
+		// a callback with no status at all is asking nothing of us, rather than naming a status we don't know
+		Label:                "Status Missing",
+		URL:                  statusBaseURL,
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: "no msg status, ignoring",
+	},
+	{
+		Label:                "Status URL check",
+		URL:                  "/c/mbd/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status",
+		ExpectedRespStatus:   200,
+		ExpectedBodyContains: "no msg status, ignoring",
+	},
+	{
+		// a field we can't convert costs us that field, not the whole report - note statusDatetime isn't even
+		// one we read, and used to be enough on its own to discard the status
+		Label:              "Status with unparseable datetime",
+		URL:                statusBaseURL + "&status=sent&statusDatetime=garbage",
+		ExpectedRespStatus: 200,
+		ExpectedStatuses:   []ExpectedStatus{{MsgUUID: "019a0719-ac96-7eb9-a837-cac215164834", Status: models.MsgStatusSent}},
+		ExpectedErrors: []*svclogs.Error{
+			models.ErrorRequestUnparseable(errors.New(`schema: error converting value for "statusDatetime". Details: parsing time "garbage" as "2006-01-02T15:04:05Z07:00": cannot parse "garbage" as "2006"`)),
+		},
 	},
 }
 

--- a/handlers/messagebird/handler_test.go
+++ b/handlers/messagebird/handler_test.go
@@ -217,6 +217,18 @@ var defaultReceiveTestCases = []IncomingTestCase{
 			models.ErrorRequestUnparseable(errors.New(`schema: error converting value for "statusDatetime". Details: parsing time "garbage" as "2006-01-02T15:04:05Z07:00": cannot parse "garbage" as "2006"`)),
 		},
 	},
+	{
+		// what's recovered is the report, not the field: the status is recorded, but an error code we
+		// couldn't convert is still not the one that says the contact stopped, so no event comes with it
+		Label:              "Status with unparseable error code",
+		URL:                statusBaseURL + "&status=delivery_failed&statusErrorCode=nope",
+		ExpectedRespStatus: 200,
+		ExpectedStatuses:   []ExpectedStatus{{MsgUUID: "019a0719-ac96-7eb9-a837-cac215164834", Status: models.MsgStatusFailed}},
+		ExpectedEvents:     nil,
+		ExpectedErrors: []*svclogs.Error{
+			models.ErrorRequestUnparseable(errors.New(`schema: error converting value for "statusErrorCode"`)),
+		},
+	},
 }
 
 func TestReceiving(t *testing.T) {


### PR DESCRIPTION
## Summary

`ReceivedStatus` was tagged with `schema:"..."`, but `handlers.DecodeAndValidateForm` configures its decoder with `SetAliasTag("name")` — so every one of those tags was inert, including two `required` markers. Fields still populated, because gorilla/schema falls back to matching on the field name case-insensitively.

The missing `required` check turns out not to be the interesting part. The consequence was that the *only* way the decode could fail was a field we couldn't convert — and the handler answered that by ignoring the whole request, discarding a status report it had otherwise parsed.

## Changes

**`ReceivedStatus` tags `schema` → `name`**, with a comment saying why, and the two inert `required` markers dropped. On its own this is a no-op — verified that the struct decodes identically before and after for every input below — but tagged the other way it's a trap for the next person who adds a field and expects the tag to do something.

**`receiveStatus` tolerates a partial decode.** A field we can't convert now costs us that field rather than the entire report, and the failure is recorded via `models.ErrorRequestUnparseable` (added in #1164 for the same situation in nexmo) instead of being answered. The response stays a 2xx: MessageBird retries a non-2xx, and an endpoint that keeps failing is eventually paused at their end.

**The `Ignore` now fires on the condition its comment always claimed** — a callback carrying no status at all, which is what a URL check looks like. Previously that fell through to `UnknownStatusError` and answered 400, so the one case the branch was written for was the one case it didn't cover.

## Behavior examples

| request | before | after |
|---|---|---|
| `…/status` with no `status` (URL check) | 400 `unknown status ''` | 200 ignored |
| `…&status=sent&statusDatetime=garbage` | 200, **status silently discarded** | 200, status recorded, error logged |
| `…&status=delivery_failed&statusErrorCode=nope` | 200, **status discarded**, no stop event | 200, status recorded, error logged, still no stop event |
| `…&status=expiryttd` (unknown value) | 400 | 400 — unchanged |
| well-formed callback | unchanged | unchanged |

`statusDatetime` is decoded and never read, and was enough on its own to lose a delivery report — that row is a clean recovery.

The third row is the one to be precise about. What's recovered is the *report*, not the field: an unconvertible `statusErrorCode` stays `0`, which isn't `errorStopped`, so the status is recorded but the stop-contact event that should have accompanied it still doesn't fire. That's better than discarding the report and the opt-out both, and the parse failure is now visible on the channel log rather than silent — but this PR does not recover the opt-out itself. `Status with unparseable error code` pins that trade-off down rather than leaving it implied.

## Test plan

- [x] `go test -p=1 ./...` green
- [x] All four new cases verified to fail against the old handler (swapped it back in, confirmed red, restored)
- [x] `Status with unparseable datetime` asserts the status **is** applied, so it covers the recovered report rather than just the logging
- [x] `Status with unparseable error code` asserts the status is applied **and** that no event accompanies it — `handlertest` asserts the event count, so the empty expectation genuinely catches a spurious stop event
- [x] Existing cases unchanged, including `Status Valid`, `Status- Stop Received` and `Receive Invalid Status`
- [x] Confirmed by direct probe that `schema`- and `name`-tagged versions of the struct decode identically across valid input, missing status, capitalised keys, and unconvertible date/int fields — so the retag carries no behavior of its own
- [x] `gofmt` clean
