### PR TITLE
Convert six simple handlers' tests to JSON case files

### DIFF
--- a/handlers/arabiacell/handler_test.go
+++ b/handlers/arabiacell/handler_test.go
@@ -1,118 +1,20 @@
 package arabiacell
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
-
-const (
-	receiveURL = "/c/ac/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-)
-
-var incomingCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid",
-		URL:                  receiveURL,
-		Data:                 "B=Msg&M=254791541111",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Message Accepted",
-		ExpectedMsgText:      Sp("Msg"),
-		ExpectedURN:          "tel:+254791541111",
-	},
-	{
-		Label:                "Receive Missing Number",
-		URL:                  receiveURL,
-		Data:                 "B=Msg",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "required field 'M'",
-	},
-}
 
 func TestIncoming(t *testing.T) {
 	chs := []*models.Channel{
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "AC", "2020", "US", []string{urns.Phone.Prefix}, nil),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler, incomingCases)
-}
-
-var outgoingCases = []OutgoingTestCase{
-	{
-		Label:          "Plain Send",
-		MsgText:        "Simple Message ☺",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://acsdp.arabiacell.net": {
-				httpx.NewMockResponse(200, nil, []byte(`<response><code>204</code><text>MT is successfully sent</text><message_id>external1</message_id></response>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Form: url.Values{
-					"userName":      {"user1"},
-					"password":      {"pass1"},
-					"handlerType":   {"send_msg"},
-					"serviceId":     {"service1"},
-					"msisdn":        {"+250788383383"},
-					"messageBody":   {"Simple Message ☺\nhttps://foo.bar/image.jpg"},
-					"chargingLevel": {"0"},
-				},
-			},
-		},
-		ExpectedExtIDs: []string{"external1"},
-	},
-	{
-		Label:   "Invalid XML",
-		MsgText: "Invalid XML",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://acsdp.arabiacell.net": {
-				httpx.NewMockResponse(200, nil, []byte(`not xml`)),
-			},
-		},
-		ExpectedError: channels.ErrResponseUnparseable,
-	},
-	{
-		Label:   "Error Response",
-		MsgText: "Error Response",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://acsdp.arabiacell.net": {
-				httpx.NewMockResponse(200, nil, []byte(`<response><code>501</code><text>failure</text><message_id></message_id></response>`)),
-			},
-		},
-		ExpectedError: channels.ErrResponseContent,
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://acsdp.arabiacell.net": {
-				httpx.NewMockResponse(501, nil, []byte(`Bad Gateway`)),
-			},
-		},
-		ExpectedError: channels.ErrConnectionFailed,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://acsdp.arabiacell.net": {
-				httpx.NewMockResponse(429, nil, []byte(`Bad Gateway`)),
-			},
-		},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
@@ -125,5 +27,5 @@ func TestOutgoing(t *testing.T) {
 			configChargingLevel:   "0",
 		})
 
-	RunOutgoingTestCases(t, ch, newHandler, outgoingCases, []string{"pass1"}, nil)
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"pass1"}})
 }

--- a/handlers/arabiacell/testdata/incoming.json
+++ b/handlers/arabiacell/testdata/incoming.json
@@ -1,0 +1,61 @@
+[
+    {
+        "label": "Receive Valid",
+        "url": "/c/ac/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "B=Msg\u0026M=254791541111",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                        "text": "Msg",
+                        "urn": "tel:+254791541111",
+                        "received_on": "2025-11-19T17:20:05Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+254791541111",
+                "text": "Msg",
+                "created_on": "2025-11-19T17:20:03Z",
+                "received_on": "2025-11-19T17:20:05Z",
+                "log_uuids": [
+                    "019a9d21-5de8-7000-a1e4-7638cffc03a6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Missing Number",
+        "url": "/c/ac/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "B=Msg",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing required field 'M'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/arabiacell/testdata/outgoing.json
+++ b/handlers/arabiacell/testdata/outgoing.json
@@ -1,0 +1,289 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message ☺",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "https://acsdp.arabiacell.net": [
+                {
+                    "status": 200,
+                    "body": "<response><code>204</code><text>MT is successfully sent</text><message_id>external1</message_id></response>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://acsdp.arabiacell.net",
+                "headers": {
+                    "Accept": "application/xml",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "chargingLevel": [
+                        "0"
+                    ],
+                    "handlerType": [
+                        "send_msg"
+                    ],
+                    "messageBody": [
+                        "Simple Message ☺\nhttps://foo.bar/image.jpg"
+                    ],
+                    "msisdn": [
+                        "+250788383383"
+                    ],
+                    "password": [
+                        "pass1"
+                    ],
+                    "serviceId": [
+                        "service1"
+                    ],
+                    "userName": [
+                        "user1"
+                    ]
+                }
+            }
+        ],
+        "external_ids": [
+            "external1"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Invalid XML",
+        "msg": {
+            "text": "Invalid XML",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://acsdp.arabiacell.net": [
+                {
+                    "status": 200,
+                    "body": "not xml"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://acsdp.arabiacell.net",
+                "headers": {
+                    "Accept": "application/xml",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "chargingLevel": [
+                        "0"
+                    ],
+                    "handlerType": [
+                        "send_msg"
+                    ],
+                    "messageBody": [
+                        "Invalid XML"
+                    ],
+                    "msisdn": [
+                        "+250788383383"
+                    ],
+                    "password": [
+                        "pass1"
+                    ],
+                    "serviceId": [
+                        "service1"
+                    ],
+                    "userName": [
+                        "user1"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response couldn't be parsed",
+            "loggable": true,
+            "log_error": {
+                "code": "response_unparseable",
+                "message": "Response could not be parsed in the expected format."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Response",
+        "msg": {
+            "text": "Error Response",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://acsdp.arabiacell.net": [
+                {
+                    "status": 200,
+                    "body": "<response><code>501</code><text>failure</text><message_id></message_id></response>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://acsdp.arabiacell.net",
+                "headers": {
+                    "Accept": "application/xml",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "chargingLevel": [
+                        "0"
+                    ],
+                    "handlerType": [
+                        "send_msg"
+                    ],
+                    "messageBody": [
+                        "Error Response"
+                    ],
+                    "msisdn": [
+                        "+250788383383"
+                    ],
+                    "password": [
+                        "pass1"
+                    ],
+                    "serviceId": [
+                        "service1"
+                    ],
+                    "userName": [
+                        "user1"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response content",
+            "log_error": {
+                "code": "response_content",
+                "message": "Response content indicates non-success."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://acsdp.arabiacell.net": [
+                {
+                    "status": 501,
+                    "body": "Bad Gateway"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://acsdp.arabiacell.net",
+                "headers": {
+                    "Accept": "application/xml",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "chargingLevel": [
+                        "0"
+                    ],
+                    "handlerType": [
+                        "send_msg"
+                    ],
+                    "messageBody": [
+                        "Error Message"
+                    ],
+                    "msisdn": [
+                        "+250788383383"
+                    ],
+                    "password": [
+                        "pass1"
+                    ],
+                    "serviceId": [
+                        "service1"
+                    ],
+                    "userName": [
+                        "user1"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel connection failed",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_failed",
+                "message": "Connection to server failed."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://acsdp.arabiacell.net": [
+                {
+                    "status": 429,
+                    "body": "Bad Gateway"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://acsdp.arabiacell.net",
+                "headers": {
+                    "Accept": "application/xml",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "chargingLevel": [
+                        "0"
+                    ],
+                    "handlerType": [
+                        "send_msg"
+                    ],
+                    "messageBody": [
+                        "Error Message"
+                    ],
+                    "msisdn": [
+                        "+250788383383"
+                    ],
+                    "password": [
+                        "pass1"
+                    ],
+                    "serviceId": [
+                        "service1"
+                    ],
+                    "userName": [
+                        "user1"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/burstsms/handler_test.go
+++ b/handlers/burstsms/handler_test.go
@@ -1,10 +1,8 @@
 package burstsms
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
@@ -12,151 +10,12 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 )
 
-const (
-	receiveURL = "/c/bs/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-	statusURL  = "/c/bs/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/"
-)
-
-var testCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid",
-		URL:                  receiveURL + "?response=Msg&mobile=254791541111",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Message Accepted",
-		ExpectedMsgText:      Sp("Msg"),
-		ExpectedURN:          "tel:+254791541111",
-	},
-	{
-		Label:                "Receive Missing Number",
-		URL:                  receiveURL + "?response=Msg",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "required field 'mobile'",
-	},
-	{
-		Label:                "Status Valid",
-		URL:                  statusURL + "?message_id=12345&status=pending",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Status Update Accepted",
-		ExpectedStatuses:     []ExpectedStatus{{ExternalID: "12345", Status: models.MsgStatusSent}},
-	},
-	{
-		Label:                "Receive Invalid Status",
-		URL:                  statusURL + "?message_id=12345&status=unknown",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "unknown status 'unknown'",
-	},
-}
-
 func TestIncoming(t *testing.T) {
 	chs := []*models.Channel{
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "BS", "2020", "US", []string{urns.Phone.Prefix}, nil),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler, testCases)
-}
-
-var outgoingCases = []OutgoingTestCase{
-	{
-		Label:          "Plain Send",
-		MsgText:        "Simple Message ☺",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.transmitsms.com/send-sms.json": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "message_id": 19835, "recipients": 3, "cost": 1.000 }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Form: url.Values{
-					"to":      {"250788383383"},
-					"message": {"Simple Message ☺\nhttps://foo.bar/image.jpg"},
-					"from":    {"2020"},
-				},
-			},
-		},
-		ExpectedExtIDs: []string{"19835"},
-	},
-	{
-		Label:   "Invalid JSON",
-		MsgText: "Invalid JSON",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.transmitsms.com/send-sms.json": {
-				httpx.NewMockResponse(200, nil, []byte(`not json`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Form: url.Values{
-					"to":      {"250788383383"},
-					"message": {"Invalid JSON"},
-					"from":    {"2020"},
-				},
-			},
-		},
-		ExpectedError: channels.ErrResponseUnparseable,
-	},
-	{
-		Label:   "Error Response",
-		MsgText: "Error Response",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.transmitsms.com/send-sms.json": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "message_id": 0 }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Form: url.Values{
-					"to":      {"250788383383"},
-					"message": {"Error Response"},
-					"from":    {"2020"},
-				},
-			},
-		},
-		ExpectedError: channels.ErrResponseContent,
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.transmitsms.com/send-sms.json": {
-				httpx.NewMockResponse(501, nil, []byte(`Bad Gateway`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Form: url.Values{
-					"to":      {"250788383383"},
-					"message": {"Error Message"},
-					"from":    {"2020"},
-				},
-			},
-		},
-		ExpectedError: channels.ErrConnectionFailed,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.transmitsms.com/send-sms.json": {
-				httpx.NewMockResponse(429, nil, []byte(`Bad Gateway`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Form: url.Values{
-					"to":      {"250788383383"},
-					"message": {"Error Message"},
-					"from":    {"2020"},
-				},
-			},
-		},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
@@ -165,5 +24,5 @@ func TestOutgoing(t *testing.T) {
 		map[string]any{models.ConfigUsername: "user1", models.ConfigPassword: "pass1"},
 	)
 
-	RunOutgoingTestCases(t, ch, newHandler, outgoingCases, []string{httpx.BasicAuth("user1", "pass1")}, nil)
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{httpx.BasicAuth("user1", "pass1")}})
 }

--- a/handlers/burstsms/testdata/incoming.json
+++ b/handlers/burstsms/testdata/incoming.json
@@ -1,0 +1,110 @@
+[
+    {
+        "label": "Receive Valid",
+        "url": "/c/bs/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?response=Msg&mobile=254791541111",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                        "text": "Msg",
+                        "urn": "tel:+254791541111",
+                        "received_on": "2025-11-19T17:20:05Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+254791541111",
+                "text": "Msg",
+                "created_on": "2025-11-19T17:20:03Z",
+                "received_on": "2025-11-19T17:20:05Z",
+                "log_uuids": [
+                    "019a9d21-5de8-7000-a1e4-7638cffc03a6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Missing Number",
+        "url": "/c/bs/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?response=Msg",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing required field 'mobile'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Status Valid",
+        "url": "/c/bs/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/?message_id=12345&status=pending",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "S",
+                        "external_id": "12345"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "external_identifier": "12345",
+                "status": "S",
+                "log_uuid": "0199f028-0e48-7000-82fd-5b92b67a3e7e"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Invalid Status",
+        "url": "/c/bs/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/?message_id=12345&status=unknown",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "unknown status 'unknown', must be one of 'delivered', 'hard-bounce', 'pending', 'soft-bounce'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    }
+]

--- a/handlers/burstsms/testdata/outgoing.json
+++ b/handlers/burstsms/testdata/outgoing.json
@@ -1,0 +1,240 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message ☺",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "https://api.transmitsms.com/send-sms.json": [
+                {
+                    "status": 200,
+                    "body": {
+                        "message_id": 19835,
+                        "recipients": 3,
+                        "cost": 1.0
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.transmitsms.com/send-sms.json",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic dXNlcjE6cGFzczE=",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "message": [
+                        "Simple Message ☺\nhttps://foo.bar/image.jpg"
+                    ],
+                    "to": [
+                        "250788383383"
+                    ]
+                }
+            }
+        ],
+        "external_ids": [
+            "19835"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Invalid JSON",
+        "msg": {
+            "text": "Invalid JSON",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api.transmitsms.com/send-sms.json": [
+                {
+                    "status": 200,
+                    "body": "not json"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.transmitsms.com/send-sms.json",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic dXNlcjE6cGFzczE=",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "message": [
+                        "Invalid JSON"
+                    ],
+                    "to": [
+                        "250788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response couldn't be parsed",
+            "loggable": true,
+            "log_error": {
+                "code": "response_unparseable",
+                "message": "Response could not be parsed in the expected format."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Response",
+        "msg": {
+            "text": "Error Response",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api.transmitsms.com/send-sms.json": [
+                {
+                    "status": 200,
+                    "body": {
+                        "message_id": 0
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.transmitsms.com/send-sms.json",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic dXNlcjE6cGFzczE=",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "message": [
+                        "Error Response"
+                    ],
+                    "to": [
+                        "250788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response content",
+            "log_error": {
+                "code": "response_content",
+                "message": "Response content indicates non-success."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api.transmitsms.com/send-sms.json": [
+                {
+                    "status": 501,
+                    "body": "Bad Gateway"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.transmitsms.com/send-sms.json",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic dXNlcjE6cGFzczE=",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "message": [
+                        "Error Message"
+                    ],
+                    "to": [
+                        "250788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel connection failed",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_failed",
+                "message": "Connection to server failed."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api.transmitsms.com/send-sms.json": [
+                {
+                    "status": 429,
+                    "body": "Bad Gateway"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.transmitsms.com/send-sms.json",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic dXNlcjE6cGFzczE=",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "message": [
+                        "Error Message"
+                    ],
+                    "to": [
+                        "250788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/external/handler.go
+++ b/handlers/external/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/gsm7"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
@@ -182,7 +183,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 	}
 
 	// if we have a date, parse it
-	date := time.Now()
+	date := dates.Now()
 	if dateString != "" {
 		date, err = time.Parse(time.RFC3339Nano, dateString)
 		if err != nil {

--- a/handlers/firebase/handler.go
+++ b/handlers/firebase/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"golang.org/x/oauth2/google"
@@ -64,7 +65,7 @@ type receiveForm struct {
 
 // receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *receiveForm, in *channels.Received, clog *models.ChannelLog) error {
-	date := time.Now().UTC()
+	date := dates.Now().UTC()
 	if form.Date != "" {
 		var err error
 		date, err = time.Parse("2006-01-02T15:04:05.000", form.Date)
@@ -307,5 +308,5 @@ func (h *handler) fetchAccessToken(channel *models.Channel) (string, time.Durati
 		return "", 0, err
 	}
 
-	return token.AccessToken, token.Expiry.UTC().Sub(time.Now().UTC()), nil
+	return token.AccessToken, token.Expiry.UTC().Sub(dates.Now().UTC()), nil
 }

--- a/handlers/generic.go
+++ b/handlers/generic.go
@@ -8,10 +8,10 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -43,7 +43,7 @@ func NewTelReceiveHandler(fromField string, bodyField string) channels.ReceiveFu
 			return err
 		}
 
-		in.Msg(models.NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(time.Now().UTC()))
+		in.Msg(models.NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(dates.Now().UTC()))
 		return nil
 	}
 }

--- a/handlers/highconnection/handler.go
+++ b/handlers/highconnection/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -47,7 +48,7 @@ type moForm struct {
 
 // receiveMessage is our receive function for incoming messages
 func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r *http.Request, form *moForm, in *channels.Received, clog *models.ChannelLog) error {
-	date := time.Now()
+	date := dates.Now()
 	if form.ReceiveDate != "" {
 		var err error
 		date, err = time.Parse("2006-01-02T15:04:05", form.ReceiveDate)

--- a/handlers/i2sms/handler_test.go
+++ b/handlers/i2sms/handler_test.go
@@ -1,10 +1,8 @@
 package i2sms
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
@@ -12,153 +10,22 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "I2", "2020", "US", []string{urns.Phone.Prefix}, nil),
-}
-
-const (
-	receiveURL = "/c/i2/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-)
-
-var testCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid",
-		URL:                  receiveURL,
-		Data:                 "message=Msg&mobile=254791541111",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "",
-		ExpectedMsgText:      Sp("Msg"),
-		ExpectedURN:          "tel:+254791541111",
-	},
-	{
-		Label:                "Receive Missing Number",
-		URL:                  receiveURL,
-		Data:                 "message=Msg",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "required field 'mobile'",
-	},
-}
-
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, testCases)
-}
+	chs := []*models.Channel{
+		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "I2", "2020", "US", []string{urns.Phone.Prefix}, nil),
+	}
 
-var defaultSendTestCases = []OutgoingTestCase{
-	{
-		Label:          "Plain Send",
-		MsgText:        "Simple Message ☺",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://mx2.i2sms.net/mxapi.php": {
-				httpx.NewMockResponse(200, nil, []byte(`{"result":{"session_id":"5b8fc97d58795484819426"}, "error_code": "00", "error_desc": "Success"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Form: url.Values{
-					"action":  {"send_single"},
-					"mobile":  {"250788383383"},
-					"message": {"Simple Message ☺\nhttps://foo.bar/image.jpg"},
-					"channel": {"hash123"},
-				},
-			},
-		},
-		ExpectedExtIDs: []string{"5b8fc97d58795484819426"},
-	},
-	{
-		Label:   "Invalid JSON",
-		MsgText: "Invalid XML",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://mx2.i2sms.net/mxapi.php": {
-				httpx.NewMockResponse(200, nil, []byte(`not json`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Form: url.Values{
-					"action":  {"send_single"},
-					"mobile":  {"250788383383"},
-					"message": {"Invalid XML"},
-					"channel": {"hash123"},
-				},
-			},
-		},
-		ExpectedError: channels.ErrResponseUnparseable,
-	},
-	{
-		Label:   "Error Response",
-		MsgText: "Error Response",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://mx2.i2sms.net/mxapi.php": {
-				httpx.NewMockResponse(200, nil, []byte(`{"result":{}, "error_code": "10", "error_desc": "Failed"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Form: url.Values{
-					"action":  {"send_single"},
-					"mobile":  {"250788383383"},
-					"message": {"Error Response"},
-					"channel": {"hash123"},
-				},
-			},
-		},
-		ExpectedError: channels.ErrFailedWithReason("10", "Failed"),
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://mx2.i2sms.net/mxapi.php": {
-				httpx.NewMockResponse(501, nil, []byte(`Bad Gateway`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Form: url.Values{
-					"action":  {"send_single"},
-					"mobile":  {"250788383383"},
-					"message": {"Error Message"},
-					"channel": {"hash123"},
-				},
-			},
-		},
-		ExpectedError: channels.ErrConnectionFailed,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://mx2.i2sms.net/mxapi.php": {
-				httpx.NewMockResponse(429, nil, []byte(`Bad Gateway`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Form: url.Values{
-					"action":  {"send_single"},
-					"mobile":  {"250788383383"},
-					"message": {"Error Message"},
-					"channel": {"hash123"},
-				},
-			},
-		},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "I2", "2020", "US",
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "I2", "2020", "US",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
 			models.ConfigUsername: "user1",
 			models.ConfigPassword: "pass1",
 			configChannelHash:     "hash123",
 		})
-	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{httpx.BasicAuth("user1", "pass1"), "hash123"}, nil)
+
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{httpx.BasicAuth("user1", "pass1"), "hash123"}})
 }

--- a/handlers/i2sms/testdata/incoming.json
+++ b/handlers/i2sms/testdata/incoming.json
@@ -1,0 +1,48 @@
+[
+    {
+        "label": "Receive Valid",
+        "url": "/c/i2/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "message=Msg\u0026mobile=254791541111",
+        "response": {
+            "status": 200
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+254791541111",
+                "text": "Msg",
+                "created_on": "2025-11-19T17:20:03Z",
+                "received_on": "2025-11-19T17:20:05Z",
+                "log_uuids": [
+                    "019a9d21-5de8-7000-a1e4-7638cffc03a6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Missing Number",
+        "url": "/c/i2/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "message=Msg",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing required field 'mobile'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/i2sms/testdata/outgoing.json
+++ b/handlers/i2sms/testdata/outgoing.json
@@ -1,0 +1,260 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message ☺",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "https://mx2.i2sms.net/mxapi.php": [
+                {
+                    "status": 200,
+                    "body": {
+                        "result": {
+                            "session_id": "5b8fc97d58795484819426"
+                        },
+                        "error_code": "00",
+                        "error_desc": "Success"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://mx2.i2sms.net/mxapi.php",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic dXNlcjE6cGFzczE=",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "action": [
+                        "send_single"
+                    ],
+                    "channel": [
+                        "hash123"
+                    ],
+                    "message": [
+                        "Simple Message ☺\nhttps://foo.bar/image.jpg"
+                    ],
+                    "mobile": [
+                        "250788383383"
+                    ]
+                }
+            }
+        ],
+        "external_ids": [
+            "5b8fc97d58795484819426"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Invalid JSON",
+        "msg": {
+            "text": "Invalid XML",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://mx2.i2sms.net/mxapi.php": [
+                {
+                    "status": 200,
+                    "body": "not json"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://mx2.i2sms.net/mxapi.php",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic dXNlcjE6cGFzczE=",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "action": [
+                        "send_single"
+                    ],
+                    "channel": [
+                        "hash123"
+                    ],
+                    "message": [
+                        "Invalid XML"
+                    ],
+                    "mobile": [
+                        "250788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response couldn't be parsed",
+            "loggable": true,
+            "log_error": {
+                "code": "response_unparseable",
+                "message": "Response could not be parsed in the expected format."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Response",
+        "msg": {
+            "text": "Error Response",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://mx2.i2sms.net/mxapi.php": [
+                {
+                    "status": 200,
+                    "body": {
+                        "result": {},
+                        "error_code": "10",
+                        "error_desc": "Failed"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://mx2.i2sms.net/mxapi.php",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic dXNlcjE6cGFzczE=",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "action": [
+                        "send_single"
+                    ],
+                    "channel": [
+                        "hash123"
+                    ],
+                    "message": [
+                        "Error Response"
+                    ],
+                    "mobile": [
+                        "250788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rejected send with reason",
+            "log_error": {
+                "code": "rejected_with_reason",
+                "ext_code": "10",
+                "message": "Failed"
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://mx2.i2sms.net/mxapi.php": [
+                {
+                    "status": 501,
+                    "body": "Bad Gateway"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://mx2.i2sms.net/mxapi.php",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic dXNlcjE6cGFzczE=",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "action": [
+                        "send_single"
+                    ],
+                    "channel": [
+                        "hash123"
+                    ],
+                    "message": [
+                        "Error Message"
+                    ],
+                    "mobile": [
+                        "250788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel connection failed",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_failed",
+                "message": "Connection to server failed."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://mx2.i2sms.net/mxapi.php": [
+                {
+                    "status": 429,
+                    "body": "Bad Gateway"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://mx2.i2sms.net/mxapi.php",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic dXNlcjE6cGFzczE=",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "action": [
+                        "send_single"
+                    ],
+                    "channel": [
+                        "hash123"
+                    ],
+                    "message": [
+                        "Error Message"
+                    ],
+                    "mobile": [
+                        "250788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/infobip/handler.go
+++ b/handlers/infobip/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -148,7 +149,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 		}
 
 		// Parse date if provided
-		date := time.Now()
+		date := dates.Now()
 		if dateString != "" {
 			// The format for ReceivedAt is "yyyy-MM-dd'T'HH:mm:ss.SSS+0000"
 			// It is not RFC3339 Compliant

--- a/handlers/jasmin/handler.go
+++ b/handlers/jasmin/handler.go
@@ -8,12 +8,12 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/gsm7"
 	"github.com/nyaruka/gocommon/urns"
 	"golang.org/x/text/encoding/unicode"
@@ -97,7 +97,7 @@ func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http
 	}
 
 	// build our msg
-	msg := models.NewIncomingMsg(c, urn, text, form.ID, clog).WithReceivedOn(time.Now().UTC())
+	msg := models.NewIncomingMsg(c, urn, text, form.ID, clog).WithReceivedOn(dates.Now().UTC())
 
 	in.Msg(msg)
 	return nil

--- a/handlers/justcall/handler.go
+++ b/handlers/justcall/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 )
@@ -98,7 +99,7 @@ func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http
 	}
 
 	dateString := payload.Data.Datetime
-	date := time.Now()
+	date := dates.Now()
 	var err error
 	if dateString != "" {
 		date, err = time.Parse("2006-01-02 15:04:05", dateString)

--- a/handlers/messangi/handler_test.go
+++ b/handlers/messangi/handler_test.go
@@ -3,137 +3,24 @@ package messangi
 import (
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MG", "2020", "JM", []string{urns.Phone.Prefix}, nil),
-}
-
-const (
-	receiveURL = "/c/mg/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-)
-
-var testCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid",
-		URL:                  receiveURL,
-		Data:                 "mo=Msg&mobile=18765422035",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Message Accepted",
-		ExpectedMsgText:      Sp("Msg"),
-		ExpectedURN:          "tel:+18765422035"},
-	{
-		Label:                "Receive Missing Number",
-		URL:                  receiveURL,
-		Data:                 "mo=Msg",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "required field 'mobile'"},
-}
-
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, testCases)
-}
+	chs := []*models.Channel{
+		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MG", "2020", "JM", []string{urns.Phone.Prefix}, nil),
+	}
 
-var defaultSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message ☺",
-		MsgURN:  "tel:+18765422035",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://flow.messangi.me/mmc/rest/api/sendMT/*": {
-				httpx.NewMockResponse(200, nil, []byte(`<response><input>sendMT</input><status>OK</status><description>Completed</description></response>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Path: "/mmc/rest/api/sendMT/7/2020/2/18765422035/U2ltcGxlIE1lc3NhZ2Ug4pi6/my-public-key/f69bc6a924480d3ed82970d9679c4be90589bd3064add51c47e8bf50a211d55f",
-		}},
-	},
-	{
-		Label:   "Long Send",
-		MsgText: "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, I need to keep adding more things to make it work",
-		MsgURN:  "tel:+18765422035",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://flow.messangi.me/mmc/rest/api/sendMT/*": {
-				httpx.NewMockResponse(200, nil, []byte(`<response><input>sendMT</input><status>OK</status><description>Completed</description></response>`)),
-				httpx.NewMockResponse(200, nil, []byte(`<response><input>sendMT</input><status>OK</status><description>Completed</description></response>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Path: "/mmc/rest/api/sendMT/7/2020/2/18765422035/VGhpcyBpcyBhIGxvbmdlciBtZXNzYWdlIHRoYW4gMTYwIGNoYXJhY3RlcnMgYW5kIHdpbGwgY2F1c2UgdXMgdG8gc3BsaXQgaXQgaW50byB0d28gc2VwYXJhdGUgcGFydHMsIGlzbid0IHRoYXQgcmlnaHQgYnV0IGl0IGlzIGV2ZW4gbG9uZ2VyIHRoYW4gYmVmb3JlIEkgc2F5LA/my-public-key/48c658e8db8635843ac3d3e497a81cf79cc0d75b8630dae03c6e7d93a749ab90",
-			},
-			{
-				Path: "/mmc/rest/api/sendMT/7/2020/2/18765422035/SSBuZWVkIHRvIGtlZXAgYWRkaW5nIG1vcmUgdGhpbmdzIHRvIG1ha2UgaXQgd29yaw/my-public-key/ba305915a6cf56c1255071655de42b4408071460317bb5bf3419bb9f865c5078",
-			},
-		},
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+18765422035",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://flow.messangi.me/mmc/rest/api/sendMT/*": {
-				httpx.NewMockResponse(200, nil, []byte(`<response><input>sendMT</input><status>OK</status><description>Completed</description></response>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Path: "/mmc/rest/api/sendMT/7/2020/2/18765422035/TXkgcGljIQpodHRwczovL2Zvby5iYXIvaW1hZ2UuanBn/my-public-key/4babdf316c0b5c7b6b40855329b421b1da1b8e63690d59eb5c231049dc4067fd",
-		}},
-	},
-	{
-		Label:   "Invalid Parameters",
-		MsgText: "Invalid Parameters",
-		MsgURN:  "tel:+18765422035",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://flow.messangi.me/mmc/rest/api/sendMT/*": {
-				httpx.NewMockResponse(404, nil, []byte(``)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Path: "/mmc/rest/api/sendMT/7/2020/2/18765422035/SW52YWxpZCBQYXJhbWV0ZXJz/my-public-key/f3d2ea825cf61226925dee2db3c14b7fc00f3183f11809d2183d1e2dbd230df6",
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Invalid Parameters",
-		MsgURN:  "tel:+18765422035",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://flow.messangi.me/mmc/rest/api/sendMT/*": {
-				httpx.NewMockResponse(429, nil, []byte(``)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Path: "/mmc/rest/api/sendMT/7/2020/2/18765422035/SW52YWxpZCBQYXJhbWV0ZXJz/my-public-key/f3d2ea825cf61226925dee2db3c14b7fc00f3183f11809d2183d1e2dbd230df6",
-		}},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
-	{
-		Label:   "Error Response",
-		MsgText: "Error Response",
-		MsgURN:  "tel:+18765422035",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://flow.messangi.me/mmc/rest/api/sendMT/*": {
-				httpx.NewMockResponse(200, nil, []byte(`<response><input>sendMT</input><status>ERROR</status><description>Completed</description></response>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Path: "/mmc/rest/api/sendMT/7/2020/2/18765422035/RXJyb3IgUmVzcG9uc2U/my-public-key/27f4c67fa00848ea6029cc0b1797aae6d05e2970ecb6e44ca486b463b933e61a",
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
 	maxMsgLength = 160
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MG", "2020", "JM",
+
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MG", "2020", "JM",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
 			"public_key":  "my-public-key",
@@ -141,5 +28,6 @@ func TestOutgoing(t *testing.T) {
 			"instance_id": 7,
 			"carrier_id":  2,
 		})
-	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"my-private-key"}, nil)
+
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"my-private-key"}})
 }

--- a/handlers/messangi/testdata/incoming.json
+++ b/handlers/messangi/testdata/incoming.json
@@ -1,0 +1,61 @@
+[
+    {
+        "label": "Receive Valid",
+        "url": "/c/mg/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "mo=Msg\u0026mobile=18765422035",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                        "text": "Msg",
+                        "urn": "tel:+18765422035",
+                        "received_on": "2025-11-19T17:20:05Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+18765422035",
+                "text": "Msg",
+                "created_on": "2025-11-19T17:20:03Z",
+                "received_on": "2025-11-19T17:20:05Z",
+                "log_uuids": [
+                    "019a9d21-5de8-7000-a1e4-7638cffc03a6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Missing Number",
+        "url": "/c/mg/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "mo=Msg",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing required field 'mobile'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/messangi/testdata/outgoing.json
+++ b/handlers/messangi/testdata/outgoing.json
@@ -1,0 +1,188 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message ☺",
+            "urn": "tel:+18765422035"
+        },
+        "http_mocks": {
+            "https://flow.messangi.me/mmc/rest/api/sendMT/*": [
+                {
+                    "status": 200,
+                    "body": "<response><input>sendMT</input><status>OK</status><description>Completed</description></response>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/U2ltcGxlIE1lc3NhZ2Ug4pi6/my-public-key/f69bc6a924480d3ed82970d9679c4be90589bd3064add51c47e8bf50a211d55f",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Long Send",
+        "msg": {
+            "text": "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, I need to keep adding more things to make it work",
+            "urn": "tel:+18765422035"
+        },
+        "http_mocks": {
+            "https://flow.messangi.me/mmc/rest/api/sendMT/*": [
+                {
+                    "status": 200,
+                    "body": "<response><input>sendMT</input><status>OK</status><description>Completed</description></response>"
+                },
+                {
+                    "status": 200,
+                    "body": "<response><input>sendMT</input><status>OK</status><description>Completed</description></response>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/VGhpcyBpcyBhIGxvbmdlciBtZXNzYWdlIHRoYW4gMTYwIGNoYXJhY3RlcnMgYW5kIHdpbGwgY2F1c2UgdXMgdG8gc3BsaXQgaXQgaW50byB0d28gc2VwYXJhdGUgcGFydHMsIGlzbid0IHRoYXQgcmlnaHQgYnV0IGl0IGlzIGV2ZW4gbG9uZ2VyIHRoYW4gYmVmb3JlIEkgc2F5LA/my-public-key/48c658e8db8635843ac3d3e497a81cf79cc0d75b8630dae03c6e7d93a749ab90",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            },
+            {
+                "method": "GET",
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/SSBuZWVkIHRvIGtlZXAgYWRkaW5nIG1vcmUgdGhpbmdzIHRvIG1ha2UgaXQgd29yaw/my-public-key/ba305915a6cf56c1255071655de42b4408071460317bb5bf3419bb9f865c5078",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+18765422035",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "https://flow.messangi.me/mmc/rest/api/sendMT/*": [
+                {
+                    "status": 200,
+                    "body": "<response><input>sendMT</input><status>OK</status><description>Completed</description></response>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/TXkgcGljIQpodHRwczovL2Zvby5iYXIvaW1hZ2UuanBn/my-public-key/4babdf316c0b5c7b6b40855329b421b1da1b8e63690d59eb5c231049dc4067fd",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Invalid Parameters",
+        "msg": {
+            "text": "Invalid Parameters",
+            "urn": "tel:+18765422035"
+        },
+        "http_mocks": {
+            "https://flow.messangi.me/mmc/rest/api/sendMT/*": [
+                {
+                    "status": 404,
+                    "body": ""
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/SW52YWxpZCBQYXJhbWV0ZXJz/my-public-key/f3d2ea825cf61226925dee2db3c14b7fc00f3183f11809d2183d1e2dbd230df6",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Invalid Parameters",
+            "urn": "tel:+18765422035"
+        },
+        "http_mocks": {
+            "https://flow.messangi.me/mmc/rest/api/sendMT/*": [
+                {
+                    "status": 429,
+                    "body": ""
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/SW52YWxpZCBQYXJhbWV0ZXJz/my-public-key/f3d2ea825cf61226925dee2db3c14b7fc00f3183f11809d2183d1e2dbd230df6",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Response",
+        "msg": {
+            "text": "Error Response",
+            "urn": "tel:+18765422035"
+        },
+        "http_mocks": {
+            "https://flow.messangi.me/mmc/rest/api/sendMT/*": [
+                {
+                    "status": 200,
+                    "body": "<response><input>sendMT</input><status>ERROR</status><description>Completed</description></response>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/RXJyb3IgUmVzcG9uc2U/my-public-key/27f4c67fa00848ea6029cc0b1797aae6d05e2970ecb6e44ca486b463b933e61a",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/mtarget/handler.go
+++ b/handlers/mtarget/handler.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/buger/jsonparser"
 	"github.com/gomodule/redigo/redis"
@@ -15,6 +14,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -140,7 +140,7 @@ func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http
 		return nil
 	}
 
-	msg := models.NewIncomingMsg(c, urn, text, msgID, clog).WithReceivedOn(time.Now().UTC())
+	msg := models.NewIncomingMsg(c, urn, text, msgID, clog).WithReceivedOn(dates.Now().UTC())
 	in.Msg(msg)
 	return nil
 }

--- a/handlers/novo/handler.go
+++ b/handlers/novo/handler.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"net/url"
-	"time"
 
 	"github.com/buger/jsonparser"
 	"github.com/nyaruka/courier/v26/core/channels"
@@ -15,6 +14,7 @@ import (
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/utils"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -71,7 +71,7 @@ func (h *handler) receiveMessage(ctx context.Context, c *models.Channel, r *http
 		return err
 	}
 
-	msg := models.NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(time.Now().UTC())
+	msg := models.NewIncomingMsg(c, urn, body, "", clog).WithReceivedOn(dates.Now().UTC())
 	in.Msg(msg)
 	return nil
 }

--- a/handlers/novo/handler_test.go
+++ b/handlers/novo/handler_test.go
@@ -1,162 +1,28 @@
 package novo
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "NV", "2020", "TT",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			"merchant_id":     "my-merchant-id",
-			"merchant_secret": "my-merchant-secret",
-			"secret":          "sesame",
-		}),
-}
-
-const (
-	receiveURL = "/c/nv/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-)
-
-var testCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid",
-		URL:                  receiveURL,
-		Headers:              map[string]string{"Authorization": "sesame"},
-		Data:                 "text=Msg&from=18686846481",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Message Accepted",
-		ExpectedMsgText:      Sp("Msg"),
-		ExpectedURN:          "tel:+18686846481",
-	},
-	{
-		Label:                "Receive Missing Number",
-		URL:                  receiveURL,
-		Headers:              map[string]string{"Authorization": "sesame"},
-		Data:                 "text=Msg",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "required field 'from'",
-	},
-	{
-		Label:                "Receive Missing Authorization",
-		URL:                  receiveURL,
-		Data:                 "text=Msg&from=18686846481",
-		ExpectedRespStatus:   401,
-		ExpectedBodyContains: "invalid Authorization header",
-	},
-}
+var testChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "NV", "2020", "TT",
+	[]string{urns.Phone.Prefix},
+	map[string]any{
+		"merchant_id":     "my-merchant-id",
+		"merchant_secret": "my-merchant-secret",
+		"secret":          "sesame",
+	})
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, testCases)
-}
-
-var defaultSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message ☺",
-		MsgURN:  "tel:+18686846481",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": {
-				httpx.NewMockResponse(200, nil, []byte(`{"blastId": "-437733473338","status": "FINISHED","type": "SMS","statusDescription": "Finished"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Params: url.Values{"from": {"2020"}, "to": {"18686846481"}, "msg": {"Simple Message ☺"}, "signature": {"29f1fe56b81979aaf9dfb693b91ad16c87a9303951f38abcc2794501da79fff0"}},
-		}},
-	},
-	{
-		Label:   "Long Send",
-		MsgText: "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, I need to keep adding more things to make it work",
-		MsgURN:  "tel:+18686846481",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": {
-				httpx.NewMockResponse(200, nil, []byte(`{"blastId": "-437733473338","status": "FINISHED","type": "SMS","statusDescription": "Finished"}`)),
-				httpx.NewMockResponse(200, nil, []byte(`{"blastId": "-437733473338","status": "FINISHED","type": "SMS","statusDescription": "Finished"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Params: url.Values{"from": {"2020"}, "to": {"18686846481"}, "msg": {"This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say,"}, "signature": {"974f711ede732846e4d4da9bc95bf9452ae2337d5452c7417a19ed4034afd197"}},
-			},
-			{
-				Params: url.Values{"from": {"2020"}, "to": {"18686846481"}, "msg": {"I need to keep adding more things to make it work"}, "signature": {"d6251beaa3398cb00c9354fd2fa80cc14ff0d9d42f6d6d488ad0f51b0719d89b"}},
-			},
-		},
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+18686846481",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": {
-				httpx.NewMockResponse(200, nil, []byte(`{"blastId": "-437733473338","status": "FINISHED","type": "SMS","statusDescription": "Finished"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Params: url.Values{"from": {"2020"}, "to": {"18686846481"}, "msg": {"My pic!\nhttps://foo.bar/image.jpg"}, "signature": {"77a0feaf9a39e593f3e87d8cd3798e8aeabc1646501df7331c8d3bc3a54277fb"}},
-		}},
-	},
-	{
-		Label:   "Invalid Parameters",
-		MsgText: "Invalid Parameters",
-		MsgURN:  "tel:+18686846481",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": {
-				httpx.NewMockResponse(200, nil, []byte(`{"error": "Incorrect Query String Authentication ","expectedQueryString": "8868;18686846480;test;"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Params: url.Values{"from": {"2020"}, "to": {"18686846481"}, "msg": {"Invalid Parameters"}, "signature": {"4b640a668fd83223e38d429b15ea737ef58e1ab025b756baaca4743f3adb3f77"}},
-		}},
-		ExpectedError: channels.ErrResponseContent,
-	},
-	{
-		Label:   "Error Response",
-		MsgText: "Error Response",
-		MsgURN:  "tel:+18686846481",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": {
-				httpx.NewMockResponse(400, nil, []byte(`{"error": "Incorrect Query String Authentication ","expectedQueryString": "8868;18686846480;test;"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Params: url.Values{"from": {"2020"}, "to": {"18686846481"}, "msg": {"Error Response"}, "signature": {"9fe49f073109de29f8c6d5108fd5719ee0b70c22cedb23fffdbabc8a99b9a0a9"}},
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Response",
-		MsgURN:  "tel:+18686846481",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": {
-				httpx.NewMockResponse(429, nil, []byte(`{"error": "Incorrect Query String Authentication ","expectedQueryString": "8868;18686846480;test;"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Params: url.Values{"from": {"2020"}, "to": {"18686846481"}, "msg": {"Error Response"}, "signature": {"9fe49f073109de29f8c6d5108fd5719ee0b70c22cedb23fffdbabc8a99b9a0a9"}},
-		}},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
+	RunIncomingTests(t, []*models.Channel{testChannel}, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
 	maxMsgLength = 160
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "NV", "2020", "TT",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			"merchant_id":     "my-merchant-id",
-			"merchant_secret": "my-merchant-secret",
-			"secret":          "sesame",
-		})
-	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"my-merchant-secret", "sesame"}, nil)
+
+	RunOutgoingTests(t, testChannel, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"my-merchant-secret", "sesame"}})
 }

--- a/handlers/novo/testdata/incoming.json
+++ b/handlers/novo/testdata/incoming.json
@@ -1,0 +1,88 @@
+[
+    {
+        "label": "Receive Valid",
+        "url": "/c/nv/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "headers": {
+            "Authorization": "sesame"
+        },
+        "data": "text=Msg\u0026from=18686846481",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                        "text": "Msg",
+                        "urn": "tel:+18686846481",
+                        "received_on": "2025-11-19T17:20:05Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+18686846481",
+                "text": "Msg",
+                "created_on": "2025-11-19T17:20:03Z",
+                "received_on": "2025-11-19T17:20:05Z",
+                "log_uuids": [
+                    "019a9d21-5de8-7000-a1e4-7638cffc03a6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Missing Number",
+        "url": "/c/nv/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "headers": {
+            "Authorization": "sesame"
+        },
+        "data": "text=Msg",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing required field 'from'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Missing Authorization",
+        "url": "/c/nv/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "text=Msg\u0026from=18686846481",
+        "response": {
+            "status": 401,
+            "body": {
+                "message": "Unauthorized",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "invalid Authorization header"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/novo/testdata/outgoing.json
+++ b/handlers/novo/testdata/outgoing.json
@@ -1,0 +1,217 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message ☺",
+            "urn": "tel:+18686846481"
+        },
+        "http_mocks": {
+            "http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": [
+                {
+                    "status": 200,
+                    "body": {
+                        "blastId": "-437733473338",
+                        "status": "FINISHED",
+                        "type": "SMS",
+                        "statusDescription": "Finished"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Simple+Message+%E2%98%BA&signature=29f1fe56b81979aaf9dfb693b91ad16c87a9303951f38abcc2794501da79fff0&to=18686846481",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Long Send",
+        "msg": {
+            "text": "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, I need to keep adding more things to make it work",
+            "urn": "tel:+18686846481"
+        },
+        "http_mocks": {
+            "http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": [
+                {
+                    "status": 200,
+                    "body": {
+                        "blastId": "-437733473338",
+                        "status": "FINISHED",
+                        "type": "SMS",
+                        "statusDescription": "Finished"
+                    }
+                },
+                {
+                    "status": 200,
+                    "body": {
+                        "blastId": "-437733473338",
+                        "status": "FINISHED",
+                        "type": "SMS",
+                        "statusDescription": "Finished"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=This+is+a+longer+message+than+160+characters+and+will+cause+us+to+split+it+into+two+separate+parts%2C+isn%27t+that+right+but+it+is+even+longer+than+before+I+say%2C&signature=974f711ede732846e4d4da9bc95bf9452ae2337d5452c7417a19ed4034afd197&to=18686846481",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            },
+            {
+                "method": "GET",
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=I+need+to+keep+adding+more+things+to+make+it+work&signature=d6251beaa3398cb00c9354fd2fa80cc14ff0d9d42f6d6d488ad0f51b0719d89b&to=18686846481",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+18686846481",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": [
+                {
+                    "status": 200,
+                    "body": {
+                        "blastId": "-437733473338",
+                        "status": "FINISHED",
+                        "type": "SMS",
+                        "statusDescription": "Finished"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&signature=77a0feaf9a39e593f3e87d8cd3798e8aeabc1646501df7331c8d3bc3a54277fb&to=18686846481",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Invalid Parameters",
+        "msg": {
+            "text": "Invalid Parameters",
+            "urn": "tel:+18686846481"
+        },
+        "http_mocks": {
+            "http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": [
+                {
+                    "status": 200,
+                    "body": {
+                        "error": "Incorrect Query String Authentication ",
+                        "expectedQueryString": "8868;18686846480;test;"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Invalid+Parameters&signature=4b640a668fd83223e38d429b15ea737ef58e1ab025b756baaca4743f3adb3f77&to=18686846481",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "response content",
+            "log_error": {
+                "code": "response_content",
+                "message": "Response content indicates non-success."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Response",
+        "msg": {
+            "text": "Error Response",
+            "urn": "tel:+18686846481"
+        },
+        "http_mocks": {
+            "http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": [
+                {
+                    "status": 400,
+                    "body": {
+                        "error": "Incorrect Query String Authentication ",
+                        "expectedQueryString": "8868;18686846480;test;"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Error+Response&signature=9fe49f073109de29f8c6d5108fd5719ee0b70c22cedb23fffdbabc8a99b9a0a9&to=18686846481",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Response",
+            "urn": "tel:+18686846481"
+        },
+        "http_mocks": {
+            "http://novosmstools.com/novo_te/my-merchant-id/sendSMS*": [
+                {
+                    "status": 429,
+                    "body": {
+                        "error": "Incorrect Query String Authentication ",
+                        "expectedQueryString": "8868;18686846480;test;"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Error+Response&signature=9fe49f073109de29f8c6d5108fd5719ee0b70c22cedb23fffdbabc8a99b9a0a9&to=18686846481",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/smscentral/handler_test.go
+++ b/handlers/smscentral/handler_test.go
@@ -1,152 +1,31 @@
 package smscentral
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-const (
-	receiveURL = "/c/sc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive"
-)
-
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "SC", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{"username": "Username", "password": "Password"}),
-}
-
-var handleTestCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid Message",
-		URL:                  receiveURL,
-		Data:                 "mobile=%2B2349067554729&message=Join",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2349067554729",
-	},
-	{
-		Label:                "Receive No Message",
-		URL:                  receiveURL,
-		Data:                 "mobile=%2B2349067554729",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp(""),
-		ExpectedURN:          "tel:+2349067554729",
-	},
-	{
-		Label:                "Receive invalid URN",
-		URL:                  receiveURL,
-		Data:                 "mobile=MTN&message=Join",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "not a possible number",
-	},
-	{
-		Label:                "Receive No Params",
-		URL:                  receiveURL,
-		Data:                 "none",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "field 'mobile' required",
-	},
-	{
-		Label:                "Receive No Sender",
-		URL:                  receiveURL,
-		Data:                 "message=Join",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "field 'mobile' required",
-	},
-}
-
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
-}
+	chs := []*models.Channel{
+		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "SC", "2020", "US",
+			[]string{urns.Phone.Prefix},
+			map[string]any{"username": "Username", "password": "Password"}),
+	}
 
-var defaultSendTestCases = []OutgoingTestCase{
-	{Label: "Plain Send",
-		MsgText: "Simple Message", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smail.smscentral.com.np/bp/ApiSms.php": {
-				httpx.NewMockResponse(200, nil, []byte(`[{"id": "1002"}]`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form: url.Values{"content": {"Simple Message"}, "mobile": {"250788383383"}, "pass": {"Password"}, "user": {"Username"}},
-		}},
-	},
-	{Label: "Unicode Send",
-		MsgText: "☺", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smail.smscentral.com.np/bp/ApiSms.php": {
-				httpx.NewMockResponse(200, nil, []byte(`[{"id": "1002"}]`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form: url.Values{"content": {"☺"}, "mobile": {"250788383383"}, "pass": {"Password"}, "user": {"Username"}},
-		}},
-	},
-	{Label: "Send Attachment",
-		MsgText: "My pic!", MsgURN: "tel:+250788383383", MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smail.smscentral.com.np/bp/ApiSms.php": {
-				httpx.NewMockResponse(200, nil, []byte(`[{"id": "1002"}]`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form: url.Values{"content": {"My pic!\nhttps://foo.bar/image.jpg"}, "mobile": {"250788383383"}, "pass": {"Password"}, "user": {"Username"}},
-		}},
-	},
-	{Label: "Error Sending",
-		MsgText: "Error Message", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smail.smscentral.com.np/bp/ApiSms.php": {
-				httpx.NewMockResponse(401, nil, []byte(`{ "error": "failed" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form: url.Values{"content": {`Error Message`}, "mobile": {"250788383383"}, "pass": {"Password"}, "user": {"Username"}},
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{Label: "Throttled",
-		MsgText: "Error Message", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smail.smscentral.com.np/bp/ApiSms.php": {
-				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form: url.Values{"content": {`Error Message`}, "mobile": {"250788383383"}, "pass": {"Password"}, "user": {"Username"}},
-		}},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
-	{Label: "Connection Error",
-		MsgText: "Error Message", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smail.smscentral.com.np/bp/ApiSms.php": {
-				httpx.NewMockResponse(500, nil, []byte(`{ "error": "failed" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form: url.Values{"content": {`Error Message`}, "mobile": {"250788383383"}, "pass": {"Password"}, "user": {"Username"}},
-		}},
-		ExpectedError: channels.ErrConnectionFailed,
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "SC", "2020", "US",
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "SC", "2020", "US",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
 			models.ConfigPassword: "Password",
 			models.ConfigUsername: "Username",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Password"}, nil)
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"Password"}})
 }

--- a/handlers/smscentral/testdata/incoming.json
+++ b/handlers/smscentral/testdata/incoming.json
@@ -1,0 +1,149 @@
+[
+    {
+        "label": "Receive Valid Message",
+        "url": "/c/sc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive",
+        "data": "mobile=%2B2349067554729\u0026message=Join",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d240-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-11-01T05:43:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d240-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-11-01T05:43:03Z",
+                "received_on": "2025-11-01T05:43:03Z",
+                "log_uuids": [
+                    "019a3df0-c688-7000-aac1-d0d96ed17383"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No Message",
+        "url": "/c/sc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive",
+        "data": "mobile=%2B2349067554729",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019af9bc-13e0-7000-973c-3620ab19cfd5",
+                        "text": "",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-12-07T16:54:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019af9bc-13e0-7000-973c-3620ab19cfd5",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "",
+                "created_on": "2025-12-07T16:54:03Z",
+                "received_on": "2025-12-07T16:54:03Z",
+                "log_uuids": [
+                    "019af9bc-0828-7000-aad7-5c6bcfe8b5ed"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive invalid URN",
+        "url": "/c/sc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive",
+        "data": "mobile=MTN\u0026message=Join",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "not a possible number"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No Params",
+        "url": "/c/sc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive",
+        "data": "none",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "Key: 'moForm.Mobile' Error:Field validation for 'Mobile' failed on the 'required' tag"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'mobile' required"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No Sender",
+        "url": "/c/sc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive",
+        "data": "message=Join",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "Key: 'moForm.Mobile' Error:Field validation for 'Mobile' failed on the 'required' tag"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'mobile' required"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/smscentral/testdata/outgoing.json
+++ b/handlers/smscentral/testdata/outgoing.json
@@ -1,0 +1,286 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smail.smscentral.com.np/bp/ApiSms.php": [
+                {
+                    "status": 200,
+                    "body": [
+                        {
+                            "id": "1002"
+                        }
+                    ]
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "content": [
+                        "Simple Message"
+                    ],
+                    "mobile": [
+                        "250788383383"
+                    ],
+                    "pass": [
+                        "Password"
+                    ],
+                    "user": [
+                        "Username"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smail.smscentral.com.np/bp/ApiSms.php": [
+                {
+                    "status": 200,
+                    "body": [
+                        {
+                            "id": "1002"
+                        }
+                    ]
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "content": [
+                        "☺"
+                    ],
+                    "mobile": [
+                        "250788383383"
+                    ],
+                    "pass": [
+                        "Password"
+                    ],
+                    "user": [
+                        "Username"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://smail.smscentral.com.np/bp/ApiSms.php": [
+                {
+                    "status": 200,
+                    "body": [
+                        {
+                            "id": "1002"
+                        }
+                    ]
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "content": [
+                        "My pic!\nhttps://foo.bar/image.jpg"
+                    ],
+                    "mobile": [
+                        "250788383383"
+                    ],
+                    "pass": [
+                        "Password"
+                    ],
+                    "user": [
+                        "Username"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smail.smscentral.com.np/bp/ApiSms.php": [
+                {
+                    "status": 401,
+                    "body": {
+                        "error": "failed"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "content": [
+                        "Error Message"
+                    ],
+                    "mobile": [
+                        "250788383383"
+                    ],
+                    "pass": [
+                        "Password"
+                    ],
+                    "user": [
+                        "Username"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smail.smscentral.com.np/bp/ApiSms.php": [
+                {
+                    "status": 429,
+                    "body": {
+                        "error": "failed"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "content": [
+                        "Error Message"
+                    ],
+                    "mobile": [
+                        "250788383383"
+                    ],
+                    "pass": [
+                        "Password"
+                    ],
+                    "user": [
+                        "Username"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Connection Error",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smail.smscentral.com.np/bp/ApiSms.php": [
+                {
+                    "status": 500,
+                    "body": {
+                        "error": "failed"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "content": [
+                        "Error Message"
+                    ],
+                    "mobile": [
+                        "250788383383"
+                    ],
+                    "pass": [
+                        "Password"
+                    ],
+                    "user": [
+                        "Username"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel connection failed",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_failed",
+                "message": "Connection to server failed."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/yo/handler.go
+++ b/handlers/yo/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/handlers"
 	"github.com/nyaruka/courier/v26/runtime"
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/urns"
 )
 
@@ -68,7 +69,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel *models.Channel, r
 		dateString = form.Time
 	}
 
-	date := time.Now()
+	date := dates.Now()
 	if dateString != "" {
 		var err error
 		date, err = time.Parse(time.RFC3339Nano, dateString)


### PR DESCRIPTION
## Summary

Converts the tests of six simple SMS handlers (arabiacell, messangi, smscentral, novo, i2sms and burstsms) to the file-based case format introduced in #1167. Along the way, handlers that stamped incoming messages with the wall clock are switched to the mockable clock so the received time is stable in recorded outcomes.

## Changes

**Converted handlers** (`handlers/{arabiacell,messangi,smscentral,novo,i2sms,burstsms}/`)
- Cases moved to `testdata/incoming.json` and `testdata/outgoing.json`; each `handler_test.go` is now just the channel definitions and the runner calls. Messangi and novo keep their one-line max message length override in Go.
- 791 lines of Go test cases replaced by 58.

**Mockable clock for received time** (`handlers/generic.go` and nine handlers)
- The generic receive helper and the external, firebase, highconnection, infobip, jasmin, justcall, mtarget, novo and yo handlers used `time.Now()` for the received time of an incoming message when the provider doesn't supply one. They now use `dates.Now()`, which is the wall clock outside tests and the mocked clock inside them. Without this the recorded `received_on` changed on every run. No behaviour change in production.

## Test plan

- [x] Every recorded outcome reviewed against the expectations in the old Go cases; all match, including novo's query-string signatures and messangi's URL-embedded hashes
- [x] Each converted handler passes with and without `-update`, and a second run confirms the files are stable
- [x] Full `go test -p=1 ./...` passes in the devcontainer, including the legacy tests of the handlers whose clock source changed
- [x] `go vet ./...` and `gofmt` clean