### PR TITLE
Cache a channel's absence so a dead callback URL doesn't query per request

### DIFF
--- a/core/models/channel.go
+++ b/core/models/channel.go
@@ -264,14 +264,21 @@ SELECT
   JOIN orgs_org o ON c.org_id = o.id
  WHERE c.uuid = $1 AND c.is_active = TRUE AND c.org_id IS NOT NULL`
 
+// a channel that isn't there is loaded as a nil rather than as an error, so that the cache can hold it -
+// cache.Local doesn't remember a fetch that failed, and a provider still calling a deleted channel's URL
+// otherwise puts a query on the database for every request. GetChannel turns the nil back into
+// ErrChannelNotFound. A database error is still an error, so an outage isn't cached as absence.
 func loadChannelByUUID(ctx context.Context, rt *runtime.Runtime, uuid ChannelUUID) (*Channel, error) {
 	channel := &Channel{}
 	err := rt.DB.GetContext(ctx, channel, sqlSelectChannelFromUUID, uuid)
 
 	if err == sql.ErrNoRows {
-		return nil, ErrChannelNotFound
+		return nil, nil
 	}
-	return channel, err
+	if err != nil {
+		return nil, err
+	}
+	return channel, nil
 }
 
 const sqlSelectChannelFromAddress = `
@@ -292,14 +299,18 @@ SELECT
   JOIN orgs_org o ON c.org_id = o.id
  WHERE c.address = $1 AND c.is_active = TRUE AND c.org_id IS NOT NULL`
 
+// as above, absence is a nil rather than an error so that it can be cached
 func loadChannelByAddress(ctx context.Context, rt *runtime.Runtime, addr ChannelAddress) (*Channel, error) {
 	channel := &Channel{}
 	err := rt.DB.GetContext(ctx, channel, sqlSelectChannelFromAddress, addr)
 
 	if err == sql.ErrNoRows {
-		return nil, ErrChannelNotFound
+		return nil, nil
 	}
-	return channel, err
+	if err != nil {
+		return nil, err
+	}
+	return channel, nil
 }
 
 // GetChannel returns the channel with the passed in type and UUID. It reads through the channel cache created by
@@ -311,6 +322,9 @@ func GetChannel(ctx context.Context, typ ChannelType, uuid ChannelUUID) (*Channe
 	ch, err := channelsByUUID.GetOrFetch(timeout, uuid)
 	if err != nil {
 		return nil, err
+	}
+	if ch == nil {
+		return nil, ErrChannelNotFound
 	}
 
 	if typ != AnyChannelType && ch.ChannelType() != typ {
@@ -329,6 +343,9 @@ func GetChannelByAddress(ctx context.Context, typ ChannelType, address ChannelAd
 	ch, err := channelsByAddr.GetOrFetch(timeout, address)
 	if err != nil {
 		return nil, err
+	}
+	if ch == nil {
+		return nil, ErrChannelNotFound
 	}
 
 	if typ != AnyChannelType && ch.ChannelType() != typ {

--- a/core/models/channel.go
+++ b/core/models/channel.go
@@ -268,6 +268,11 @@ SELECT
 // cache.Local doesn't remember a fetch that failed, and a provider still calling a deleted channel's URL
 // otherwise puts a query on the database for every request. GetChannel turns the nil back into
 // ErrChannelNotFound. A database error is still an error, so an outage isn't cached as absence.
+//
+// Only lookups by UUID do this. A UUID names one channel for good - it's minted with the channel and no
+// other channel ever takes it - so once it's absent the only way back is the channel returning, which is
+// the same staleness as an edit to a channel already cached. An address is reused, and absence at one is
+// routine rather than terminal: see loadChannelByAddress.
 func loadChannelByUUID(ctx context.Context, rt *runtime.Runtime, uuid ChannelUUID) (*Channel, error) {
 	channel := &Channel{}
 	err := rt.DB.GetContext(ctx, channel, sqlSelectChannelFromUUID, uuid)
@@ -299,13 +304,16 @@ SELECT
   JOIN orgs_org o ON c.org_id = o.id
  WHERE c.address = $1 AND c.is_active = TRUE AND c.org_id IS NOT NULL`
 
-// as above, absence is a nil rather than an error so that it can be cached
+// unlike the lookup by UUID above, this one does NOT cache absence. Addresses are looked up from the body of
+// a shared webhook - Meta posts every page's events to one URL - so a request naming an address we have no
+// channel for is ordinary traffic rather than a dead callback, and the address is one a channel can later be
+// provisioned at. Caching that absence would leave a newly connected page invisible until the entry expired.
 func loadChannelByAddress(ctx context.Context, rt *runtime.Runtime, addr ChannelAddress) (*Channel, error) {
 	channel := &Channel{}
 	err := rt.DB.GetContext(ctx, channel, sqlSelectChannelFromAddress, addr)
 
 	if err == sql.ErrNoRows {
-		return nil, nil
+		return nil, ErrChannelNotFound
 	}
 	if err != nil {
 		return nil, err
@@ -343,9 +351,6 @@ func GetChannelByAddress(ctx context.Context, typ ChannelType, address ChannelAd
 	ch, err := channelsByAddr.GetOrFetch(timeout, address)
 	if err != nil {
 		return nil, err
-	}
-	if ch == nil {
-		return nil, ErrChannelNotFound
 	}
 
 	if typ != AnyChannelType && ch.ChannelType() != typ {

--- a/core/models/channel_test.go
+++ b/core/models/channel_test.go
@@ -1,0 +1,68 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/courier/v26/test"
+	"github.com/nyaruka/courier/v26/testsuite"
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetChannelCachesAbsence(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	ch := test.NewMockChannel("d84e0f1e-6b1e-4f4a-9e6e-9a48c4b8b5a1", "NX", "2020", "US", []string{urns.Phone.Prefix}, nil)
+	testsuite.InsertChannel(t, rt, ch) // flushes the cache
+
+	got, err := models.GetChannel(ctx, "NX", ch.UUID())
+	assert.NoError(t, err)
+	assert.Equal(t, ch.UUID(), got.UUID())
+
+	// deactivating puts it outside what the load query selects, so it's gone as far as we're concerned
+	rt.DB.MustExec(`UPDATE channels_channel SET is_active = FALSE WHERE uuid = $1`, ch.UUID())
+	models.FlushChannelCache()
+
+	_, err = models.GetChannel(ctx, "NX", ch.UUID())
+	assert.ErrorIs(t, err, models.ErrChannelNotFound)
+
+	// that absence is cached, so bringing it back doesn't take effect until the entry expires or is flushed -
+	// which is what saves a provider still calling a deleted channel's URL a query per request
+	rt.DB.MustExec(`UPDATE channels_channel SET is_active = TRUE WHERE uuid = $1`, ch.UUID())
+
+	_, err = models.GetChannel(ctx, "NX", ch.UUID())
+	assert.ErrorIs(t, err, models.ErrChannelNotFound, "absence should have been served from the cache")
+
+	models.FlushChannelCache()
+
+	got, err = models.GetChannel(ctx, "NX", ch.UUID())
+	assert.NoError(t, err)
+	assert.Equal(t, ch.UUID(), got.UUID())
+
+	// a channel that's there but of another type is still a type error rather than an absence
+	_, err = models.GetChannel(ctx, "TG", ch.UUID())
+	assert.ErrorIs(t, err, models.ErrChannelWrongType)
+}
+
+func TestGetChannelByAddressCachesAbsence(t *testing.T) {
+	ctx, rt := testsuite.Runtime(t)
+
+	ch := test.NewMockChannel("6b1e0f1e-d84e-4f4a-9e6e-9a48c4b8b5a2", "NX", "2021", "US", []string{urns.Phone.Prefix}, nil)
+	testsuite.InsertChannel(t, rt, ch)
+
+	got, err := models.GetChannelByAddress(ctx, "NX", models.ChannelAddress("2021"))
+	assert.NoError(t, err)
+	assert.Equal(t, ch.UUID(), got.UUID())
+
+	rt.DB.MustExec(`UPDATE channels_channel SET is_active = FALSE WHERE uuid = $1`, ch.UUID())
+	models.FlushChannelCache()
+
+	_, err = models.GetChannelByAddress(ctx, "NX", models.ChannelAddress("2021"))
+	assert.ErrorIs(t, err, models.ErrChannelNotFound)
+
+	rt.DB.MustExec(`UPDATE channels_channel SET is_active = TRUE WHERE uuid = $1`, ch.UUID())
+
+	_, err = models.GetChannelByAddress(ctx, "NX", models.ChannelAddress("2021"))
+	assert.ErrorIs(t, err, models.ErrChannelNotFound, "absence should have been served from the cache")
+}

--- a/core/models/channel_test.go
+++ b/core/models/channel_test.go
@@ -45,7 +45,7 @@ func TestGetChannelCachesAbsence(t *testing.T) {
 	assert.ErrorIs(t, err, models.ErrChannelWrongType)
 }
 
-func TestGetChannelByAddressCachesAbsence(t *testing.T) {
+func TestGetChannelByAddressDoesntCacheAbsence(t *testing.T) {
 	ctx, rt := testsuite.Runtime(t)
 
 	ch := test.NewMockChannel("6b1e0f1e-d84e-4f4a-9e6e-9a48c4b8b5a2", "NX", "2021", "US", []string{urns.Phone.Prefix}, nil)
@@ -61,8 +61,12 @@ func TestGetChannelByAddressCachesAbsence(t *testing.T) {
 	_, err = models.GetChannelByAddress(ctx, "NX", models.ChannelAddress("2021"))
 	assert.ErrorIs(t, err, models.ErrChannelNotFound)
 
+	// an address is reused and is asked about by shared webhooks that carry it in the body, so absence at one
+	// isn't cached - a channel provisioned at an address we've already been asked about has to be visible at
+	// once rather than when an entry expires
 	rt.DB.MustExec(`UPDATE channels_channel SET is_active = TRUE WHERE uuid = $1`, ch.UUID())
 
-	_, err = models.GetChannelByAddress(ctx, "NX", models.ChannelAddress("2021"))
-	assert.ErrorIs(t, err, models.ErrChannelNotFound, "absence should have been served from the cache")
+	got, err = models.GetChannelByAddress(ctx, "NX", models.ChannelAddress("2021"))
+	assert.NoError(t, err, "absence should not have been cached")
+	assert.Equal(t, ch.UUID(), got.UUID())
 }


### PR DESCRIPTION
## Summary

`cache.Local.GetOrFetch` doesn't remember a fetch that returned an error, so returning `ErrChannelNotFound` from the loader meant **every** request for a channel that no longer exists ran a fresh `SELECT ... JOIN orgs_org`. Providers go on calling a deleted channel's callback URL for as long as their retry policy says to, so that's a sustained query load for rows that will never come back.

Load absence as a `nil` channel instead — which the cache holds like any other value — and turn it back into `ErrChannelNotFound` at the point of use.

## Changes

**`loadChannelByUUID`** returns `(nil, nil)` on `sql.ErrNoRows` rather than an error, so the cache stores the absence. A database error is still returned as an error and so is still never cached — an outage can't be recorded as "this channel doesn't exist".

**`loadChannelByAddress` deliberately does not do this.** A UUID names one channel for good: it's minted with the channel, no other channel ever takes it, so once it's absent the only way back is that channel returning — the same staleness as an edit to a channel already in the cache. An address is reused, and is read from the body of a *shared* webhook: Meta posts every page's events to one URL, so a request naming an address we have no channel for is ordinary traffic rather than a dead callback. Caching that would leave a page connected afterwards invisible until the entry expired — a staleness that didn't exist before. Nothing is given up by the asymmetry: of the requests for channels we can't find, address-resolved ones are 3 in ~17,500.

**`GetChannel`** maps a cached `nil` back to `ErrChannelNotFound`, so nothing outside this file sees the new representation. `ErrChannelWrongType` is unaffected — a channel that exists under another type is still a type error, not an absence. Both loaders also stop returning a non-nil channel alongside a non-nil error, which no caller relied on.

## Behavior examples

Nothing a provider sees changes: a request for a channel that isn't there is answered exactly as before. The difference is what it costs us.

| requests for a deleted channel UUID, within one TTL | before | after |
|---|---|---|
| 1st | 1 query | 1 query |
| 2nd … nth | 1 query each | served from cache |

Lookups by address are unchanged in every respect.

The entry expires on the same one-minute TTL as a channel that does exist, so a channel reactivated while an absence is held is stale for no longer than an edit to a channel already cached.

One property does get worse, and it's worth stating plainly rather than as a footnote: absences occupy cache entries, and the UUID is taken from the request path *before* any handler signature check runs. So a caller can park an entry per distinct UUID for a minute, and `cache.Local` has no capacity bound. That is not "strictly better" — it is better against the resource that matters, since before this change each of those same requests cost a Postgres query instead, and loading the shared database is worse than transient memory on a stateless node. Bounding the cache needs a `cache.NewLocal` that accepts a capacity, so it's being looked at separately.

## Test plan

- [x] `go test -p=1 ./...` green
- [x] `TestGetChannelCachesAbsence` — deactivate, flush, confirm not-found, then **reactivate without flushing** and confirm it's *still* not-found; that staleness is the proof the absence was cached rather than re-queried
- [x] `TestGetChannelByAddressDoesntCacheAbsence` — the mirror image, asserting the address lookup sees the reactivation immediately; verified to fail against the first commit, so it guards the asymmetry rather than just describing it
- [x] The UUID test verified to fail against the previous loader (swapped it back in, confirmed red on exactly that assertion, restored)
- [x] Covers that a flush restores visibility, and that a wrong-type lookup still returns `ErrChannelWrongType` rather than being swallowed as absence
- [x] `gofmt` clean
