### PR TITLE
Convert ten more simple handlers' tests to JSON case files

### DIFF
--- a/handlers/dart/handler_test.go
+++ b/handlers/dart/handler_test.go
@@ -1,206 +1,31 @@
 package dart
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var daTestChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "DA", "2020", "ID", []string{urns.Phone.Prefix}, nil),
-}
-
-const (
-	receiveURL = "/c/da/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-	statusURL  = "/c/da/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered/"
-)
-
-var daTestCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid",
-		URL:                  receiveURL + "?userid=testusr&password=test&original=6289881134560&sendto=2020&message=Msg&messageid=foo",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "000",
-		ExpectedMsgText:      Sp("Msg"),
-		ExpectedURN:          "tel:+6289881134560",
-		ExpectedExternalID:   "foo",
-	},
-	{
-		Label:                "Receive Valid",
-		URL:                  receiveURL + "?userid=testusr&password=test&original=cmp-oodddqddwdwdcd&sendto=2020&message=Msg&messageid=bar",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "000",
-		ExpectedMsgText:      Sp("Msg"),
-		ExpectedURN:          "ext:cmp-oodddqddwdwdcd",
-		ExpectedExternalID:   "bar",
-	},
-	{
-		Label:                "Receive Invalid",
-		URL:                  receiveURL,
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "missing required parameters original and sendto",
-	},
-
-	{
-		Label:                "Valid Status",
-		URL:                  statusURL + "?status=10&messageid=019a0719-ac96-7eb9-a837-cac215164834",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "000",
-		ExpectedStatuses:     []ExpectedStatus{{MsgUUID: "019a0719-ac96-7eb9-a837-cac215164834", Status: models.MsgStatusDelivered}},
-	},
-	{
-		Label:                "Valid Status",
-		URL:                  statusURL + "?status=10&messageid=019a0719-ac96-7eb9-a837-cac215164834.2",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "000",
-		ExpectedStatuses:     []ExpectedStatus{{MsgUUID: "019a0719-ac96-7eb9-a837-cac215164834", Status: models.MsgStatusDelivered}},
-	},
-	{
-		Label:                "Failed Status",
-		URL:                  statusURL + "?status=30&messageid=019a0719-ac96-7eb9-a837-cac215164834",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "000",
-		ExpectedStatuses:     []ExpectedStatus{{MsgUUID: "019a0719-ac96-7eb9-a837-cac215164834", Status: models.MsgStatusFailed}},
-	},
-	{
-		Label:                "Missing Status",
-		URL:                  statusURL + "?messageid=019a0719-ac96-7eb9-a837-cac215164834",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "parameters messageid and status should not be empty",
-	},
-	{
-		Label:                "Missing Status",
-		URL:                  statusURL + "?status=foo&messageid=019a0719-ac96-7eb9-a837-cac215164834",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "parsing failed: status 'foo' is not an integer",
-	},
-	{
-		Label:                "Missing Status",
-		URL:                  statusURL + "?status=10&messageid=abc",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "parsing failed: messageid 'abc' is not a UUID",
-	},
-}
-
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, daTestChannels, NewHandler("DA", "DartMedia", sendURL, maxMsgLength), daTestCases)
-}
+	chs := []*models.Channel{
+		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "DA", "2020", "ID", []string{urns.Phone.Prefix}, nil),
+	}
 
-var defaultSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://202.43.169.11/APIhttpU/receive2waysms.php*": {
-				httpx.NewMockResponse(200, nil, []byte(`000`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{Params: url.Values{"message": {"Simple Message"}, "sendto": {"250788383383"}, "original": {"2020"}, "userid": {"Username"}, "password": {"Password"}, "dcs": {"0"}, "udhl": {"0"}, "messageid": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}}},
-		},
-	},
-	{
-		Label:   "Long Send",
-		MsgText: "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, I need to keep adding more things to make it work",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://202.43.169.11/APIhttpU/receive2waysms.php*": {
-				httpx.NewMockResponse(200, nil, []byte(`000`)),
-				httpx.NewMockResponse(200, nil, []byte(`000`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{Params: url.Values{"message": {"This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say,"}, "sendto": {"250788383383"}, "original": {"2020"}, "userid": {"Username"}, "password": {"Password"}, "dcs": {"0"}, "udhl": {"0"}, "messageid": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}}},
-			{Params: url.Values{"message": {"I need to keep adding more things to make it work"}, "sendto": {"250788383383"}, "original": {"2020"}, "userid": {"Username"}, "password": {"Password"}, "dcs": {"0"}, "udhl": {"0"}, "messageid": {"0191e180-7d60-7000-aded-7d8b151cbd5b.2"}}},
-		},
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://202.43.169.11/APIhttpU/receive2waysms.php*": {
-				httpx.NewMockResponse(200, nil, []byte(`000`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{Params: url.Values{"message": {"My pic!\nhttps://foo.bar/image.jpg"}, "sendto": {"250788383383"}, "original": {"2020"}, "userid": {"Username"}, "password": {"Password"}, "dcs": {"0"}, "udhl": {"0"}, "messageid": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}}},
-		},
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://202.43.169.11/APIhttpU/receive2waysms.php*": {
-				httpx.NewMockResponse(400, nil, []byte(`Error`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{Params: url.Values{"message": {"Error Message"}, "sendto": {"250788383383"}, "original": {"2020"}, "userid": {"Username"}, "password": {"Password"}, "dcs": {"0"}, "udhl": {"0"}, "messageid": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}}},
-		},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://202.43.169.11/APIhttpU/receive2waysms.php*": {
-				httpx.NewMockResponse(429, nil, []byte(`Error`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{Params: url.Values{"message": {"Error Message"}, "sendto": {"250788383383"}, "original": {"2020"}, "userid": {"Username"}, "password": {"Password"}, "dcs": {"0"}, "udhl": {"0"}, "messageid": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}}},
-		},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
-	{
-		Label:   "Authentication Error",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://202.43.169.11/APIhttpU/receive2waysms.php*": {
-				httpx.NewMockResponse(200, nil, []byte(`001`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{Params: url.Values{"message": {"Simple Message"}, "sendto": {"250788383383"}, "original": {"2020"}, "userid": {"Username"}, "password": {"Password"}, "dcs": {"0"}, "udhl": {"0"}, "messageid": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}}},
-		},
-		ExpectedError: channels.ErrFailedWithReason("001", "Authentication error."),
-	},
-	{
-		Label:   "Account Expired",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://202.43.169.11/APIhttpU/receive2waysms.php*": {
-				httpx.NewMockResponse(200, nil, []byte(`101`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{Params: url.Values{"message": {"Simple Message"}, "sendto": {"250788383383"}, "original": {"2020"}, "userid": {"Username"}, "password": {"Password"}, "dcs": {"0"}, "udhl": {"0"}, "messageid": {"0191e180-7d60-7000-aded-7d8b151cbd5b"}}},
-		},
-		ExpectedError: channels.ErrFailedWithReason("101", "Account expired or invalid parameters."),
-	},
+	RunIncomingTests(t, chs, NewHandler("DA", "DartMedia", sendURL, maxMsgLength), "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
 	maxMsgLength = 160
-	var defaultDAChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "DA", "2020", "ID",
+
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "DA", "2020", "ID",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
 			models.ConfigUsername: "Username",
 			models.ConfigPassword: "Password",
 		})
 
-	RunOutgoingTestCases(t, defaultDAChannel, NewHandler("DA", "Dartmedia", sendURL, maxMsgLength), defaultSendTestCases, []string{"Password"}, nil)
+	RunOutgoingTests(t, ch, NewHandler("DA", "Dartmedia", sendURL, maxMsgLength), "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"Password"}})
 }

--- a/handlers/dart/testdata/incoming.json
+++ b/handlers/dart/testdata/incoming.json
@@ -1,0 +1,197 @@
+[
+    {
+        "label": "Receive Valid",
+        "url": "/c/da/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?userid=testusr&password=test&original=6289881134560&sendto=2020&message=Msg&messageid=foo",
+        "response": {
+            "status": 200,
+            "body": "000"
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+6289881134560",
+                "text": "Msg",
+                "external_id": "foo",
+                "created_on": "2025-11-19T17:20:03Z",
+                "received_on": "2025-11-19T17:20:03Z",
+                "log_uuids": [
+                    "019a9d21-5de8-7000-a1e4-7638cffc03a6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid External ID",
+        "url": "/c/da/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?userid=testusr&password=test&original=cmp-oodddqddwdwdcd&sendto=2020&message=Msg&messageid=bar",
+        "response": {
+            "status": 200,
+            "body": "000"
+        },
+        "msgs": [
+            {
+                "uuid": "019a969b-7da0-7000-ba39-cc51d81df68c",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "ext:cmp-oodddqddwdwdcd",
+                "text": "Msg",
+                "external_id": "bar",
+                "created_on": "2025-11-18T10:56:03Z",
+                "received_on": "2025-11-18T10:56:03Z",
+                "log_uuids": [
+                    "019a969b-71e8-7000-a123-36c8f54670b6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Invalid",
+        "url": "/c/da/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing required parameters original and sendto"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Valid Status",
+        "url": "/c/da/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered/?status=10&messageid=019a0719-ac96-7eb9-a837-cac215164834",
+        "response": {
+            "status": 200,
+            "body": "000"
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "msg_uuid": "019a0719-ac96-7eb9-a837-cac215164834",
+                "status": "D",
+                "log_uuid": "019a9405-84c8-7000-a071-1bb56436b1db"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Valid Status With Part Suffix",
+        "url": "/c/da/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered/?status=10&messageid=019a0719-ac96-7eb9-a837-cac215164834.2",
+        "response": {
+            "status": 200,
+            "body": "000"
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "msg_uuid": "019a0719-ac96-7eb9-a837-cac215164834",
+                "status": "D",
+                "log_uuid": "019a9c0f-9fc8-7000-aee2-3beacb9b6491"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Failed Status",
+        "url": "/c/da/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered/?status=30&messageid=019a0719-ac96-7eb9-a837-cac215164834",
+        "response": {
+            "status": 200,
+            "body": "000"
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "msg_uuid": "019a0719-ac96-7eb9-a837-cac215164834",
+                "status": "F",
+                "log_uuid": "019aee08-6d28-7000-ba9a-8c34955ac51e"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Missing Status",
+        "url": "/c/da/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered/?messageid=019a0719-ac96-7eb9-a837-cac215164834",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "parameters messageid and status should not be empty"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid Status",
+        "url": "/c/da/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered/?status=foo&messageid=019a0719-ac96-7eb9-a837-cac215164834",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "parsing failed: status 'foo' is not an integer"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid Message ID",
+        "url": "/c/da/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered/?status=10&messageid=abc",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "parsing failed: messageid 'abc' is not a UUID"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    }
+]

--- a/handlers/dart/testdata/outgoing.json
+++ b/handlers/dart/testdata/outgoing.json
@@ -1,0 +1,230 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://202.43.169.11/APIhttpU/receive2waysms.php*": [
+                {
+                    "status": 200,
+                    "body": "000"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=Simple+Message&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Long Send",
+        "msg": {
+            "text": "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, I need to keep adding more things to make it work",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://202.43.169.11/APIhttpU/receive2waysms.php*": [
+                {
+                    "status": 200,
+                    "body": "000"
+                },
+                {
+                    "status": 200,
+                    "body": "000"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=This+is+a+longer+message+than+160+characters+and+will+cause+us+to+split+it+into+two+separate+parts%2C+isn%27t+that+right+but+it+is+even+longer+than+before+I+say%2C&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            },
+            {
+                "method": "GET",
+                "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=I+need+to+keep+adding+more+things+to+make+it+work&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b.2&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://202.43.169.11/APIhttpU/receive2waysms.php*": [
+                {
+                    "status": 200,
+                    "body": "000"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://202.43.169.11/APIhttpU/receive2waysms.php*": [
+                {
+                    "status": 400,
+                    "body": "Error"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=Error+Message&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://202.43.169.11/APIhttpU/receive2waysms.php*": [
+                {
+                    "status": 429,
+                    "body": "Error"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=Error+Message&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Authentication Error",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://202.43.169.11/APIhttpU/receive2waysms.php*": [
+                {
+                    "status": 200,
+                    "body": "001"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=Simple+Message&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rejected send with reason",
+            "log_error": {
+                "code": "rejected_with_reason",
+                "ext_code": "001",
+                "message": "Authentication error."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Account Expired",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://202.43.169.11/APIhttpU/receive2waysms.php*": [
+                {
+                    "status": 200,
+                    "body": "101"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=Simple+Message&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rejected send with reason",
+            "log_error": {
+                "code": "rejected_with_reason",
+                "ext_code": "101",
+                "message": "Account expired or invalid parameters."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/dmark/handler_test.go
+++ b/handlers/dmark/handler_test.go
@@ -1,183 +1,28 @@
 package dmark
 
 import (
-	"net/url"
 	"testing"
-	"time"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "DK", "2020", "RW", []string{urns.Phone.Prefix}, nil),
-}
-
-const (
-	receiveURL = "/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-	statusURL  = "/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/"
-)
-
-var testCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid",
-		URL:                  receiveURL,
-		Data:                 "text=Msg&short_code=2020&tstamp=2017-10-26T15:51:32.906335%2B00:00&msisdn=254791541111",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Message Accepted",
-		ExpectedMsgText:      Sp("Msg"),
-		ExpectedURN:          "tel:+254791541111",
-		ExpectedDate:         time.Date(2017, 10, 26, 15, 51, 32, 906335000, time.UTC),
-	},
-	{
-		Label:                "Invalid URN",
-		URL:                  receiveURL,
-		Data:                 "text=Msg&short_code=2020&tstamp=2017-10-26T15:51:32.906335%2B00:00&msisdn=MTN",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "not a possible number",
-	},
-	{
-		Label:                "Receive Empty",
-		URL:                  receiveURL,
-		Data:                 "empty",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "field 'msisdn' required",
-	},
-	{
-		Label:                "Receive Missing Text",
-		URL:                  receiveURL,
-		Data:                 "short_code=2020&tstamp=2017-10-26T15:51:32.906335%2B00:00&msisdn=254791541111",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "field 'text' required",
-	},
-	{
-		Label:                "Receive Invalid TS",
-		URL:                  receiveURL,
-		Data:                 "text=Msg&short_code=2020&tstamp=2017-10-26&msisdn=254791541111",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "invalid tstamp",
-	},
-	{
-		Label:                "Status Invalid",
-		URL:                  statusURL,
-		Data:                 "uuid=019a0719-ac96-7eb9-a837-cac215164834&status=Borked",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "unknown status",
-	},
-	{
-		Label:                "Status Missing",
-		URL:                  statusURL,
-		Data:                 "uuid=019a0719-ac96-7eb9-a837-cac215164834",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "field 'status' required",
-	},
-	{
-		Label:                "Status Valid",
-		URL:                  statusURL,
-		Data:                 "uuid=019a0719-ac96-7eb9-a837-cac215164834&status=1",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"status":"D"`,
-		ExpectedStatuses:     []ExpectedStatus{{MsgUUID: "019a0719-ac96-7eb9-a837-cac215164834", Status: models.MsgStatusDelivered}},
-	},
-}
-
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, testCases)
-}
+	chs := []*models.Channel{
+		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "DK", "2020", "RW", []string{urns.Phone.Prefix}, nil),
+	}
 
-var defaultSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message ☺",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://smsapi1.dmarkmobile.com/sms/": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "type": "MT", "sms_id": "6b1c15d3-cba2-46f7-9a25-78265e58057d" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Authorization": "Token Authy"},
-			Form: url.Values{
-				"text":     {"Simple Message ☺"},
-				"receiver": {"250788383383"},
-				"sender":   {"2020"},
-				"dlr_url":  {"https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%s"},
-			},
-		}},
-		ExpectedExtIDs: []string{"6b1c15d3-cba2-46f7-9a25-78265e58057d"},
-	},
-	{
-		Label:   "Invalid Body",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://smsapi1.dmarkmobile.com/sms/": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "error": "failed" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Authorization": "Token Authy"},
-			Form: url.Values{
-				"text":     {"Error Message"},
-				"receiver": {"250788383383"},
-				"sender":   {"2020"},
-				"dlr_url":  {"https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%s"},
-			},
-		}},
-		ExpectedError: channels.ErrResponseContent,
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://smsapi1.dmarkmobile.com/sms/": {
-				httpx.NewMockResponse(401, nil, []byte(`{ "error": "failed" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Authorization": "Token Authy"},
-			Form: url.Values{
-				"text":     {"Error Message"},
-				"receiver": {"250788383383"},
-				"sender":   {"2020"},
-				"dlr_url":  {"https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%s"},
-			},
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://smsapi1.dmarkmobile.com/sms/": {
-				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Authorization": "Token Authy"},
-			Form: url.Values{
-				"text":     {"Error Message"},
-				"receiver": {"250788383383"},
-				"sender":   {"2020"},
-				"dlr_url":  {"https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%s"},
-			},
-		}},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "DK", "2020", "US",
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "DK", "2020", "US",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
 			models.ConfigAuthToken: "Authy",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Authy"}, nil)
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"Authy"}})
 }

--- a/handlers/dmark/testdata/incoming.json
+++ b/handlers/dmark/testdata/incoming.json
@@ -1,0 +1,221 @@
+[
+    {
+        "label": "Receive Valid",
+        "url": "/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "text=Msg\u0026short_code=2020\u0026tstamp=2017-10-26T15:51:32.906335%2B00:00\u0026msisdn=254791541111",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                        "text": "Msg",
+                        "urn": "tel:+254791541111",
+                        "received_on": "2017-10-26T15:51:32.906335Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+254791541111",
+                "text": "Msg",
+                "created_on": "2025-11-19T17:20:03Z",
+                "received_on": "2017-10-26T15:51:32.906335Z",
+                "log_uuids": [
+                    "019a9d21-5de8-7000-a1e4-7638cffc03a6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid URN",
+        "url": "/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "text=Msg\u0026short_code=2020\u0026tstamp=2017-10-26T15:51:32.906335%2B00:00\u0026msisdn=MTN",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "not a possible number"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Empty",
+        "url": "/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "empty",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "Key: 'moForm.MSISDN' Error:Field validation for 'MSISDN' failed on the 'required' tag\nKey: 'moForm.Text' Error:Field validation for 'Text' failed on the 'required' tag\nKey: 'moForm.ShortCode' Error:Field validation for 'ShortCode' failed on the 'required' tag\nKey: 'moForm.TStamp' Error:Field validation for 'TStamp' failed on the 'required' tag"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'msisdn' required"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'text' required"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'shortcode' required"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'tstamp' required"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Missing Text",
+        "url": "/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "short_code=2020\u0026tstamp=2017-10-26T15:51:32.906335%2B00:00\u0026msisdn=254791541111",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "Key: 'moForm.Text' Error:Field validation for 'Text' failed on the 'required' tag"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'text' required"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Invalid TS",
+        "url": "/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "text=Msg\u0026short_code=2020\u0026tstamp=2017-10-26\u0026msisdn=254791541111",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "invalid tstamp: 2017-10-26"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Status Invalid",
+        "url": "/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/",
+        "data": "uuid=019a0719-ac96-7eb9-a837-cac215164834\u0026status=Borked",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "unknown status 'Borked', must be one of '1', '16', '2', '4', '8'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Status Missing",
+        "url": "/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/",
+        "data": "uuid=019a0719-ac96-7eb9-a837-cac215164834",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "Key: 'statusForm.Status' Error:Field validation for 'Status' failed on the 'required' tag"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'status' required"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Status Valid",
+        "url": "/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/",
+        "data": "uuid=019a0719-ac96-7eb9-a837-cac215164834\u0026status=1",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "D"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "msg_uuid": "019a0719-ac96-7eb9-a837-cac215164834",
+                "status": "D",
+                "log_uuid": "0199f028-0e48-7000-82fd-5b92b67a3e7e"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    }
+]

--- a/handlers/dmark/testdata/outgoing.json
+++ b/handlers/dmark/testdata/outgoing.json
@@ -1,0 +1,204 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message ☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://smsapi1.dmarkmobile.com/sms/": [
+                {
+                    "status": 200,
+                    "body": {
+                        "type": "MT",
+                        "sms_id": "6b1c15d3-cba2-46f7-9a25-78265e58057d"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://smsapi1.dmarkmobile.com/sms/",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Token Authy",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "dlr_url": [
+                        "https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%s"
+                    ],
+                    "receiver": [
+                        "250788383383"
+                    ],
+                    "sender": [
+                        "2020"
+                    ],
+                    "text": [
+                        "Simple Message ☺"
+                    ]
+                }
+            }
+        ],
+        "external_ids": [
+            "6b1c15d3-cba2-46f7-9a25-78265e58057d"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Invalid Body",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://smsapi1.dmarkmobile.com/sms/": [
+                {
+                    "status": 200,
+                    "body": {
+                        "error": "failed"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://smsapi1.dmarkmobile.com/sms/",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Token Authy",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "dlr_url": [
+                        "https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%s"
+                    ],
+                    "receiver": [
+                        "250788383383"
+                    ],
+                    "sender": [
+                        "2020"
+                    ],
+                    "text": [
+                        "Error Message"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response content",
+            "log_error": {
+                "code": "response_content",
+                "message": "Response content indicates non-success."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://smsapi1.dmarkmobile.com/sms/": [
+                {
+                    "status": 401,
+                    "body": {
+                        "error": "failed"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://smsapi1.dmarkmobile.com/sms/",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Token Authy",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "dlr_url": [
+                        "https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%s"
+                    ],
+                    "receiver": [
+                        "250788383383"
+                    ],
+                    "sender": [
+                        "2020"
+                    ],
+                    "text": [
+                        "Error Message"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://smsapi1.dmarkmobile.com/sms/": [
+                {
+                    "status": 429,
+                    "body": {
+                        "error": "failed"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://smsapi1.dmarkmobile.com/sms/",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Token Authy",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "dlr_url": [
+                        "https://localhost/c/dk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status?uuid=0191e180-7d60-7000-aded-7d8b151cbd5b&status=%s"
+                    ],
+                    "receiver": [
+                        "250788383383"
+                    ],
+                    "sender": [
+                        "2020"
+                    ],
+                    "text": [
+                        "Error Message"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/freshchat/handler_test.go
+++ b/handlers/freshchat/handler_test.go
@@ -2,180 +2,34 @@ package freshchat
 
 import (
 	"testing"
-	"time"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "FC", "2020", "US", []string{urns.FreshChat.Prefix}, map[string]any{
-		"username":   "c8fddfaf-622a-4a0e-b060-4f3ccbeab606", //agent_id
-		"secret":     cert,                                   // public_key for sig
-		"auth_token": "authtoken",                            //API bearer token
-	}),
-	// author-id
-}
-
-const (
-	cert = "-----BEGIN RSA PUBLIC KEY----- MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuGJLF4hTTtxWogT6dNkGf3CEgLAR2mGJzlds5cNbrHFoJNFnmVhkRYGzLYxx4EtDiezNCZVHfyMI2AKuNSQW2fEdDatVIG+q3Zr/X9eeDl8kQOGy804J/fgCYDrN8RQu0n5Dh1inv4puca0wb29SCvoAwrWb33ehDBIvv6+rUKBdjtv2xTV65kNiVDo5VRCaYRVeE10osxeONgw55HVY4nczuxnR+dmc2282de6WHe5LXtr0ZBdJ8yttFOLIluZ/sNM5DIWZBkIWQhyT581tbA7bTpsIbrT/IMBlmioIILw8WGtI7zcmNkjU5dnq5HnlVKEDhj/Ug/dLiyno8+Vp7QIDAQAB -----END RSA PUBLIC KEY-----"
-
-	receiveURL       = "/c/fc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-	validSignature   = `AhrmypOSWoewHG6LmIRuWjxyokuMDmPklrSU9p0gpUNjdSRCJzvpL6rjuTi5poV/ZLzWRWNM7X9yWjT5m9YFPshYrvigcd1ph4Ot2xmaJGYoUNJHijQccE6oDtDIp6i/8oLRafHgObQnGukZWPbP9OE5EiKz/VcsMP0Wv7hawI/sfIviM0w+6fNOKXWi0jDBH9ap1mj5CqOUOojni7OD5iYmIrjV/h33dyNmbvAta9E+trzcEhYqxfHIN4Z8R2FsatfRHWicoQ4PE5cQ8+UONVya8qr85nQ9w8N7Ql7yNg9fEViYG4/W/JnGEbPPEf8WrYtKzoVyuupDz4mVHdfKWg==`
-	validReceive     = `{"actor":{"actor_type":"user","actor_id":"882f3926-b292-414b-a411-96380db373cd"},"action":"message_create","action_time":"2019-06-21T17:43:20.875Z","data":{"message":{"message_parts":[{"text":{"content":"Test 2"}}],"app_id":"55b190fa-5d3c-45c4-bc49-74ddcfcf53d7","actor_id":"882f3926-b292-414b-a411-96380db373cd","id":"7a454fde-c720-4c97-a61d-0ffe70449eb6","channel_id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606","conversation_id":"c327498e-f713-481e-8d83-0603e03d2521","message_type":"normal","actor_type":"user","created_time":"2019-06-21T17:43:20.866Z"}}}`
-	invalidSignature = `f7wMD1BBhcj60U0z3dCY519qmxQ8qfVUU212Dapw9vpZfRBfjjmukUK2GwbAb0Nc+TGQHxN4iP4WD+Y/mSx6f4bmkBsvCy3l4OCQ/FEK0y5R7f+GLLDhgbTh90MwuLDHhvxB5dxIeu59leL+4yO+l/8M3Tm48aQurVBi9IAlzFsMtc1S1CiRxsDUb/rD6IRekPa0pUAbkno9qJ/CGXh0kZMdsYzRkzZmKCs79OWrvU94ha0ptyt5wArfmD1oSzY3PjeL2w8LWDc0QV21H/Hvj42azIUqebiNRtZ2E+f34AfQsyfcPuy1k/6qLuYGOdU1uZidPuPcGpeSIm0GW6k9HQ==`
-)
-
-var sigtestCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid w Signature",
-		Headers:              map[string]string{"Content-Type": "application/json", "X-FreshChat-Signature": validSignature},
-		URL:                  receiveURL,
-		Data:                 validReceive,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Message Accepted",
-		ExpectedMsgText:      Sp("Test 2"),
-		ExpectedURN:          "freshchat:c8fddfaf-622a-4a0e-b060-4f3ccbeab606/882f3926-b292-414b-a411-96380db373cd",
-		ExpectedDate:         time.Date(2019, 6, 21, 17, 43, 20, 866000000, time.UTC),
-		ExpectedExternalID:   "7a454fde-c720-4c97-a61d-0ffe70449eb6",
-	},
-	{
-		Label:                "Bad Signature",
-		Headers:              map[string]string{"Content-Type": "application/json", "X-FreshChat-Signature": invalidSignature},
-		URL:                  receiveURL,
-		Data:                 validReceive,
-		ExpectedRespStatus:   401,
-		ExpectedBodyContains: `{"message":"Unauthorized","data":[{"type":"error","error":"unable to verify signature, crypto/rsa: verification error"}]}`,
-	},
-}
-
-var testCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid w Sig",
-		Headers:              map[string]string{"Content-Type": "application/json", "X-FreshChat-Signature": validSignature},
-		URL:                  receiveURL,
-		Data:                 validReceive,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Message Accepted",
-		ExpectedMsgText:      Sp("Test 2"),
-		ExpectedURN:          "freshchat:c8fddfaf-622a-4a0e-b060-4f3ccbeab606/882f3926-b292-414b-a411-96380db373cd",
-		ExpectedDate:         time.Date(2019, 6, 21, 17, 43, 20, 866000000, time.UTC),
-	},
-	{
-		Label:                "Bad JSON",
-		Headers:              map[string]string{"Content-Type": "application/json", "X-FreshChat-Signature": invalidSignature},
-		URL:                  receiveURL,
-		Data:                 "empty",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: `{"message":"Error","data":[{"type":"error","error":"unable to parse request JSON: invalid character 'e' looking for beginning of value"}]}`,
-	},
-}
+const cert = "-----BEGIN RSA PUBLIC KEY----- MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuGJLF4hTTtxWogT6dNkGf3CEgLAR2mGJzlds5cNbrHFoJNFnmVhkRYGzLYxx4EtDiezNCZVHfyMI2AKuNSQW2fEdDatVIG+q3Zr/X9eeDl8kQOGy804J/fgCYDrN8RQu0n5Dh1inv4puca0wb29SCvoAwrWb33ehDBIvv6+rUKBdjtv2xTV65kNiVDo5VRCaYRVeE10osxeONgw55HVY4nczuxnR+dmc2282de6WHe5LXtr0ZBdJ8yttFOLIluZ/sNM5DIWZBkIWQhyT581tbA7bTpsIbrT/IMBlmioIILw8WGtI7zcmNkjU5dnq5HnlVKEDhj/Ug/dLiyno8+Vp7QIDAQAB -----END RSA PUBLIC KEY-----"
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler("FC", "FreshChat", true), sigtestCases)
-	RunIncomingTestCases(t, testChannels, newHandler("FC", "FreshChat", false), testCases)
-}
+	chs := []*models.Channel{
+		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "FC", "2020", "US", []string{urns.FreshChat.Prefix}, map[string]any{
+			"username":   "c8fddfaf-622a-4a0e-b060-4f3ccbeab606", // agent_id
+			"secret":     cert,                                   // public_key for sig
+			"auth_token": "authtoken",                            // API bearer token
+		}),
+	}
 
-var defaultSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message ☺",
-		MsgURN:  "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.freshchat.com/v2/conversations": {
-				httpx.NewMockResponse(200, nil, []byte(``)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/json", "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ="},
-			Body:    `{"messages":[{"message_parts":[{"text":{"content":"Simple Message ☺"}}],"actor_id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606","actor_type":"agent"}],"channel_id":"0534f78-b6e9-4f79-8853-11cedfc1f35b","users":[{"id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606"}]}`,
-		}},
-	},
-	{
-		Label:          "Send with text and image",
-		MsgText:        "Simple Message ☺",
-		MsgURN:         "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
-		MsgAttachments: []string{"image:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.freshchat.com/v2/conversations": {
-				httpx.NewMockResponse(200, nil, []byte(``)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/json", "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ="},
-			Body:    `{"messages":[{"message_parts":[{"text":{"content":"Simple Message ☺"}},{"image":{"url":"https://foo.bar/image.jpg"}}],"actor_id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606","actor_type":"agent"}],"channel_id":"0534f78-b6e9-4f79-8853-11cedfc1f35b","users":[{"id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606"}]}`,
-		}},
-	},
-	{
-		Label:          "Send with image only",
-		MsgURN:         "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
-		MsgAttachments: []string{"image/jpg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.freshchat.com/v2/conversations": {
-				httpx.NewMockResponse(200, nil, []byte(``)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/json", "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ="},
-			Body:    `{"messages":[{"message_parts":[{"image":{"url":"https://foo.bar/image.jpg"}}],"actor_id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606","actor_type":"agent"}],"channel_id":"0534f78-b6e9-4f79-8853-11cedfc1f35b","users":[{"id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606"}]}`,
-		}},
-	},
-	{
-		Label:   "Error sending",
-		MsgText: "Error",
-		MsgURN:  "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.freshchat.com/v2/conversations": {
-				httpx.NewMockResponse(400, nil, []byte(``)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/json", "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ="},
-			Body:    `{"messages":[{"message_parts":[{"text":{"content":"Error"}}],"actor_id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606","actor_type":"agent"}],"channel_id":"0534f78-b6e9-4f79-8853-11cedfc1f35b","users":[{"id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606"}]}`,
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error",
-		MsgURN:  "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.freshchat.com/v2/conversations": {
-				httpx.NewMockResponse(429, nil, []byte(``)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/json", "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ="},
-			Body:    `{"messages":[{"message_parts":[{"text":{"content":"Error"}}],"actor_id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606","actor_type":"agent"}],"channel_id":"0534f78-b6e9-4f79-8853-11cedfc1f35b","users":[{"id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606"}]}`,
-		}},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
-	{
-		Label:   "Connection Error",
-		MsgText: "Error",
-		MsgURN:  "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.freshchat.com/v2/conversations": {
-				httpx.NewMockResponse(500, nil, []byte(``)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/json", "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ="},
-			Body:    `{"messages":[{"message_parts":[{"text":{"content":"Error"}}],"actor_id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606","actor_type":"agent"}],"channel_id":"0534f78-b6e9-4f79-8853-11cedfc1f35b","users":[{"id":"c8fddfaf-622a-4a0e-b060-4f3ccbeab606"}]}`,
-		}},
-		ExpectedError: channels.ErrConnectionFailed,
-	},
+	RunIncomingTests(t, chs, newHandler("FC", "FreshChat", true), "testdata/incoming.json", nil)
+	RunIncomingTests(t, chs, newHandler("FC", "FreshChat", false), "testdata/incoming_no_validation.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "FC", "2020", "US", []string{urns.FreshChat.Prefix}, map[string]any{
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "FC", "2020", "US", []string{urns.FreshChat.Prefix}, map[string]any{
 		"username":   "c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
 		"secret":     cert,
 		"auth_token": "enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
 	})
-	RunOutgoingTestCases(t, defaultChannel, newHandler("FC", "FreshChat", false), defaultSendTestCases, []string{cert, "enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ="}, nil)
+
+	RunOutgoingTests(t, ch, newHandler("FC", "FreshChat", false), "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{cert, "enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ="}})
 }

--- a/handlers/freshchat/testdata/incoming.json
+++ b/handlers/freshchat/testdata/incoming.json
@@ -1,0 +1,71 @@
+[
+    {
+        "label": "Receive Valid w Signature",
+        "url": "/c/fc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "headers": {
+            "Content-Type": "application/json",
+            "X-FreshChat-Signature": "AhrmypOSWoewHG6LmIRuWjxyokuMDmPklrSU9p0gpUNjdSRCJzvpL6rjuTi5poV/ZLzWRWNM7X9yWjT5m9YFPshYrvigcd1ph4Ot2xmaJGYoUNJHijQccE6oDtDIp6i/8oLRafHgObQnGukZWPbP9OE5EiKz/VcsMP0Wv7hawI/sfIviM0w+6fNOKXWi0jDBH9ap1mj5CqOUOojni7OD5iYmIrjV/h33dyNmbvAta9E+trzcEhYqxfHIN4Z8R2FsatfRHWicoQ4PE5cQ8+UONVya8qr85nQ9w8N7Ql7yNg9fEViYG4/W/JnGEbPPEf8WrYtKzoVyuupDz4mVHdfKWg=="
+        },
+        "data": "{\"actor\":{\"actor_type\":\"user\",\"actor_id\":\"882f3926-b292-414b-a411-96380db373cd\"},\"action\":\"message_create\",\"action_time\":\"2019-06-21T17:43:20.875Z\",\"data\":{\"message\":{\"message_parts\":[{\"text\":{\"content\":\"Test 2\"}}],\"app_id\":\"55b190fa-5d3c-45c4-bc49-74ddcfcf53d7\",\"actor_id\":\"882f3926-b292-414b-a411-96380db373cd\",\"id\":\"7a454fde-c720-4c97-a61d-0ffe70449eb6\",\"channel_id\":\"c8fddfaf-622a-4a0e-b060-4f3ccbeab606\",\"conversation_id\":\"c327498e-f713-481e-8d83-0603e03d2521\",\"message_type\":\"normal\",\"actor_type\":\"user\",\"created_time\":\"2019-06-21T17:43:20.866Z\"}}}",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019b3b20-7ec0-7000-9ddf-385fc8c7c98f",
+                        "text": "Test 2",
+                        "urn": "freshchat:c8fddfaf-622a-4a0e-b060-4f3ccbeab606/882f3926-b292-414b-a411-96380db373cd",
+                        "external_id": "7a454fde-c720-4c97-a61d-0ffe70449eb6",
+                        "received_on": "2019-06-21T17:43:20.866Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019b3b20-7ec0-7000-9ddf-385fc8c7c98f",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "freshchat:c8fddfaf-622a-4a0e-b060-4f3ccbeab606/882f3926-b292-414b-a411-96380db373cd",
+                "text": "Test 2",
+                "external_id": "7a454fde-c720-4c97-a61d-0ffe70449eb6",
+                "created_on": "2025-12-20T09:39:03Z",
+                "received_on": "2019-06-21T17:43:20.866Z",
+                "log_uuids": [
+                    "019b3b20-7308-7000-bebd-362f095ad319"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Bad Signature",
+        "url": "/c/fc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "headers": {
+            "Content-Type": "application/json",
+            "X-FreshChat-Signature": "f7wMD1BBhcj60U0z3dCY519qmxQ8qfVUU212Dapw9vpZfRBfjjmukUK2GwbAb0Nc+TGQHxN4iP4WD+Y/mSx6f4bmkBsvCy3l4OCQ/FEK0y5R7f+GLLDhgbTh90MwuLDHhvxB5dxIeu59leL+4yO+l/8M3Tm48aQurVBi9IAlzFsMtc1S1CiRxsDUb/rD6IRekPa0pUAbkno9qJ/CGXh0kZMdsYzRkzZmKCs79OWrvU94ha0ptyt5wArfmD1oSzY3PjeL2w8LWDc0QV21H/Hvj42azIUqebiNRtZ2E+f34AfQsyfcPuy1k/6qLuYGOdU1uZidPuPcGpeSIm0GW6k9HQ=="
+        },
+        "data": "{\"actor\":{\"actor_type\":\"user\",\"actor_id\":\"882f3926-b292-414b-a411-96380db373cd\"},\"action\":\"message_create\",\"action_time\":\"2019-06-21T17:43:20.875Z\",\"data\":{\"message\":{\"message_parts\":[{\"text\":{\"content\":\"Test 2\"}}],\"app_id\":\"55b190fa-5d3c-45c4-bc49-74ddcfcf53d7\",\"actor_id\":\"882f3926-b292-414b-a411-96380db373cd\",\"id\":\"7a454fde-c720-4c97-a61d-0ffe70449eb6\",\"channel_id\":\"c8fddfaf-622a-4a0e-b060-4f3ccbeab606\",\"conversation_id\":\"c327498e-f713-481e-8d83-0603e03d2521\",\"message_type\":\"normal\",\"actor_type\":\"user\",\"created_time\":\"2019-06-21T17:43:20.866Z\"}}}",
+        "response": {
+            "status": 401,
+            "body": {
+                "message": "Unauthorized",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "unable to verify signature, crypto/rsa: verification error"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/freshchat/testdata/incoming_no_validation.json
+++ b/handlers/freshchat/testdata/incoming_no_validation.json
@@ -1,0 +1,97 @@
+[
+    {
+        "label": "Receive Valid w Sig",
+        "url": "/c/fc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "headers": {
+            "Content-Type": "application/json",
+            "X-FreshChat-Signature": "AhrmypOSWoewHG6LmIRuWjxyokuMDmPklrSU9p0gpUNjdSRCJzvpL6rjuTi5poV/ZLzWRWNM7X9yWjT5m9YFPshYrvigcd1ph4Ot2xmaJGYoUNJHijQccE6oDtDIp6i/8oLRafHgObQnGukZWPbP9OE5EiKz/VcsMP0Wv7hawI/sfIviM0w+6fNOKXWi0jDBH9ap1mj5CqOUOojni7OD5iYmIrjV/h33dyNmbvAta9E+trzcEhYqxfHIN4Z8R2FsatfRHWicoQ4PE5cQ8+UONVya8qr85nQ9w8N7Ql7yNg9fEViYG4/W/JnGEbPPEf8WrYtKzoVyuupDz4mVHdfKWg=="
+        },
+        "data": {
+            "actor": {
+                "actor_type": "user",
+                "actor_id": "882f3926-b292-414b-a411-96380db373cd"
+            },
+            "action": "message_create",
+            "action_time": "2019-06-21T17:43:20.875Z",
+            "data": {
+                "message": {
+                    "message_parts": [
+                        {
+                            "text": {
+                                "content": "Test 2"
+                            }
+                        }
+                    ],
+                    "app_id": "55b190fa-5d3c-45c4-bc49-74ddcfcf53d7",
+                    "actor_id": "882f3926-b292-414b-a411-96380db373cd",
+                    "id": "7a454fde-c720-4c97-a61d-0ffe70449eb6",
+                    "channel_id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
+                    "conversation_id": "c327498e-f713-481e-8d83-0603e03d2521",
+                    "message_type": "normal",
+                    "actor_type": "user",
+                    "created_time": "2019-06-21T17:43:20.866Z"
+                }
+            }
+        },
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "0199f35b-7fa0-7000-bd07-740984d9a380",
+                        "text": "Test 2",
+                        "urn": "freshchat:c8fddfaf-622a-4a0e-b060-4f3ccbeab606/882f3926-b292-414b-a411-96380db373cd",
+                        "external_id": "7a454fde-c720-4c97-a61d-0ffe70449eb6",
+                        "received_on": "2019-06-21T17:43:20.866Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "0199f35b-7fa0-7000-bd07-740984d9a380",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "freshchat:c8fddfaf-622a-4a0e-b060-4f3ccbeab606/882f3926-b292-414b-a411-96380db373cd",
+                "text": "Test 2",
+                "external_id": "7a454fde-c720-4c97-a61d-0ffe70449eb6",
+                "created_on": "2025-10-17T18:08:03Z",
+                "received_on": "2019-06-21T17:43:20.866Z",
+                "log_uuids": [
+                    "0199f35b-73e8-7000-aa27-10d327c4ccbe"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Bad JSON",
+        "url": "/c/fc/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "headers": {
+            "Content-Type": "application/json",
+            "X-FreshChat-Signature": "f7wMD1BBhcj60U0z3dCY519qmxQ8qfVUU212Dapw9vpZfRBfjjmukUK2GwbAb0Nc+TGQHxN4iP4WD+Y/mSx6f4bmkBsvCy3l4OCQ/FEK0y5R7f+GLLDhgbTh90MwuLDHhvxB5dxIeu59leL+4yO+l/8M3Tm48aQurVBi9IAlzFsMtc1S1CiRxsDUb/rD6IRekPa0pUAbkno9qJ/CGXh0kZMdsYzRkzZmKCs79OWrvU94ha0ptyt5wArfmD1oSzY3PjeL2w8LWDc0QV21H/Hvj42azIUqebiNRtZ2E+f34AfQsyfcPuy1k/6qLuYGOdU1uZidPuPcGpeSIm0GW6k9HQ=="
+        },
+        "data": "empty",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "unable to parse request JSON: invalid character 'e' looking for beginning of value"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/freshchat/testdata/outgoing.json
+++ b/handlers/freshchat/testdata/outgoing.json
@@ -1,0 +1,323 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message ☺",
+            "urn": "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606"
+        },
+        "http_mocks": {
+            "https://api.freshchat.com/v2/conversations": [
+                {
+                    "status": 200,
+                    "body": ""
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.freshchat.com/v2/conversations",
+                "headers": {
+                    "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "message_parts": [
+                                {
+                                    "text": {
+                                        "content": "Simple Message ☺"
+                                    }
+                                }
+                            ],
+                            "actor_id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
+                            "actor_type": "agent"
+                        }
+                    ],
+                    "channel_id": "0534f78-b6e9-4f79-8853-11cedfc1f35b",
+                    "users": [
+                        {
+                            "id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606"
+                        }
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send with text and image",
+        "msg": {
+            "text": "Simple Message ☺",
+            "urn": "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
+            "attachments": [
+                "image:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "https://api.freshchat.com/v2/conversations": [
+                {
+                    "status": 200,
+                    "body": ""
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.freshchat.com/v2/conversations",
+                "headers": {
+                    "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "message_parts": [
+                                {
+                                    "text": {
+                                        "content": "Simple Message ☺"
+                                    }
+                                },
+                                {
+                                    "image": {
+                                        "url": "https://foo.bar/image.jpg"
+                                    }
+                                }
+                            ],
+                            "actor_id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
+                            "actor_type": "agent"
+                        }
+                    ],
+                    "channel_id": "0534f78-b6e9-4f79-8853-11cedfc1f35b",
+                    "users": [
+                        {
+                            "id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606"
+                        }
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send with image only",
+        "msg": {
+            "urn": "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
+            "attachments": [
+                "image/jpg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "https://api.freshchat.com/v2/conversations": [
+                {
+                    "status": 200,
+                    "body": ""
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.freshchat.com/v2/conversations",
+                "headers": {
+                    "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "message_parts": [
+                                {
+                                    "image": {
+                                        "url": "https://foo.bar/image.jpg"
+                                    }
+                                }
+                            ],
+                            "actor_id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
+                            "actor_type": "agent"
+                        }
+                    ],
+                    "channel_id": "0534f78-b6e9-4f79-8853-11cedfc1f35b",
+                    "users": [
+                        {
+                            "id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606"
+                        }
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error sending",
+        "msg": {
+            "text": "Error",
+            "urn": "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606"
+        },
+        "http_mocks": {
+            "https://api.freshchat.com/v2/conversations": [
+                {
+                    "status": 400,
+                    "body": ""
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.freshchat.com/v2/conversations",
+                "headers": {
+                    "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "message_parts": [
+                                {
+                                    "text": {
+                                        "content": "Error"
+                                    }
+                                }
+                            ],
+                            "actor_id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
+                            "actor_type": "agent"
+                        }
+                    ],
+                    "channel_id": "0534f78-b6e9-4f79-8853-11cedfc1f35b",
+                    "users": [
+                        {
+                            "id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606"
+                        }
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error",
+            "urn": "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606"
+        },
+        "http_mocks": {
+            "https://api.freshchat.com/v2/conversations": [
+                {
+                    "status": 429,
+                    "body": ""
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.freshchat.com/v2/conversations",
+                "headers": {
+                    "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "message_parts": [
+                                {
+                                    "text": {
+                                        "content": "Error"
+                                    }
+                                }
+                            ],
+                            "actor_id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
+                            "actor_type": "agent"
+                        }
+                    ],
+                    "channel_id": "0534f78-b6e9-4f79-8853-11cedfc1f35b",
+                    "users": [
+                        {
+                            "id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606"
+                        }
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Connection Error",
+        "msg": {
+            "text": "Error",
+            "urn": "freshchat:0534f78-b6e9-4f79-8853-11cedfc1f35b/c8fddfaf-622a-4a0e-b060-4f3ccbeab606"
+        },
+        "http_mocks": {
+            "https://api.freshchat.com/v2/conversations": [
+                {
+                    "status": 500,
+                    "body": ""
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.freshchat.com/v2/conversations",
+                "headers": {
+                    "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "message_parts": [
+                                {
+                                    "text": {
+                                        "content": "Error"
+                                    }
+                                }
+                            ],
+                            "actor_id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606",
+                            "actor_type": "agent"
+                        }
+                    ],
+                    "channel_id": "0534f78-b6e9-4f79-8853-11cedfc1f35b",
+                    "users": [
+                        {
+                            "id": "c8fddfaf-622a-4a0e-b060-4f3ccbeab606"
+                        }
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel connection failed",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_failed",
+                "message": "Connection to server failed."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/handlertest/incoming.go
+++ b/handlers/handlertest/incoming.go
@@ -24,7 +24,7 @@ type IncomingCase struct {
 	Label         string                           `json:"label"`
 	URL           string                           `json:"url"`
 	Headers       map[string]string                `json:"headers,omitempty"`
-	Data          HTTPBody                         `json:"data,omitempty"`
+	Data          HTTPBody                         `json:"data,omitzero"`
 	MultipartForm map[string]string                `json:"multipart_form,omitempty"`
 	Unsigned      bool                             `json:"unsigned,omitempty"` // don't sign this request even if the run signs requests
 	HTTPMocks     map[string][]*httpx.MockResponse `json:"http_mocks,omitempty"`
@@ -135,10 +135,10 @@ func RunIncomingTests(t *testing.T, chs []*models.Channel, newFn channels.NewHan
 				client.Transport = httpx.WithTraces(localOnlyTransport{http.DefaultTransport})
 			}
 
-			status, body := makeHandlerRequest(t, s, tc.URL, tc.Headers, string(tc.Data), tc.MultipartForm, opts.signer(tc))
+			status, body := makeHandlerRequest(t, s, tc.URL, tc.Headers, string(tc.Data.Bytes()), tc.MultipartForm, opts.signer(tc))
 
 			actual := *tc
-			actual.Response = &HandlerResponse{Status: status, Body: body}
+			actual.Response = &HandlerResponse{Status: status, Body: NewHTTPBody(body)}
 			actual.Msgs, actual.Statuses, actual.Events, actual.Requests, actual.Log = nil, nil, nil, nil, nil
 
 			for _, event := range handledEvents {
@@ -183,7 +183,7 @@ func RunIncomingTests(t *testing.T, chs []*models.Channel, newFn channels.NewHan
 			models.FlushChannelCache()
 
 			validCase := cases[0]
-			status, body := makeHandlerRequest(t, s, validCase.URL, validCase.Headers, string(validCase.Data), validCase.MultipartForm, opts.signer(validCase))
+			status, body := makeHandlerRequest(t, s, validCase.URL, validCase.Headers, string(validCase.Data.Bytes()), validCase.MultipartForm, opts.signer(validCase))
 			assert.Equal(t, 400, status, "status code mismatch")
 			assert.Contains(t, string(body), "channel not found")
 		})

--- a/handlers/handlertest/snapshots.go
+++ b/handlers/handlertest/snapshots.go
@@ -28,14 +28,29 @@ import (
 // The types below are the building blocks of those files.
 
 // HTTPBody is a request or response body. In test files a body which is a JSON object or array is written as
-// that JSON, and any other body is written as a string.
-type HTTPBody []byte
+// that JSON, and any other body is written as a string. A body can also be written as a string even though it's
+// JSON, which preserves its exact bytes - needed when a signature is calculated over them.
+type HTTPBody struct {
+	data   []byte
+	quoted bool // written as a string in the file
+}
+
+// NewHTTPBody creates a body from the given bytes
+func NewHTTPBody(data []byte) HTTPBody {
+	return HTTPBody{data: data}
+}
+
+// Bytes returns the bytes of this body
+func (b HTTPBody) Bytes() []byte { return b.data }
+
+// IsZero returns whether this body is empty, so that empty bodies are omitted from files
+func (b HTTPBody) IsZero() bool { return len(b.data) == 0 }
 
 func (b HTTPBody) MarshalJSON() ([]byte, error) {
-	if isJSONContainer(b) {
-		return b, nil
+	if !b.quoted && isJSONContainer(b.data) {
+		return b.data, nil
 	}
-	return json.Marshal(string(b))
+	return json.Marshal(string(b.data))
 }
 
 func (b *HTTPBody) UnmarshalJSON(data []byte) error {
@@ -44,11 +59,11 @@ func (b *HTTPBody) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(data, &s); err != nil {
 			return err
 		}
-		*b = HTTPBody(s)
+		*b = HTTPBody{data: []byte(s), quoted: true}
 	} else if bytes.Equal(data, []byte("null")) {
-		*b = nil
+		*b = HTTPBody{}
 	} else {
-		*b = HTTPBody(data)
+		*b = HTTPBody{data: data}
 	}
 	return nil
 }
@@ -62,7 +77,7 @@ func isJSONContainer(b []byte) bool {
 // HandlerResponse is how a handler answered a request
 type HandlerResponse struct {
 	Status int      `json:"status"`
-	Body   HTTPBody `json:"body,omitempty"`
+	Body   HTTPBody `json:"body,omitzero"`
 }
 
 // HandlerLog is the channel log a handler wrote, minus the timing and HTTP traces which aren't stable
@@ -78,7 +93,7 @@ type CapturedRequest struct {
 	URL     string            `json:"url"`
 	Headers map[string]string `json:"headers,omitempty"`
 	Form    url.Values        `json:"form,omitempty"`
-	Body    HTTPBody          `json:"body,omitempty"`
+	Body    HTTPBody          `json:"body,omitzero"`
 }
 
 func captureRequest(r *http.Request) *CapturedRequest {
@@ -95,7 +110,7 @@ func captureRequest(r *http.Request) *CapturedRequest {
 	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
 		c.Form, _ = url.ParseQuery(string(body))
 	} else {
-		c.Body = body
+		c.Body = NewHTTPBody(body)
 	}
 	return c
 }

--- a/handlers/m3tech/handler_test.go
+++ b/handlers/m3tech/handler_test.go
@@ -1,179 +1,24 @@
 package m3tech
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "M3", "2020", "US", []string{urns.Phone.Prefix}, nil),
-}
-
-var handleTestCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid Message",
-		URL:                  "/c/m3/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive?from=+923161909799&text=hello+world",
-		Data:                 " ",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "SMS Accepted",
-		ExpectedMsgText:      Sp("hello world"),
-		ExpectedURN:          "tel:+923161909799",
-	},
-	{
-		Label:                "Invalid URN",
-		URL:                  "/c/m3/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive?from=MTN&text=hello+world",
-		Data:                 " ",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "not a possible number",
-	},
-	{
-		Label:                "Receive No From",
-		URL:                  "/c/m3/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive?text=hello",
-		Data:                 " ",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "missing required field 'from'",
-	},
-}
-
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
-}
+	chs := []*models.Channel{
+		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "M3", "2020", "US", []string{urns.Phone.Prefix}, nil),
+	}
 
-var defaultSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": {
-				httpx.NewMockResponse(200, nil, []byte(`[{"Response": "0"}]`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Params: url.Values{
-				"MobileNo":    {"250788383383"},
-				"SMS":         {"Simple Message"},
-				"SMSChannel":  {"0"},
-				"AuthKey":     {"m3-Tech"},
-				"HandsetPort": {"0"},
-				"MsgHeader":   {"2020"},
-				"MsgId":       {"0191e180-7d60-7000-aded-7d8b151cbd5b"},
-				"Telco":       {"0"},
-				"SMSType":     {"0"},
-				"UserId":      {"Username"},
-				"Password":    {"Password"},
-			},
-		}},
-	},
-	{
-		Label:   "Unicode Send",
-		MsgText: "☺",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": {
-				httpx.NewMockResponse(200, nil, []byte(`[{"Response": "0"}]`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Params: url.Values{
-				"SMS":         {"☺"},
-				"MobileNo":    {"250788383383"},
-				"SMSChannel":  {"0"},
-				"AuthKey":     {"m3-Tech"},
-				"HandsetPort": {"0"},
-				"MsgHeader":   {"2020"},
-				"MsgId":       {"0191e180-7d60-7000-aded-7d8b151cbd5b"},
-				"Telco":       {"0"},
-				"SMSType":     {"7"},
-				"UserId":      {"Username"},
-				"Password":    {"Password"},
-			},
-		}},
-	},
-	{
-		Label:   "Smart Encoding",
-		MsgText: "Fancy “Smart” Quotes",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": {
-				httpx.NewMockResponse(200, nil, []byte(`[{"Response": "0"}]`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Params: url.Values{
-				"SMS":         {`Fancy "Smart" Quotes`},
-				"MobileNo":    {"250788383383"},
-				"SMSChannel":  {"0"},
-				"AuthKey":     {"m3-Tech"},
-				"HandsetPort": {"0"},
-				"MsgHeader":   {"2020"},
-				"MsgId":       {"0191e180-7d60-7000-aded-7d8b151cbd5b"},
-				"Telco":       {"0"},
-				"SMSType":     {"0"},
-				"UserId":      {"Username"},
-				"Password":    {"Password"},
-			},
-		}},
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": {
-				httpx.NewMockResponse(200, nil, []byte(`[{"Response": "0"}]`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Params: url.Values{
-				"SMS":         {"My pic!\nhttps://foo.bar/image.jpg"},
-				"MobileNo":    {"250788383383"},
-				"SMSChannel":  {"0"},
-				"AuthKey":     {"m3-Tech"},
-				"HandsetPort": {"0"},
-				"MsgHeader":   {"2020"},
-				"MsgId":       {"0191e180-7d60-7000-aded-7d8b151cbd5b"},
-				"Telco":       {"0"},
-				"SMSType":     {"0"},
-				"UserId":      {"Username"},
-				"Password":    {"Password"},
-			},
-		}},
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Sending",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": {
-				httpx.NewMockResponse(403, nil, []byte(`[{"Response": "101"}]`)),
-			},
-		},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Sending",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": {
-				httpx.NewMockResponse(429, nil, []byte(`[{"Response": "101"}]`)),
-			},
-		},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "M3", "2020", "US",
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "M3", "2020", "US",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
 			"password": "Password",
@@ -181,5 +26,5 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Password"}, nil)
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"Password"}})
 }

--- a/handlers/m3tech/testdata/incoming.json
+++ b/handlers/m3tech/testdata/incoming.json
@@ -1,0 +1,70 @@
+[
+    {
+        "label": "Receive Valid Message",
+        "url": "/c/m3/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive?from=+923161909799&text=hello+world",
+        "data": " ",
+        "response": {
+            "status": 200,
+            "body": "SMS Accepted: 019a3df0-d240-7000-a841-50246e59817e"
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d240-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+923161909799",
+                "text": "hello world",
+                "created_on": "2025-11-01T05:43:03Z",
+                "received_on": "2025-11-01T05:43:05Z",
+                "log_uuids": [
+                    "019a3df0-c688-7000-aac1-d0d96ed17383"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid URN",
+        "url": "/c/m3/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive?from=MTN&text=hello+world",
+        "data": " ",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "not a possible number"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No From",
+        "url": "/c/m3/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive?text=hello",
+        "data": " ",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing required field 'from'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/m3tech/testdata/outgoing.json
+++ b/handlers/m3tech/testdata/outgoing.json
@@ -1,0 +1,194 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": [
+                {
+                    "status": 200,
+                    "body": [
+                        {
+                            "Response": "0"
+                        }
+                    ]
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Simple+Message&SMSChannel=0&SMSType=0&Telco=0&UserId=Username",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": [
+                {
+                    "status": 200,
+                    "body": [
+                        {
+                            "Response": "0"
+                        }
+                    ]
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=%E2%98%BA&SMSChannel=0&SMSType=7&Telco=0&UserId=Username",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Smart Encoding",
+        "msg": {
+            "text": "Fancy “Smart” Quotes",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": [
+                {
+                    "status": 200,
+                    "body": [
+                        {
+                            "Response": "0"
+                        }
+                    ]
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Fancy+%22Smart%22+Quotes&SMSChannel=0&SMSType=0&Telco=0&UserId=Username",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": [
+                {
+                    "status": 200,
+                    "body": [
+                        {
+                            "Response": "0"
+                        }
+                    ]
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&SMSChannel=0&SMSType=0&Telco=0&UserId=Username",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Sending",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": [
+                {
+                    "status": 403,
+                    "body": [
+                        {
+                            "Response": "101"
+                        }
+                    ]
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Error+Sending&SMSChannel=0&SMSType=0&Telco=0&UserId=Username",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Sending",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS*": [
+                {
+                    "status": 429,
+                    "body": [
+                        {
+                            "Response": "101"
+                        }
+                    ]
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Error+Sending&SMSChannel=0&SMSType=0&Telco=0&UserId=Username",
+                "headers": {
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/macrokiosk/handler_test.go
+++ b/handlers/macrokiosk/handler_test.go
@@ -2,196 +2,25 @@ package macrokiosk
 
 import (
 	"testing"
-	"time"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
-	"github.com/nyaruka/gocommon/svclogs"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MK", "2020", "MY", []string{urns.Phone.Prefix}, nil),
-}
-
-var (
-	receiveURL = "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-	statusURL  = "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/"
-
-	validReceive         = "shortcode=2020&from=%2B60124361111&text=Hello&msgid=abc1234&time=2016-03-3019:33:06"
-	invalidURN           = "shortcode=2020&from=MTN&text=Hello&msgid=abc1234&time=2016-03-3019:33:06"
-	validLongcodeReceive = "longcode=2020&msisdn=%2B60124361111&text=Hello&msgid=abc1234&time=2016-03-3019:33:06"
-	missingParamsReceive = "from=%2B60124361111&text=Hello&msgid=abc1234&time=2016-03-3019:33:06"
-	invalidParamsReceive = "longcode=2020&from=%2B60124361111&text=Hello&msgid=abc1234&time=2016-03-3019:33:06"
-	invalidAddress       = "shortcode=1515&from=%2B60124361111&text=Hello&msgid=abc1234&time=2016-03-3019:33:06"
-
-	validStatus      = "msgid=12345&status=ACCEPTED"
-	processingStatus = "msgid=12345&status=PROCESSING"
-	unknownStatus    = "msgid=12345&status=UNKNOWN"
-)
-
-var incomingTestCases = []IncomingTestCase{
-	{Label: "Receive Valid", URL: receiveURL, Data: validReceive, ExpectedRespStatus: 200, ExpectedBodyContains: "-1",
-		ExpectedMsgText: Sp("Hello"), ExpectedURN: "tel:+60124361111", ExpectedDate: time.Date(2016, 3, 30, 11, 33, 06, 0, time.UTC),
-		ExpectedExternalID: "abc1234"},
-	{Label: "Receive Valid via GET", URL: receiveURL + "?" + validReceive, ExpectedRespStatus: 200, ExpectedBodyContains: "-1",
-		ExpectedMsgText: Sp("Hello"), ExpectedURN: "tel:+60124361111", ExpectedDate: time.Date(2016, 3, 30, 11, 33, 06, 0, time.UTC),
-		ExpectedExternalID: "abc1234"},
-	{Label: "Receive Valid", URL: receiveURL, Data: validLongcodeReceive, ExpectedRespStatus: 200, ExpectedBodyContains: "-1",
-		ExpectedMsgText: Sp("Hello"), ExpectedURN: "tel:+60124361111", ExpectedDate: time.Date(2016, 3, 30, 11, 33, 06, 0, time.UTC),
-		ExpectedExternalID: "abc1234"},
-	{Label: "Invalid URN", URL: receiveURL, Data: invalidURN, ExpectedRespStatus: 400, ExpectedBodyContains: "not a possible number"},
-	{Label: "Missing Params", URL: receiveURL, Data: missingParamsReceive, ExpectedRespStatus: 400, ExpectedBodyContains: "missing shortcode, longcode, from or msisdn parameters"},
-	{Label: "Invalid Params", URL: receiveURL, Data: invalidParamsReceive, ExpectedRespStatus: 400, ExpectedBodyContains: "missing shortcode, longcode, from or msisdn parameters"},
-	{Label: "Invalid Address Params", URL: receiveURL, Data: invalidAddress, ExpectedRespStatus: 400, ExpectedBodyContains: "invalid to number [1515], expecting [2020]"},
-
-	{
-		Label:                "Valid Status",
-		URL:                  statusURL,
-		Data:                 validStatus,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"status":"S"`,
-		ExpectedStatuses: []ExpectedStatus{
-			{ExternalID: "12345", Status: models.MsgStatusSent},
-		},
-	},
-	{
-		Label:                "Wired Status",
-		URL:                  statusURL,
-		Data:                 processingStatus,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"status":"W"`,
-		ExpectedStatuses: []ExpectedStatus{
-			{ExternalID: "12345", Status: models.MsgStatusWired},
-		},
-	},
-	{Label: "Unknown Status", URL: statusURL, Data: unknownStatus, ExpectedRespStatus: 200, ExpectedBodyContains: `ignoring unknown status 'UNKNOWN'`},
-}
-
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, incomingTestCases)
-}
+	chs := []*models.Channel{
+		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MK", "2020", "MY", []string{urns.Phone.Prefix}, nil),
+	}
 
-var outgoingTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message ☺",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://www.etracker.cc/bulksms/send": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "MsgID":"abc123" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{
-				"Content-Type": "application/json",
-				"Accept":       "application/json",
-			},
-			Body: `{"user":"Username","pass":"Password","to":"250788383383","text":"Simple Message ☺","from":"macro","servid":"service-id","type":"5"}`,
-		}},
-		ExpectedExtIDs: []string{"abc123"},
-	},
-	{
-		Label:   "Long Send",
-		MsgText: "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, I need to keep adding more things to make it work",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://www.etracker.cc/bulksms/send": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "MsgID":"abc123" }`)),
-				httpx.NewMockResponse(200, nil, []byte(`{ "MsgID":"abc123" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Headers: map[string]string{
-					"Content-Type": "application/json",
-					"Accept":       "application/json",
-				},
-				Body: `{"user":"Username","pass":"Password","to":"250788383383","text":"This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say,","from":"macro","servid":"service-id","type":"0"}`,
-			},
-			{
-				Headers: map[string]string{
-					"Content-Type": "application/json",
-					"Accept":       "application/json",
-				},
-				Body: `{"user":"Username","pass":"Password","to":"250788383383","text":"I need to keep adding more things to make it work","from":"macro","servid":"service-id","type":"0"}`,
-			},
-		},
-		ExpectedExtIDs: []string{"abc123", "abc123"},
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://www.etracker.cc/bulksms/send": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "MsgID":"abc123" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{
-				"Content-Type": "application/json",
-				"Accept":       "application/json",
-			},
-			Body: `{"user":"Username","pass":"Password","to":"250788383383","text":"My pic!\nhttps://foo.bar/image.jpg","from":"macro","servid":"service-id","type":"0"}`,
-		}},
-		ExpectedExtIDs: []string{"abc123"},
-	},
-	{
-		Label:   "No External Id",
-		MsgText: "No External ID",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://www.etracker.cc/bulksms/send": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "missing":"missing" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{
-				"Content-Type": "application/json",
-				"Accept":       "application/json",
-			},
-			Body: `{"user":"Username","pass":"Password","to":"250788383383","text":"No External ID","from":"macro","servid":"service-id","type":"0"}`,
-		}},
-		ExpectedLogErrors: []*svclogs.Error{models.ErrorResponseValueMissing("MsgID")},
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://www.etracker.cc/bulksms/send": {
-				httpx.NewMockResponse(401, nil, []byte(`{ "error": "failed" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"user":"Username","pass":"Password","to":"250788383383","text":"Error Message","from":"macro","servid":"service-id","type":"0"}`,
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://www.etracker.cc/bulksms/send": {
-				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"user":"Username","pass":"Password","to":"250788383383","text":"Error Message","from":"macro","servid":"service-id","type":"0"}`,
-		}},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
 	maxMsgLength = 160
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MK", "2020", "US",
+
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MK", "2020", "US",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
 			"password":                "Password",
@@ -201,5 +30,5 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler, outgoingTestCases, []string{"Password"}, nil)
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"Password"}})
 }

--- a/handlers/macrokiosk/testdata/incoming.json
+++ b/handlers/macrokiosk/testdata/incoming.json
@@ -1,0 +1,251 @@
+[
+    {
+        "label": "Receive Valid",
+        "url": "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "shortcode=2020\u0026from=%2B60124361111\u0026text=Hello\u0026msgid=abc1234\u0026time=2016-03-3019:33:06",
+        "response": {
+            "status": 200,
+            "body": "-1"
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+60124361111",
+                "text": "Hello",
+                "external_id": "abc1234",
+                "created_on": "2025-11-19T17:20:03Z",
+                "received_on": "2016-03-30T11:33:06Z",
+                "log_uuids": [
+                    "019a9d21-5de8-7000-a1e4-7638cffc03a6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid via GET",
+        "url": "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?shortcode=2020&from=%2B60124361111&text=Hello&msgid=abc1234&time=2016-03-3019:33:06",
+        "response": {
+            "status": 200,
+            "body": "-1"
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+60124361111",
+                "text": "Hello",
+                "external_id": "abc1234",
+                "created_on": "2025-11-13T18:20:03Z",
+                "received_on": "2016-03-30T11:33:06Z",
+                "log_uuids": [
+                    "019a7e72-2468-7000-bd3d-694131f2fa9d"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid Longcode",
+        "url": "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "longcode=2020\u0026msisdn=%2B60124361111\u0026text=Hello\u0026msgid=abc1234\u0026time=2016-03-3019:33:06",
+        "response": {
+            "status": 200,
+            "body": "-1"
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+60124361111",
+                "text": "Hello",
+                "external_id": "abc1234",
+                "created_on": "2025-11-23T21:55:03Z",
+                "received_on": "2016-03-30T11:33:06Z",
+                "log_uuids": [
+                    "019ab2b6-9308-7000-9a9d-2bac66c15cf6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid URN",
+        "url": "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "shortcode=2020\u0026from=MTN\u0026text=Hello\u0026msgid=abc1234\u0026time=2016-03-3019:33:06",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "not a possible number"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Missing Params",
+        "url": "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "from=%2B60124361111\u0026text=Hello\u0026msgid=abc1234\u0026time=2016-03-3019:33:06",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing shortcode, longcode, from or msisdn parameters"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid Params",
+        "url": "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "longcode=2020\u0026from=%2B60124361111\u0026text=Hello\u0026msgid=abc1234\u0026time=2016-03-3019:33:06",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing shortcode, longcode, from or msisdn parameters"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid Address Params",
+        "url": "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "shortcode=1515\u0026from=%2B60124361111\u0026text=Hello\u0026msgid=abc1234\u0026time=2016-03-3019:33:06",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "invalid to number [1515], expecting [2020]"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Valid Status",
+        "url": "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/",
+        "data": "msgid=12345\u0026status=ACCEPTED",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "S",
+                        "external_id": "12345"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "external_identifier": "12345",
+                "status": "S",
+                "log_uuid": "019a9405-84c8-7000-a071-1bb56436b1db"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Wired Status",
+        "url": "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/",
+        "data": "msgid=12345\u0026status=PROCESSING",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "W",
+                        "external_id": "12345"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "external_identifier": "12345",
+                "status": "W",
+                "log_uuid": "019a64d1-7928-7000-9c20-45ffa890d6ae"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Unknown Status",
+        "url": "/c/mk/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/",
+        "data": "msgid=12345\u0026status=UNKNOWN",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Ignored",
+                "data": [
+                    {
+                        "type": "info",
+                        "info": "ignoring unknown status 'UNKNOWN'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    }
+]

--- a/handlers/macrokiosk/testdata/outgoing.json
+++ b/handlers/macrokiosk/testdata/outgoing.json
@@ -1,0 +1,287 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message ☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://www.etracker.cc/bulksms/send": [
+                {
+                    "status": 200,
+                    "body": {
+                        "MsgID": "abc123"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://www.etracker.cc/bulksms/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "Username",
+                    "pass": "Password",
+                    "to": "250788383383",
+                    "text": "Simple Message ☺",
+                    "from": "macro",
+                    "servid": "service-id",
+                    "type": "5"
+                }
+            }
+        ],
+        "external_ids": [
+            "abc123"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Long Send",
+        "msg": {
+            "text": "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, I need to keep adding more things to make it work",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://www.etracker.cc/bulksms/send": [
+                {
+                    "status": 200,
+                    "body": {
+                        "MsgID": "abc123"
+                    }
+                },
+                {
+                    "status": 200,
+                    "body": {
+                        "MsgID": "abc123"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://www.etracker.cc/bulksms/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "Username",
+                    "pass": "Password",
+                    "to": "250788383383",
+                    "text": "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say,",
+                    "from": "macro",
+                    "servid": "service-id",
+                    "type": "0"
+                }
+            },
+            {
+                "method": "POST",
+                "url": "https://www.etracker.cc/bulksms/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "Username",
+                    "pass": "Password",
+                    "to": "250788383383",
+                    "text": "I need to keep adding more things to make it work",
+                    "from": "macro",
+                    "servid": "service-id",
+                    "type": "0"
+                }
+            }
+        ],
+        "external_ids": [
+            "abc123",
+            "abc123"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "https://www.etracker.cc/bulksms/send": [
+                {
+                    "status": 200,
+                    "body": {
+                        "MsgID": "abc123"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://www.etracker.cc/bulksms/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "Username",
+                    "pass": "Password",
+                    "to": "250788383383",
+                    "text": "My pic!\nhttps://foo.bar/image.jpg",
+                    "from": "macro",
+                    "servid": "service-id",
+                    "type": "0"
+                }
+            }
+        ],
+        "external_ids": [
+            "abc123"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "No External Id",
+        "msg": {
+            "text": "No External ID",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://www.etracker.cc/bulksms/send": [
+                {
+                    "status": 200,
+                    "body": {
+                        "missing": "missing"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://www.etracker.cc/bulksms/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "Username",
+                    "pass": "Password",
+                    "to": "250788383383",
+                    "text": "No External ID",
+                    "from": "macro",
+                    "servid": "service-id",
+                    "type": "0"
+                }
+            }
+        ],
+        "log_errors": [
+            {
+                "code": "response_value_missing",
+                "message": "Unable to find 'MsgID' response."
+            }
+        ]
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://www.etracker.cc/bulksms/send": [
+                {
+                    "status": 401,
+                    "body": {
+                        "error": "failed"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://www.etracker.cc/bulksms/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "Username",
+                    "pass": "Password",
+                    "to": "250788383383",
+                    "text": "Error Message",
+                    "from": "macro",
+                    "servid": "service-id",
+                    "type": "0"
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://www.etracker.cc/bulksms/send": [
+                {
+                    "status": 429,
+                    "body": {
+                        "error": "failed"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://www.etracker.cc/bulksms/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "Username",
+                    "pass": "Password",
+                    "to": "250788383383",
+                    "text": "Error Message",
+                    "from": "macro",
+                    "servid": "service-id",
+                    "type": "0"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/playmobile/handler_test.go
+++ b/handlers/playmobile/handler_test.go
@@ -3,7 +3,6 @@ package playmobile
 import (
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
@@ -11,193 +10,21 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "PM", "1122", "UZ",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			"incoming_prefixes": []string{"abc", "DE"},
-		},
-	),
-}
-
-var (
-	receiveURL = "/c/pm/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-
-	validReceive = `<sms-request><message id="1107962" msisdn="998999999999" submit-date="2016-11-22 15:10:32">
-	<content type="text/plain">SMS Response Accepted</content>
-	</message></sms-request>`
-
-	invalidReceive = `<sms-request><message id="" msisdn="" submit-date="2016-11-22 15:10:32">
-	<content type="text/plain">SMS Response Accepted</content>
-	</message></sms-request>`
-
-	noMessages = `<sms-request></sms-request>`
-
-	receiveWithPrefix = `<sms-request><message id="1107962" msisdn="998999999999" submit-date="2016-11-22 15:10:32">
-	<content type="text/plain">abc SMS Response Accepted</content>
-	<content type="text/plain">aBc SMS Response Accepted</content>
-	<content type="text/plain">ABCSMS Response Accepted</content>
-	<content type="text/plain">de SMS Response Accepted</content>
-	<content type="text/plain">DESMS Response Accepted</content>
-	</message></sms-request>`
-
-	receiveWithPrefixOnly = `<sms-request><message id="1107962" msisdn="998999999999" submit-date="2016-11-22 15:10:32">
-	<content type="text/plain">abc </content>
-	</message></sms-request>`
-
-	validMessage = `{
-		"messages": [
-			{
-				"recipient": "1122",
-				"message-id": "2018-10-26-09-27-34",
-				"sms": {
-					"originator": "99999999999",
-					"content": {
-						"text": "Incoming Valid Message"
-					}
-				}
-			}
-		]
-	}`
-
-	missingMessageID = `{
-		"messages": [
-			{
-				"recipient": "99999999999",
-				"sms": {
-					"originator": "1122",
-					"content": {
-						"text": "Message from Paul"
-					}
-				}
-			}
-		]
-	}`
-)
-
-var testCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid",
-		URL:                  receiveURL,
-		Data:                 validReceive,
-		ExpectedBodyContains: "Accepted",
-		ExpectedRespStatus:   200,
-		ExpectedMsgText:      Sp("SMS Response Accepted"),
-		ExpectedURN:          "tel:+998999999999",
-	},
-	{
-		Label:                "Receive Missing MSISDN",
-		URL:                  receiveURL,
-		Data:                 invalidReceive,
-		ExpectedBodyContains: "missing required fields msidsn or id",
-		ExpectedRespStatus:   400,
-	},
-	{
-		Label:                "No Messages",
-		URL:                  receiveURL,
-		Data:                 noMessages,
-		ExpectedBodyContains: "no messages, ignored",
-		ExpectedRespStatus:   200,
-	},
-	{
-		Label:                "Invalid XML",
-		URL:                  receiveURL,
-		Data:                 `<>`,
-		ExpectedBodyContains: "",
-		ExpectedRespStatus:   400,
-	},
-	{
-		Label:                "Receive With Prefix",
-		URL:                  receiveURL,
-		Data:                 receiveWithPrefix,
-		ExpectedBodyContains: "Accepted",
-		ExpectedRespStatus:   200,
-		ExpectedMsgText:      Sp("SMS Response Accepted"),
-		ExpectedURN:          "tel:+998999999999",
-	},
-	{
-		Label:                "Receive With Prefix Only",
-		URL:                  receiveURL,
-		Data:                 receiveWithPrefixOnly,
-		ExpectedBodyContains: "no text",
-		ExpectedRespStatus:   400,
-	},
-}
-
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, testCases)
-}
+	chs := []*models.Channel{
+		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "PM", "1122", "UZ",
+			[]string{urns.Phone.Prefix},
+			map[string]any{
+				"incoming_prefixes": []string{"abc", "DE"},
+			},
+		),
+	}
 
-var defaultSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:99999999999",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/broker-api/send": {
-				httpx.NewMockResponse(200, nil, []byte(`Request is received`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"messages":[{"recipient":"99999999999","message-id":"0191e180-7d60-7000-aded-7d8b151cbd5b","sms":{"originator":"1122","content":{"text":"Simple Message"}}}]}`,
-		}},
-	},
-	{
-		Label:   "Long Send",
-		MsgText: "This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, now, I need to keep adding more things to make it work",
-		MsgURN:  "tel:99999999999",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/broker-api/send": {
-				httpx.NewMockResponse(200, nil, []byte(`Request is received`)),
-				httpx.NewMockResponse(200, nil, []byte(`Request is received`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Body: `{"messages":[{"recipient":"99999999999","message-id":"0191e180-7d60-7000-aded-7d8b151cbd5b","sms":{"originator":"1122","content":{"text":"This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, now,"}}}]}`,
-			},
-			{
-				Body: `{"messages":[{"recipient":"99999999999","message-id":"0191e180-7d60-7000-aded-7d8b151cbd5b.2","sms":{"originator":"1122","content":{"text":"I need to keep adding more things to make it work"}}}]}`,
-			},
-		},
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+18686846481",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/broker-api/send": {
-				httpx.NewMockResponse(200, nil, []byte(validMessage)),
-			},
-		},
-	},
-	{
-		Label:   "Error sending",
-		MsgText: "Error Sending",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/broker-api/send": {
-				httpx.NewMockResponse(400, nil, []byte(`not json`)),
-			},
-		},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Sending",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/broker-api/send": {
-				httpx.NewMockResponse(429, nil, []byte(`not json`)),
-			},
-		},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "PM", "1122", "UZ",
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "PM", "1122", "UZ",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
 			"password":  "Password",
@@ -206,5 +33,5 @@ func TestOutgoing(t *testing.T) {
 			"base_url":  "http://example.com",
 		})
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{httpx.BasicAuth("Username", "Password")}, nil)
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{httpx.BasicAuth("Username", "Password")}})
 }

--- a/handlers/playmobile/testdata/incoming.json
+++ b/handlers/playmobile/testdata/incoming.json
@@ -1,0 +1,166 @@
+[
+    {
+        "label": "Receive Valid",
+        "url": "/c/pm/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "\u003csms-request\u003e\u003cmessage id=\"1107962\" msisdn=\"998999999999\" submit-date=\"2016-11-22 15:10:32\"\u003e\n\t\u003ccontent type=\"text/plain\"\u003eSMS Response Accepted\u003c/content\u003e\n\t\u003c/message\u003e\u003c/sms-request\u003e",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                        "text": "SMS Response Accepted",
+                        "urn": "tel:+998999999999",
+                        "external_id": "1107962",
+                        "received_on": "2025-11-19T17:20:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+998999999999",
+                "text": "SMS Response Accepted",
+                "external_id": "1107962",
+                "created_on": "2025-11-19T17:20:03Z",
+                "received_on": "2025-11-19T17:20:03Z",
+                "log_uuids": [
+                    "019a9d21-5de8-7000-a1e4-7638cffc03a6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Missing MSISDN",
+        "url": "/c/pm/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "\u003csms-request\u003e\u003cmessage id=\"\" msisdn=\"\" submit-date=\"2016-11-22 15:10:32\"\u003e\n\t\u003ccontent type=\"text/plain\"\u003eSMS Response Accepted\u003c/content\u003e\n\t\u003c/message\u003e\u003c/sms-request\u003e",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing required fields msidsn or id"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "No Messages",
+        "url": "/c/pm/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "\u003csms-request\u003e\u003c/sms-request\u003e",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Ignored",
+                "data": [
+                    {
+                        "type": "info",
+                        "info": "no messages, ignored"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid XML",
+        "url": "/c/pm/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "\u003c\u003e",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "unable to parse request XML: XML syntax error on line 1: expected element name after \u003c"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive With Prefix",
+        "url": "/c/pm/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "\u003csms-request\u003e\u003cmessage id=\"1107962\" msisdn=\"998999999999\" submit-date=\"2016-11-22 15:10:32\"\u003e\n\t\u003ccontent type=\"text/plain\"\u003eabc SMS Response Accepted\u003c/content\u003e\n\t\u003ccontent type=\"text/plain\"\u003eaBc SMS Response Accepted\u003c/content\u003e\n\t\u003ccontent type=\"text/plain\"\u003eABCSMS Response Accepted\u003c/content\u003e\n\t\u003ccontent type=\"text/plain\"\u003ede SMS Response Accepted\u003c/content\u003e\n\t\u003ccontent type=\"text/plain\"\u003eDESMS Response Accepted\u003c/content\u003e\n\t\u003c/message\u003e\u003c/sms-request\u003e",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                        "text": "SMS Response Accepted",
+                        "urn": "tel:+998999999999",
+                        "external_id": "1107962",
+                        "received_on": "2025-12-12T03:46:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+998999999999",
+                "text": "SMS Response Accepted",
+                "external_id": "1107962",
+                "created_on": "2025-12-12T03:46:03Z",
+                "received_on": "2025-12-12T03:46:03Z",
+                "log_uuids": [
+                    "019b10aa-64a8-7000-9617-4ee77aebca0a"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive With Prefix Only",
+        "url": "/c/pm/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "\u003csms-request\u003e\u003cmessage id=\"1107962\" msisdn=\"998999999999\" submit-date=\"2016-11-22 15:10:32\"\u003e\n\t\u003ccontent type=\"text/plain\"\u003eabc \u003c/content\u003e\n\t\u003c/message\u003e\u003c/sms-request\u003e",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "no text"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/playmobile/testdata/outgoing.json
+++ b/handlers/playmobile/testdata/outgoing.json
@@ -1,0 +1,271 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:99999999999"
+        },
+        "http_mocks": {
+            "http://example.com/broker-api/send": [
+                {
+                    "status": 200,
+                    "body": "Request is received"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/broker-api/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "recipient": "99999999999",
+                            "message-id": "0191e180-7d60-7000-aded-7d8b151cbd5b",
+                            "sms": {
+                                "originator": "1122",
+                                "content": {
+                                    "text": "Simple Message"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Long Send",
+        "msg": {
+            "text": "This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, now, I need to keep adding more things to make it work",
+            "urn": "tel:99999999999"
+        },
+        "http_mocks": {
+            "http://example.com/broker-api/send": [
+                {
+                    "status": 200,
+                    "body": "Request is received"
+                },
+                {
+                    "status": 200,
+                    "body": "Request is received"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/broker-api/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "recipient": "99999999999",
+                            "message-id": "0191e180-7d60-7000-aded-7d8b151cbd5b",
+                            "sms": {
+                                "originator": "1122",
+                                "content": {
+                                    "text": "This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, This is a longer message than 640 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, now,"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "method": "POST",
+                "url": "http://example.com/broker-api/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "recipient": "99999999999",
+                            "message-id": "0191e180-7d60-7000-aded-7d8b151cbd5b.2",
+                            "sms": {
+                                "originator": "1122",
+                                "content": {
+                                    "text": "I need to keep adding more things to make it work"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+18686846481",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/broker-api/send": [
+                {
+                    "status": 200,
+                    "body": {
+                        "messages": [
+                            {
+                                "recipient": "1122",
+                                "message-id": "2018-10-26-09-27-34",
+                                "sms": {
+                                    "originator": "99999999999",
+                                    "content": {
+                                        "text": "Incoming Valid Message"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/broker-api/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "recipient": "18686846481",
+                            "message-id": "0191e180-7d60-7000-aded-7d8b151cbd5b",
+                            "sms": {
+                                "originator": "1122",
+                                "content": {
+                                    "text": "My pic!\nhttps://foo.bar/image.jpg"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error sending",
+        "msg": {
+            "text": "Error Sending",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/broker-api/send": [
+                {
+                    "status": 400,
+                    "body": "not json"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/broker-api/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "recipient": "250788383383",
+                            "message-id": "0191e180-7d60-7000-aded-7d8b151cbd5b",
+                            "sms": {
+                                "originator": "1122",
+                                "content": {
+                                    "text": "Error Sending"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Sending",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/broker-api/send": [
+                {
+                    "status": 429,
+                    "body": "not json"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/broker-api/send",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "messages": [
+                        {
+                            "recipient": "250788383383",
+                            "message-id": "0191e180-7d60-7000-aded-7d8b151cbd5b",
+                            "sms": {
+                                "originator": "1122",
+                                "content": {
+                                    "text": "Error Sending"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/plivo/handler_test.go
+++ b/handlers/plivo/handler_test.go
@@ -3,7 +3,6 @@ package plivo
 import (
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
@@ -11,176 +10,18 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "PL", "2020", "MY", []string{urns.Phone.Prefix}, nil),
-}
-
-var (
-	receiveURL = "/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-	statusURL  = "/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/"
-
-	validReceive   = "To=2020&From=60124361111&TotalRate=0&Units=1&Text=Hello&TotalAmount=0&Type=sms&MessageUUID=abc1234"
-	invalidURN     = "To=2020&From=MTN&TotalRate=0&Units=1&Text=Hello&TotalAmount=0&Type=sms&MessageUUID=abc1234"
-	invalidAddress = "To=1515&From=60124361111&TotalRate=0&Units=1&Text=Hello&TotalAmount=0&Type=sms&MessageUUID=abc1234"
-	missingParams  = "From=60124361111&TotalRate=0&Units=1&Text=Hello&TotalAmount=0&Type=sms&MessageUUID=abc1234"
-
-	validStatus          = "MessageUUID=12345&status=delivered&To=%2B60124361111&From=2020"
-	validSentStatus      = "ParentMessageUUID=12345&status=sent&MessageUUID=123&To=%2B60124361111&From=2020"
-	invalidStatusAddress = "ParentMessageUUID=12345&status=sent&MessageUUID=123&To=%2B60124361111&From=1515"
-	unknownStatus        = "MessageUUID=12345&status=UNKNOWN&To=%2B60124361111&From=2020"
-)
-
-var testCases = []IncomingTestCase{
-	{Label: "Receive Valid", URL: receiveURL, Data: validReceive, ExpectedRespStatus: 200, ExpectedBodyContains: "Message Accepted",
-		ExpectedMsgText: Sp("Hello"), ExpectedURN: "tel:+60124361111", ExpectedExternalID: "abc1234"},
-	{Label: "Invalid URN", URL: receiveURL, Data: invalidURN, ExpectedRespStatus: 400, ExpectedBodyContains: "not a possible number"},
-	{Label: "Invalid Address Params", URL: receiveURL, Data: invalidAddress, ExpectedRespStatus: 400, ExpectedBodyContains: "invalid to number [1515], expecting [2020]"},
-	{Label: "Missing Params", URL: receiveURL, Data: missingParams, ExpectedRespStatus: 400, ExpectedBodyContains: "Field validation for 'To' failed"},
-
-	{
-		Label:                "Valid Status",
-		URL:                  statusURL,
-		Data:                 validStatus,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"status":"D"`,
-		ExpectedStatuses: []ExpectedStatus{
-			{ExternalID: "12345", Status: models.MsgStatusDelivered},
-		},
-	},
-	{
-		Label:                "Sent Status",
-		URL:                  statusURL,
-		Data:                 validSentStatus,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"status":"S"`,
-		ExpectedStatuses: []ExpectedStatus{
-			{ExternalID: "12345", Status: models.MsgStatusSent},
-		},
-	},
-	{Label: "Invalid Status Address", URL: statusURL, Data: invalidStatusAddress, ExpectedRespStatus: 400, ExpectedBodyContains: "invalid to number [1515], expecting [2020]"},
-	{Label: "Unkown Status", URL: statusURL, Data: unknownStatus, ExpectedRespStatus: 200, ExpectedBodyContains: `ignoring unknown status 'UNKNOWN'`},
-}
-
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, testCases)
-}
+	chs := []*models.Channel{
+		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "PL", "2020", "MY", []string{urns.Phone.Prefix}, nil),
+	}
 
-var defaultSendTestCases = []OutgoingTestCase{
-	{Label: "Plain Send",
-		MsgText: "Simple Message ☺",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.plivo.com/v1/Account/AuthID/Message/": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "message_uuid":["abc123"] }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{
-				"Content-Type":  "application/json",
-				"Accept":        "application/json",
-				"Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-			},
-			Body: `{"src":"2020","dst":"250788383383","text":"Simple Message ☺","url":"https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status","method":"POST"}`,
-		}},
-		ExpectedExtIDs: []string{"abc123"},
-	},
-	{Label: "Long Send",
-		MsgText: "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, I need to keep adding more things to make it work",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.plivo.com/v1/Account/AuthID/Message/": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "message_uuid":["abc123"] }`)),
-				httpx.NewMockResponse(200, nil, []byte(`{ "message_uuid":["abc123"] }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Headers: map[string]string{
-					"Content-Type":  "application/json",
-					"Accept":        "application/json",
-					"Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-				},
-				Body: `{"src":"2020","dst":"250788383383","text":"This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say,","url":"https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status","method":"POST"}`,
-			},
-			{
-				Headers: map[string]string{
-					"Content-Type":  "application/json",
-					"Accept":        "application/json",
-					"Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-				},
-				Body: `{"src":"2020","dst":"250788383383","text":"I need to keep adding more things to make it work","url":"https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status","method":"POST"}`,
-			},
-		},
-		ExpectedExtIDs: []string{"abc123", "abc123"},
-	},
-	{Label: "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.plivo.com/v1/Account/AuthID/Message/": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "message_uuid":["abc123"] }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{
-				"Content-Type":  "application/json",
-				"Accept":        "application/json",
-				"Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-			},
-			Body: `{"src":"2020","dst":"250788383383","text":"My pic!\nhttps://foo.bar/image.jpg","url":"https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status","method":"POST"}`,
-		}},
-		ExpectedExtIDs: []string{"abc123"},
-	},
-	{Label: "No External Id",
-		MsgText: "No External ID",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.plivo.com/v1/Account/AuthID/Message/": {
-				httpx.NewMockResponse(200, nil, []byte(`{ "missing":"OzYDlvf3SQVc" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{
-				"Content-Type":  "application/json",
-				"Accept":        "application/json",
-				"Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-			},
-			Body: `{"src":"2020","dst":"250788383383","text":"No External ID","url":"https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status","method":"POST"}`,
-		}},
-		ExpectedError: channels.ErrResponseContent,
-	},
-	{Label: "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.plivo.com/v1/Account/AuthID/Message/": {
-				httpx.NewMockResponse(401, nil, []byte(`{ "error": "failed" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"src":"2020","dst":"250788383383","text":"Error Message","url":"https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status","method":"POST"}`,
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{Label: "Throttled",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api.plivo.com/v1/Account/AuthID/Message/": {
-				httpx.NewMockResponse(429, nil, []byte(`{ "error": "failed" }`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"src":"2020","dst":"250788383383","text":"Error Message","url":"https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status","method":"POST"}`,
-		}},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
 	maxMsgLength = 160
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "PL", "2020", "US",
+
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "PL", "2020", "US",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
 			configPlivoAuthID:    "AuthID",
@@ -189,5 +30,5 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{httpx.BasicAuth("AuthID", "AuthToken")}, nil)
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{httpx.BasicAuth("AuthID", "AuthToken")}})
 }

--- a/handlers/plivo/testdata/incoming.json
+++ b/handlers/plivo/testdata/incoming.json
@@ -1,0 +1,215 @@
+[
+    {
+        "label": "Receive Valid",
+        "url": "/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "To=2020\u0026From=60124361111\u0026TotalRate=0\u0026Units=1\u0026Text=Hello\u0026TotalAmount=0\u0026Type=sms\u0026MessageUUID=abc1234",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                        "text": "Hello",
+                        "urn": "tel:+60124361111",
+                        "external_id": "abc1234",
+                        "received_on": "2025-11-19T17:20:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a9d21-69a0-7000-85c5-5f26b6333b45",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+60124361111",
+                "text": "Hello",
+                "external_id": "abc1234",
+                "created_on": "2025-11-19T17:20:03Z",
+                "received_on": "2025-11-19T17:20:03Z",
+                "log_uuids": [
+                    "019a9d21-5de8-7000-a1e4-7638cffc03a6"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid URN",
+        "url": "/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "To=2020\u0026From=MTN\u0026TotalRate=0\u0026Units=1\u0026Text=Hello\u0026TotalAmount=0\u0026Type=sms\u0026MessageUUID=abc1234",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "not a possible number"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid Address Params",
+        "url": "/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "To=1515\u0026From=60124361111\u0026TotalRate=0\u0026Units=1\u0026Text=Hello\u0026TotalAmount=0\u0026Type=sms\u0026MessageUUID=abc1234",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "invalid to number [1515], expecting [2020]"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Missing Params",
+        "url": "/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "From=60124361111\u0026TotalRate=0\u0026Units=1\u0026Text=Hello\u0026TotalAmount=0\u0026Type=sms\u0026MessageUUID=abc1234",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "Key: 'moForm.To' Error:Field validation for 'To' failed on the 'required' tag"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'to' required"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Valid Status",
+        "url": "/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/",
+        "data": "MessageUUID=12345\u0026status=delivered\u0026To=%2B60124361111\u0026From=2020",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "D",
+                        "external_id": "12345"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "external_identifier": "12345",
+                "status": "D",
+                "log_uuid": "019a9405-84c8-7000-a071-1bb56436b1db"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Sent Status",
+        "url": "/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/",
+        "data": "ParentMessageUUID=12345\u0026status=sent\u0026MessageUUID=123\u0026To=%2B60124361111\u0026From=2020",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "S",
+                        "external_id": "12345"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "external_identifier": "12345",
+                "status": "S",
+                "log_uuid": "019a0d1a-5588-7000-8e77-de219ce504e4"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid Status Address",
+        "url": "/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/",
+        "data": "ParentMessageUUID=12345\u0026status=sent\u0026MessageUUID=123\u0026To=%2B60124361111\u0026From=1515",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "invalid to number [1515], expecting [2020]"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Unkown Status",
+        "url": "/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status/",
+        "data": "MessageUUID=12345\u0026status=UNKNOWN\u0026To=%2B60124361111\u0026From=2020",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Ignored",
+                "data": [
+                    {
+                        "type": "info",
+                        "info": "ignoring unknown status 'UNKNOWN'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    }
+]

--- a/handlers/plivo/testdata/outgoing.json
+++ b/handlers/plivo/testdata/outgoing.json
@@ -1,0 +1,290 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message ☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api.plivo.com/v1/Account/AuthID/Message/": [
+                {
+                    "status": 200,
+                    "body": {
+                        "message_uuid": [
+                            "abc123"
+                        ]
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.plivo.com/v1/Account/AuthID/Message/",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "src": "2020",
+                    "dst": "250788383383",
+                    "text": "Simple Message ☺",
+                    "url": "https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status",
+                    "method": "POST"
+                }
+            }
+        ],
+        "external_ids": [
+            "abc123"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Long Send",
+        "msg": {
+            "text": "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say, I need to keep adding more things to make it work",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api.plivo.com/v1/Account/AuthID/Message/": [
+                {
+                    "status": 200,
+                    "body": {
+                        "message_uuid": [
+                            "abc123"
+                        ]
+                    }
+                },
+                {
+                    "status": 200,
+                    "body": {
+                        "message_uuid": [
+                            "abc123"
+                        ]
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.plivo.com/v1/Account/AuthID/Message/",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "src": "2020",
+                    "dst": "250788383383",
+                    "text": "This is a longer message than 160 characters and will cause us to split it into two separate parts, isn't that right but it is even longer than before I say,",
+                    "url": "https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status",
+                    "method": "POST"
+                }
+            },
+            {
+                "method": "POST",
+                "url": "https://api.plivo.com/v1/Account/AuthID/Message/",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "src": "2020",
+                    "dst": "250788383383",
+                    "text": "I need to keep adding more things to make it work",
+                    "url": "https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status",
+                    "method": "POST"
+                }
+            }
+        ],
+        "external_ids": [
+            "abc123",
+            "abc123"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "https://api.plivo.com/v1/Account/AuthID/Message/": [
+                {
+                    "status": 200,
+                    "body": {
+                        "message_uuid": [
+                            "abc123"
+                        ]
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.plivo.com/v1/Account/AuthID/Message/",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "src": "2020",
+                    "dst": "250788383383",
+                    "text": "My pic!\nhttps://foo.bar/image.jpg",
+                    "url": "https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status",
+                    "method": "POST"
+                }
+            }
+        ],
+        "external_ids": [
+            "abc123"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "No External Id",
+        "msg": {
+            "text": "No External ID",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api.plivo.com/v1/Account/AuthID/Message/": [
+                {
+                    "status": 200,
+                    "body": {
+                        "missing": "OzYDlvf3SQVc"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.plivo.com/v1/Account/AuthID/Message/",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "src": "2020",
+                    "dst": "250788383383",
+                    "text": "No External ID",
+                    "url": "https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status",
+                    "method": "POST"
+                }
+            }
+        ],
+        "error": {
+            "message": "response content",
+            "log_error": {
+                "code": "response_content",
+                "message": "Response content indicates non-success."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api.plivo.com/v1/Account/AuthID/Message/": [
+                {
+                    "status": 401,
+                    "body": {
+                        "error": "failed"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.plivo.com/v1/Account/AuthID/Message/",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "src": "2020",
+                    "dst": "250788383383",
+                    "text": "Error Message",
+                    "url": "https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status",
+                    "method": "POST"
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api.plivo.com/v1/Account/AuthID/Message/": [
+                {
+                    "status": 429,
+                    "body": {
+                        "error": "failed"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api.plivo.com/v1/Account/AuthID/Message/",
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "src": "2020",
+                    "dst": "250788383383",
+                    "text": "Error Message",
+                    "url": "https://localhost/c/pl/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status",
+                    "method": "POST"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/rocketchat/handler_test.go
+++ b/handlers/rocketchat/handler_test.go
@@ -3,208 +3,25 @@ package rocketchat
 import (
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-const (
-	channelUUID = "8eb23e93-5ecb-45ba-b726-3b064e0c568c"
-	receiveURL  = "/c/rc/" + channelUUID + "/receive"
+var testChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c568c", "RC", "1234", "",
+	[]string{urns.RocketChat.Prefix},
+	map[string]any{
+		configBaseURL:     "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c",
+		configSecret:      "123456789",
+		configBotUsername: "rocket.cat",
+	},
 )
 
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c568c", "RC", "1234", "",
-		[]string{urns.RocketChat.Prefix},
-		map[string]any{
-			configBaseURL:     "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c",
-			configSecret:      "123456789",
-			configBotUsername: "rocket.cat",
-		},
-	),
-}
-
-const emptyMsg = `{
-	"user": {
-		"urn": "direct:john.doe",
-		"username": "john.doe",
-		"full_name": "John Doe"
-	}
-}`
-
-const helloMsg = `{
-	"user": {
-		"urn": "direct:john.doe",
-		"username": "john.doe",
-		"full_name": "John Doe"
-	},
-	"text": "Hello World"
-}`
-
-const attachmentMsg = `{
-	"user": {
-		"urn": "livechat:onrMgdKbpX9Qqtvoi",
-		"full_name": "John Doe"
-	},
-	"attachments": [{"type": "image/jpg", "url": "https://link.to/image.jpg"}]
-}`
-
-var testCases = []IncomingTestCase{
-	{
-		Label: "Receive Hello Msg",
-		URL:   receiveURL,
-		Headers: map[string]string{
-			"Authorization": "Token 123456789",
-		},
-		Data:                 helloMsg,
-		ExpectedURN:          "rocketchat:direct:john.doe#john.doe",
-		ExpectedMsgText:      Sp("Hello World"),
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-	},
-	{
-		Label: "Receive Attachment Msg",
-		URL:   receiveURL,
-		Headers: map[string]string{
-			"Authorization": "Token 123456789",
-		},
-		Data:                 attachmentMsg,
-		ExpectedURN:          "rocketchat:livechat:onrMgdKbpX9Qqtvoi",
-		ExpectedAttachments:  []string{"https://link.to/image.jpg"},
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-	},
-	{
-		Label: "Don't Receive Empty Msg",
-		URL:   receiveURL,
-		Headers: map[string]string{
-			"Authorization": "Token 123456789",
-		},
-		Data:                 emptyMsg,
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "no text or attachment",
-	},
-	{
-		Label: "Invalid Authorization",
-		URL:   receiveURL,
-		Headers: map[string]string{
-			"Authorization": "123456789",
-		},
-		Data:                 emptyMsg,
-		ExpectedRespStatus:   401,
-		ExpectedBodyContains: "invalid Authorization header",
-	},
-}
-
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, testCases)
-}
-
-var sendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "rocketchat:direct:john.doe#john.doe",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": {
-				httpx.NewMockResponse(201, nil, []byte(`{"id":"iNKE8a6k6cjbqWhWd"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"user":"direct:john.doe","bot":"rocket.cat","text":"Simple Message"}`,
-		}},
-		ExpectedExtIDs: []string{"iNKE8a6k6cjbqWhWd"},
-	},
-	{
-		Label:          "Send Attachment",
-		MsgURN:         "rocketchat:livechat:onrMgdKbpX9Qqtvoi",
-		MsgAttachments: []string{"application/pdf:https://link.to/attachment.pdf"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": {
-				httpx.NewMockResponse(201, nil, []byte(`{"id":"iNKE8a6k6cjbqWhWd"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"user":"livechat:onrMgdKbpX9Qqtvoi","bot":"rocket.cat","attachments":[{"type":"application/pdf","url":"https://link.to/attachment.pdf"}]}`,
-		}},
-		ExpectedExtIDs: []string{"iNKE8a6k6cjbqWhWd"},
-	},
-	{
-		Label:          "Send Text And Attachment",
-		MsgURN:         "rocketchat:direct:john.doe",
-		MsgText:        "Simple Message",
-		MsgAttachments: []string{"application/pdf:https://link.to/attachment.pdf"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": {
-				httpx.NewMockResponse(201, nil, []byte(`{"id":"iNKE8a6k6cjbqWhWd"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"user":"direct:john.doe","bot":"rocket.cat","text":"Simple Message","attachments":[{"type":"application/pdf","url":"https://link.to/attachment.pdf"}]}`,
-		}},
-		ExpectedExtIDs: []string{"iNKE8a6k6cjbqWhWd"},
-	},
-	{
-		Label:   "Unexcepted status response",
-		MsgText: "Simple Message",
-		MsgURN:  "rocketchat:direct:john.doe#john.doe",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": {
-				httpx.NewMockResponse(400, nil, []byte(`Error`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"user":"direct:john.doe","bot":"rocket.cat","text":"Simple Message"}`,
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Simple Message",
-		MsgURN:  "rocketchat:direct:john.doe#john.doe",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": {
-				httpx.NewMockResponse(429, nil, []byte(`Error`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"user":"direct:john.doe","bot":"rocket.cat","text":"Simple Message"}`,
-		}},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
-	{
-		Label:   "Connection Error",
-		MsgText: "Simple Message",
-		MsgURN:  "rocketchat:direct:john.doe#john.doe",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": {
-				httpx.NewMockResponse(500, nil, []byte(`Error`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"user":"direct:john.doe","bot":"rocket.cat","text":"Simple Message"}`,
-		}},
-		ExpectedError: channels.ErrConnectionFailed,
-	},
-	{
-		Label:   "Response Unexpected",
-		MsgText: "Simple Message",
-		MsgURN:  "rocketchat:direct:john.doe#john.doe",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": {
-				httpx.NewMockResponse(201, nil, []byte(`{"missing":"0"}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Body: `{"user":"direct:john.doe","bot":"rocket.cat","text":"Simple Message"}`,
-		}},
-		ExpectedError: channels.ErrResponseContent,
-	},
+	RunIncomingTests(t, []*models.Channel{testChannel}, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
-	RunOutgoingTestCases(t, testChannels[0], newHandler, sendTestCases, []string{"123456789"}, nil)
+	RunOutgoingTests(t, testChannel, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"123456789"}})
 }

--- a/handlers/rocketchat/testdata/incoming.json
+++ b/handlers/rocketchat/testdata/incoming.json
@@ -1,0 +1,170 @@
+[
+    {
+        "label": "Receive Hello Msg",
+        "url": "/c/rc/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive",
+        "headers": {
+            "Authorization": "Token 123456789"
+        },
+        "data": {
+            "user": {
+                "urn": "direct:john.doe",
+                "username": "john.doe",
+                "full_name": "John Doe"
+            },
+            "text": "Hello World"
+        },
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c568c",
+                        "msg_uuid": "019af5e0-3940-7000-a1c7-751687384d37",
+                        "text": "Hello World",
+                        "urn": "rocketchat:direct:john.doe#john.doe",
+                        "received_on": "2025-12-06T22:55:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019af5e0-3940-7000-a1c7-751687384d37",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c568c",
+                "urn": "rocketchat:direct:john.doe#john.doe",
+                "text": "Hello World",
+                "created_on": "2025-12-06T22:55:03Z",
+                "received_on": "2025-12-06T22:55:03Z",
+                "log_uuids": [
+                    "019af5e0-2d88-7000-aedd-35a54a537bd1"
+                ],
+                "contact_name": "John Doe"
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Attachment Msg",
+        "url": "/c/rc/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive",
+        "headers": {
+            "Authorization": "Token 123456789"
+        },
+        "data": {
+            "user": {
+                "urn": "livechat:onrMgdKbpX9Qqtvoi",
+                "full_name": "John Doe"
+            },
+            "attachments": [
+                {
+                    "type": "image/jpg",
+                    "url": "https://link.to/image.jpg"
+                }
+            ]
+        },
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c568c",
+                        "msg_uuid": "019aeebf-93e0-7000-9def-f4ee0aca01c6",
+                        "text": "",
+                        "urn": "rocketchat:livechat:onrMgdKbpX9Qqtvoi",
+                        "attachments": [
+                            "https://link.to/image.jpg"
+                        ],
+                        "received_on": "2025-12-05T13:42:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019aeebf-93e0-7000-9def-f4ee0aca01c6",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c568c",
+                "urn": "rocketchat:livechat:onrMgdKbpX9Qqtvoi",
+                "text": "",
+                "attachments": [
+                    "https://link.to/image.jpg"
+                ],
+                "created_on": "2025-12-05T13:42:03Z",
+                "received_on": "2025-12-05T13:42:03Z",
+                "log_uuids": [
+                    "019aeebf-8828-7000-8fb3-f63f50520e04"
+                ],
+                "contact_name": "John Doe"
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Don't Receive Empty Msg",
+        "url": "/c/rc/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive",
+        "headers": {
+            "Authorization": "Token 123456789"
+        },
+        "data": {
+            "user": {
+                "urn": "direct:john.doe",
+                "username": "john.doe",
+                "full_name": "John Doe"
+            }
+        },
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "no text or attachment"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid Authorization",
+        "url": "/c/rc/8eb23e93-5ecb-45ba-b726-3b064e0c568c/receive",
+        "headers": {
+            "Authorization": "123456789"
+        },
+        "data": {
+            "user": {
+                "urn": "direct:john.doe",
+                "username": "john.doe",
+                "full_name": "John Doe"
+            }
+        },
+        "response": {
+            "status": 401,
+            "body": {
+                "message": "Unauthorized",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "invalid Authorization header"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/rocketchat/testdata/outgoing.json
+++ b/handlers/rocketchat/testdata/outgoing.json
@@ -1,0 +1,289 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "rocketchat:direct:john.doe#john.doe"
+        },
+        "http_mocks": {
+            "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": [
+                {
+                    "status": 201,
+                    "body": {
+                        "id": "iNKE8a6k6cjbqWhWd"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
+                "headers": {
+                    "Authorization": "Token 123456789",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "direct:john.doe",
+                    "bot": "rocket.cat",
+                    "text": "Simple Message"
+                }
+            }
+        ],
+        "external_ids": [
+            "iNKE8a6k6cjbqWhWd"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "urn": "rocketchat:livechat:onrMgdKbpX9Qqtvoi",
+            "attachments": [
+                "application/pdf:https://link.to/attachment.pdf"
+            ]
+        },
+        "http_mocks": {
+            "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": [
+                {
+                    "status": 201,
+                    "body": {
+                        "id": "iNKE8a6k6cjbqWhWd"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
+                "headers": {
+                    "Authorization": "Token 123456789",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "livechat:onrMgdKbpX9Qqtvoi",
+                    "bot": "rocket.cat",
+                    "attachments": [
+                        {
+                            "type": "application/pdf",
+                            "url": "https://link.to/attachment.pdf"
+                        }
+                    ]
+                }
+            }
+        ],
+        "external_ids": [
+            "iNKE8a6k6cjbqWhWd"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Text And Attachment",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "rocketchat:direct:john.doe",
+            "attachments": [
+                "application/pdf:https://link.to/attachment.pdf"
+            ]
+        },
+        "http_mocks": {
+            "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": [
+                {
+                    "status": 201,
+                    "body": {
+                        "id": "iNKE8a6k6cjbqWhWd"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
+                "headers": {
+                    "Authorization": "Token 123456789",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "direct:john.doe",
+                    "bot": "rocket.cat",
+                    "text": "Simple Message",
+                    "attachments": [
+                        {
+                            "type": "application/pdf",
+                            "url": "https://link.to/attachment.pdf"
+                        }
+                    ]
+                }
+            }
+        ],
+        "external_ids": [
+            "iNKE8a6k6cjbqWhWd"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unexcepted status response",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "rocketchat:direct:john.doe#john.doe"
+        },
+        "http_mocks": {
+            "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": [
+                {
+                    "status": 400,
+                    "body": "Error"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
+                "headers": {
+                    "Authorization": "Token 123456789",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "direct:john.doe",
+                    "bot": "rocket.cat",
+                    "text": "Simple Message"
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "rocketchat:direct:john.doe#john.doe"
+        },
+        "http_mocks": {
+            "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": [
+                {
+                    "status": 429,
+                    "body": "Error"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
+                "headers": {
+                    "Authorization": "Token 123456789",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "direct:john.doe",
+                    "bot": "rocket.cat",
+                    "text": "Simple Message"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Connection Error",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "rocketchat:direct:john.doe#john.doe"
+        },
+        "http_mocks": {
+            "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": [
+                {
+                    "status": 500,
+                    "body": "Error"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
+                "headers": {
+                    "Authorization": "Token 123456789",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "direct:john.doe",
+                    "bot": "rocket.cat",
+                    "text": "Simple Message"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel connection failed",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_failed",
+                "message": "Connection to server failed."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Response Unexpected",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "rocketchat:direct:john.doe#john.doe"
+        },
+        "http_mocks": {
+            "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message": [
+                {
+                    "status": 201,
+                    "body": {
+                        "missing": "0"
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
+                "headers": {
+                    "Authorization": "Token 123456789",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Courier/Dev"
+                },
+                "body": {
+                    "user": "direct:john.doe",
+                    "bot": "rocket.cat",
+                    "text": "Simple Message"
+                }
+            }
+        ],
+        "error": {
+            "message": "response content",
+            "log_error": {
+                "code": "response_content",
+                "message": "Response content indicates non-success."
+            }
+        },
+        "log_errors": []
+    }
+]

--- a/handlers/telesom/handler_test.go
+++ b/handlers/telesom/handler_test.go
@@ -1,196 +1,24 @@
 package telesom
 
 import (
-	"net/url"
 	"testing"
-	"time"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/dates"
-	"github.com/nyaruka/gocommon/httpx"
-	"github.com/nyaruka/gocommon/svclogs"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "TS", "2020", "SO", []string{urns.Phone.Prefix}, nil),
-}
-
-var handleTestCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid Message",
-		URL:                  "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?mobile=%2B2349067554729&msg=Join",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2349067554729",
-	},
-	{
-		Label:                "Invalid URN",
-		URL:                  "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?mobile=MTN&msg=Join",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "not a possible number",
-	},
-	{
-		Label:                "Receive No Params",
-		URL:                  "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "field 'mobile' required",
-	},
-	{
-		Label:                "Receive No Sender",
-		URL:                  "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?msg=Join",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "field 'mobile' required",
-	},
-	{
-		Label:                "Receive Valid Message",
-		URL:                  "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
-		Data:                 "mobile=%2B2349067554729&msg=Join",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2349067554729",
-	},
-	{
-		Label:                "Invalid URN",
-		URL:                  "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
-		Data:                 "mobile=MTN&msg=Join",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "not a possible number",
-	},
-	{
-		Label:                "Receive No Params",
-		URL:                  "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
-		Data:                 "empty",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "field 'mobile' required",
-	},
-	{
-		Label:                "Receive No Sender",
-		URL:                  "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
-		Data:                 "msg=Join",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "field 'mobile' required",
-	},
-}
-
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
-}
+	chs := []*models.Channel{
+		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "TS", "2020", "SO", []string{urns.Phone.Prefix}, nil),
+	}
 
-var defaultSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+252788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://telesom.com/sendsms_other*": {
-				httpx.NewMockResponse(200, nil, []byte(`<return>Success</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form:    url.Values{"msg": {"Simple Message"}, "to": {"0788383383"}, "from": {"2020"}, "key": {"D69BB824F88F20482B94ECF3822EBD84"}},
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-		}},
-	},
-	{
-		Label:   "Unicode Send",
-		MsgText: "☺",
-		MsgURN:  "tel:+252788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://telesom.com/sendsms_other*": {
-				httpx.NewMockResponse(200, nil, []byte(`<return>Success</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form:    url.Values{"msg": {"☺"}, "to": {"0788383383"}, "from": {"2020"}, "key": {"60421A7D99BD79FE02697D567315AD0E"}},
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-		}},
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+252788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://telesom.com/sendsms_other*": {
-				httpx.NewMockResponse(401, nil, []byte(`<return>error</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form:    url.Values{"msg": {`Error Message`}, "to": {"0788383383"}, "from": {"2020"}, "key": {"3F1E492B2186551570F24C2F07D5D7E2"}},
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+252788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://telesom.com/sendsms_other*": {
-				httpx.NewMockResponse(429, nil, []byte(`<return>error</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form:    url.Values{"msg": {`Error Message`}, "to": {"0788383383"}, "from": {"2020"}, "key": {"3F1E492B2186551570F24C2F07D5D7E2"}},
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-		}},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+252788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://telesom.com/sendsms_other*": {
-				httpx.NewMockResponse(200, nil, []byte(`<return>Success</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form:    url.Values{"msg": {"My pic!\nhttps://foo.bar/image.jpg"}, "to": {"0788383383"}, "from": {"2020"}, "key": {"DBE569579FD899628C17254ECCE15DB7"}},
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-		}},
-	},
-	{
-		Label:   "Connection Error",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+252788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://telesom.com/sendsms_other*": {
-				httpx.NewMockResponse(500, nil, []byte(`<return>error</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form:    url.Values{"msg": {`Error Message`}, "to": {"0788383383"}, "from": {"2020"}, "key": {"3F1E492B2186551570F24C2F07D5D7E2"}},
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-		}},
-		ExpectedError: channels.ErrConnectionFailed,
-	},
-	{
-		Label:   "Response Unexpected",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+252788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://telesom.com/sendsms_other*": {
-				httpx.NewMockResponse(200, nil, []byte(`<return>Missing</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Form:    url.Values{"msg": {"Simple Message"}, "to": {"0788383383"}, "from": {"2020"}, "key": {"D69BB824F88F20482B94ECF3822EBD84"}},
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-		}},
-		ExpectedLogErrors: []*svclogs.Error{&svclogs.Error{Message: "Received invalid response content: <return>Missing</return>"}},
-		ExpectedError:     channels.ErrResponseContent,
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "TS", "2020", "US",
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "TS", "2020", "US",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
 			"password": "Password",
@@ -200,8 +28,5 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	// mock time so we can have predictable MD5 hashes
-	dates.SetNowFunc(dates.NewFixedNow(time.Date(2018, 4, 11, 18, 24, 30, 123456000, time.UTC)))
-
-	RunOutgoingTestCases(t, defaultChannel, newHandler, defaultSendTestCases, []string{"Password", "secret"}, nil)
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"Password", "secret"}})
 }

--- a/handlers/telesom/testdata/incoming.json
+++ b/handlers/telesom/testdata/incoming.json
@@ -1,0 +1,224 @@
+[
+    {
+        "label": "Receive Valid Message",
+        "url": "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?mobile=%2B2349067554729&msg=Join",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d240-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-11-01T05:43:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d240-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-11-01T05:43:03Z",
+                "received_on": "2025-11-01T05:43:03Z",
+                "log_uuids": [
+                    "019a3df0-c688-7000-aac1-d0d96ed17383"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid URN",
+        "url": "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?mobile=MTN&msg=Join",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "not a possible number"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No Params",
+        "url": "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "Key: 'moForm.Mobile' Error:Field validation for 'Mobile' failed on the 'required' tag\nKey: 'moForm.Message' Error:Field validation for 'Message' failed on the 'required' tag"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'mobile' required"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'message' required"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No Sender",
+        "url": "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?msg=Join",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "Key: 'moForm.Mobile' Error:Field validation for 'Mobile' failed on the 'required' tag"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'mobile' required"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid Message via POST",
+        "url": "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "mobile=%2B2349067554729\u0026msg=Join",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d240-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-10-30T19:55:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d240-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-10-30T19:55:03Z",
+                "received_on": "2025-10-30T19:55:03Z",
+                "log_uuids": [
+                    "019a36b0-1608-7000-a2eb-00510cf177af"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid URN via POST",
+        "url": "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "mobile=MTN\u0026msg=Join",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "not a possible number"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No Params via POST",
+        "url": "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "empty",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "Key: 'moForm.Mobile' Error:Field validation for 'Mobile' failed on the 'required' tag\nKey: 'moForm.Message' Error:Field validation for 'Message' failed on the 'required' tag"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'mobile' required"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'message' required"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No Sender via POST",
+        "url": "/c/ts/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "msg=Join",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "Key: 'moForm.Mobile' Error:Field validation for 'Mobile' failed on the 'required' tag"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'mobile' required"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/telesom/testdata/outgoing.json
+++ b/handlers/telesom/testdata/outgoing.json
@@ -1,0 +1,320 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+252788383383"
+        },
+        "http_mocks": {
+            "http://telesom.com/sendsms_other*": [
+                {
+                    "status": 200,
+                    "body": "<return>Success</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://telesom.com/sendsms_other",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "key": [
+                        "03EA5F12E10F46F9A6CD9DD057209061"
+                    ],
+                    "msg": [
+                        "Simple Message"
+                    ],
+                    "to": [
+                        "0788383383"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺",
+            "urn": "tel:+252788383383"
+        },
+        "http_mocks": {
+            "http://telesom.com/sendsms_other*": [
+                {
+                    "status": 200,
+                    "body": "<return>Success</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://telesom.com/sendsms_other",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "key": [
+                        "6BA942D46033A61ADC34B797C677A56F"
+                    ],
+                    "msg": [
+                        "☺"
+                    ],
+                    "to": [
+                        "0788383383"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+252788383383"
+        },
+        "http_mocks": {
+            "http://telesom.com/sendsms_other*": [
+                {
+                    "status": 401,
+                    "body": "<return>error</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://telesom.com/sendsms_other",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "key": [
+                        "BB91F9C5EB3E7092DAD42A3513E37953"
+                    ],
+                    "msg": [
+                        "Error Message"
+                    ],
+                    "to": [
+                        "0788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+252788383383"
+        },
+        "http_mocks": {
+            "http://telesom.com/sendsms_other*": [
+                {
+                    "status": 429,
+                    "body": "<return>error</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://telesom.com/sendsms_other",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "key": [
+                        "270868A581F155F5271EE31A50E98C6D"
+                    ],
+                    "msg": [
+                        "Error Message"
+                    ],
+                    "to": [
+                        "0788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+252788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://telesom.com/sendsms_other*": [
+                {
+                    "status": 200,
+                    "body": "<return>Success</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://telesom.com/sendsms_other",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "key": [
+                        "029C543FDC742D36BAC425FF4914136B"
+                    ],
+                    "msg": [
+                        "My pic!\nhttps://foo.bar/image.jpg"
+                    ],
+                    "to": [
+                        "0788383383"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Connection Error",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+252788383383"
+        },
+        "http_mocks": {
+            "http://telesom.com/sendsms_other*": [
+                {
+                    "status": 500,
+                    "body": "<return>error</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://telesom.com/sendsms_other",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "key": [
+                        "9EE66ED353E211C8BA61A32B6C5A72BF"
+                    ],
+                    "msg": [
+                        "Error Message"
+                    ],
+                    "to": [
+                        "0788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "channel connection failed",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_failed",
+                "message": "Connection to server failed."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Response Unexpected",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+252788383383"
+        },
+        "http_mocks": {
+            "http://telesom.com/sendsms_other*": [
+                {
+                    "status": 200,
+                    "body": "<return>Missing</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://telesom.com/sendsms_other",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "key": [
+                        "2F6AA5267A850FF657ECB11181C75240"
+                    ],
+                    "msg": [
+                        "Simple Message"
+                    ],
+                    "to": [
+                        "0788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response content",
+            "log_error": {
+                "code": "response_content",
+                "message": "Response content indicates non-success."
+            }
+        },
+        "log_errors": [
+            {
+                "code": "",
+                "message": "Received invalid response content: <return>Missing</return>"
+            }
+        ]
+    }
+]

--- a/handlers/yo/handler_test.go
+++ b/handlers/yo/handler_test.go
@@ -1,174 +1,20 @@
 package yo
 
 import (
-	"net/url"
 	"testing"
-	"time"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-var (
-	receiveValidMessage         = "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=2349067554729&message=Join"
-	receiveValidMessageFrom     = "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?from=%2B2349067554729&message=Join"
-	receiveValidMessageWithDate = "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=%2B2349067554729&message=Join&date=2017-06-23T12:30:00.500Z"
-	receiveValidMessageWithTime = "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=%2B2349067554729&message=Join&time=2017-06-23T12:30:00Z"
-	receiveInvalidURN           = "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=MTN&message=Join"
-	receiveNoParams             = "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-	receiveNoSender             = "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?message=Join"
-	receiveInvalidDate          = "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=%2B2349067554729&message=Join&time=20170623T123000Z"
-)
-
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "YO", "2020", "UG", []string{urns.Phone.Prefix}, map[string]any{"username": "yo-username", "password": "yo-password"}),
-}
-
-var handleTestCases = []IncomingTestCase{
-	{Label: "Receive Valid Message", URL: receiveValidMessage, Data: "", ExpectedRespStatus: 200, ExpectedBodyContains: "Accepted",
-		ExpectedMsgText: Sp("Join"), ExpectedURN: "tel:+2349067554729"},
-	{Label: "Receive Valid From", URL: receiveValidMessageFrom, Data: "", ExpectedRespStatus: 200, ExpectedBodyContains: "Accepted",
-		ExpectedMsgText: Sp("Join"), ExpectedURN: "tel:+2349067554729"},
-	{Label: "Receive Valid Message With Date", URL: receiveValidMessageWithDate, Data: "", ExpectedRespStatus: 200, ExpectedBodyContains: "Accepted",
-		ExpectedMsgText: Sp("Join"), ExpectedURN: "tel:+2349067554729", ExpectedDate: time.Date(2017, 6, 23, 12, 30, 0, int(500*time.Millisecond), time.UTC)},
-	{Label: "Receive Valid Message With Time", URL: receiveValidMessageWithTime, Data: "", ExpectedRespStatus: 200, ExpectedBodyContains: "Accepted",
-		ExpectedMsgText: Sp("Join"), ExpectedURN: "tel:+2349067554729", ExpectedDate: time.Date(2017, 6, 23, 12, 30, 0, 0, time.UTC)},
-	{Label: "Invalid URN", URL: receiveInvalidURN, Data: "", ExpectedRespStatus: 400, ExpectedBodyContains: "not a possible number"},
-	{Label: "Receive No Params", URL: receiveNoParams, Data: "", ExpectedRespStatus: 400, ExpectedBodyContains: "must have one of 'sender' or 'from'"},
-	{Label: "Receive No Sender", URL: receiveNoSender, Data: "", ExpectedRespStatus: 400, ExpectedBodyContains: "must have one of 'sender' or 'from'"},
-	{Label: "Receive Invalid Date", URL: receiveInvalidDate, Data: "", ExpectedRespStatus: 400, ExpectedBodyContains: "invalid date format, must be RFC 3339"},
-}
+var testChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "YO", "2020", "UG", []string{urns.Phone.Prefix}, map[string]any{"username": "yo-username", "password": "yo-password"})
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
-}
-
-var getSendTestCases = []OutgoingTestCase{
-	{Label: "Plain Send",
-		MsgText: "Simple Message", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smgw1.yo.co.ug:9100/sendsms*": {
-				httpx.NewMockResponse(200, nil, []byte(`ybs_autocreate_status=OK`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{Params: url.Values{"sms_content": {"Simple Message"},
-			"destinations": {"250788383383"},
-			"ybsacctno":    {"yo-username"},
-			"password":     {"yo-password"},
-			"origin":       {"2020"},
-		}}},
-	},
-	{Label: "Blacklisted",
-		MsgText: "Simple Message", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smgw1.yo.co.ug:9100/sendsms*": {
-				httpx.NewMockResponse(200, nil, []byte(`ybs_autocreate_status=ERROR&ybs_autocreate_message=256794224665%3ABLACKLISTED`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{Params: url.Values{"sms_content": {"Simple Message"},
-			"destinations": {"250788383383"},
-			"ybsacctno":    {"yo-username"},
-			"password":     {"yo-password"},
-			"origin":       {"2020"},
-		}}},
-		ExpectedError: channels.ErrContactStopped,
-	},
-	{Label: "Errored wrong authorization",
-		MsgText: "Simple Message", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smgw1.yo.co.ug:9100/sendsms*": {
-				httpx.NewMockResponse(200, nil, []byte(`ybs_autocreate_status=ERROR&ybs_autocreate_message=YBS+AutoCreate+Subsystem%3A+Access+denied+due+to+wrong+authorization+code`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{Params: url.Values{"sms_content": {"Simple Message"},
-			"destinations": {"250788383383"},
-			"ybsacctno":    {"yo-username"},
-			"password":     {"yo-password"},
-			"origin":       {"2020"},
-		}}},
-		ExpectedError: channels.ErrResponseContent,
-	},
-	{Label: "Unicode Send",
-		MsgText: "☺", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smgw1.yo.co.ug:9100/sendsms*": {
-				httpx.NewMockResponse(200, nil, []byte(`ybs_autocreate_status=OK`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{Params: url.Values{"sms_content": {"☺"},
-			"destinations": {"250788383383"},
-			"ybsacctno":    {"yo-username"},
-			"password":     {"yo-password"},
-			"origin":       {"2020"},
-		}}},
-	},
-	{Label: "Error Sending",
-		MsgText: "Error Message", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smgw1.yo.co.ug:9100/sendsms*": {
-				httpx.NewMockResponse(401, nil, []byte(`Error`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{Params: url.Values{"sms_content": {"Error Message"},
-			"destinations": {"250788383383"},
-			"ybsacctno":    {"yo-username"},
-			"password":     {"yo-password"},
-			"origin":       {"2020"},
-		}}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{Label: "Throttled",
-		MsgText: "Error Message", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smgw1.yo.co.ug:9100/sendsms*": {
-				httpx.NewMockResponse(429, nil, []byte(`Error`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{Params: url.Values{"sms_content": {"Error Message"},
-			"destinations": {"250788383383"},
-			"ybsacctno":    {"yo-username"},
-			"password":     {"yo-password"},
-			"origin":       {"2020"},
-		}}},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
-	{Label: "Connection error",
-		MsgText: "Error Message", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smgw1.yo.co.ug:9100/sendsms*": {
-				httpx.NewMockResponse(500, nil, []byte(`Error`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{Params: url.Values{"sms_content": {"Error Message"},
-			"destinations": {"250788383383"},
-			"ybsacctno":    {"yo-username"},
-			"password":     {"yo-password"},
-			"origin":       {"2020"},
-		}}},
-		ExpectedError: channels.ErrConnectionFailed,
-	},
-	{Label: "Send Attachment",
-		MsgText: "My pic!", MsgURN: "tel:+250788383383", MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://smgw1.yo.co.ug:9100/sendsms*": {
-				httpx.NewMockResponse(200, nil, []byte(`ybs_autocreate_status=OK`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{Params: url.Values{"sms_content": {"My pic!\nhttps://foo.bar/image.jpg"},
-			"destinations": {"250788383383"},
-			"ybsacctno":    {"yo-username"},
-			"password":     {"yo-password"},
-			"origin":       {"2020"},
-		}}},
-	},
+	RunIncomingTests(t, []*models.Channel{testChannel}, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
-	var getChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "YO", "2020", "UG", []string{urns.Phone.Prefix}, map[string]any{"username": "yo-username", "password": "yo-password"})
-
-	RunOutgoingTestCases(t, getChannel, newHandler, getSendTestCases, []string{"yo-password"}, nil)
+	RunOutgoingTests(t, testChannel, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"yo-password"}})
 }

--- a/handlers/yo/testdata/incoming.json
+++ b/handlers/yo/testdata/incoming.json
@@ -1,0 +1,230 @@
+[
+    {
+        "label": "Receive Valid Message",
+        "url": "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=2349067554729&message=Join",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-11-01T05:43:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-11-01T05:43:04Z",
+                "received_on": "2025-11-01T05:43:03Z",
+                "log_uuids": [
+                    "019a3df0-c688-7000-aac1-d0d96ed17383"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid From",
+        "url": "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?from=%2B2349067554729&message=Join",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-11-08T21:04:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-11-08T21:04:04Z",
+                "received_on": "2025-11-08T21:04:03Z",
+                "log_uuids": [
+                    "019a6548-7de8-7000-b837-178187882754"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid Message With Date",
+        "url": "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=%2B2349067554729&message=Join&date=2017-06-23T12:30:00.500Z",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2017-06-23T12:30:00.5Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-10-29T10:23:04Z",
+                "received_on": "2017-06-23T12:30:00.5Z",
+                "log_uuids": [
+                    "019a2f7e-0b88-7000-9854-09ae5f93f47f"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid Message With Time",
+        "url": "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=%2B2349067554729&message=Join&time=2017-06-23T12:30:00Z",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2017-06-23T12:30:00Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-12-07T04:02:04Z",
+                "received_on": "2017-06-23T12:30:00Z",
+                "log_uuids": [
+                    "019af6f9-3ea8-7000-a05e-c14f249cf2ce"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid URN",
+        "url": "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=MTN&message=Join",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "not a possible number"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No Params",
+        "url": "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "must have one of 'sender' or 'from'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No Sender",
+        "url": "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?message=Join",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "must have one of 'sender' or 'from'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Invalid Date",
+        "url": "/c/yo/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=%2B2349067554729&message=Join&time=20170623T123000Z",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "invalid date format, must be RFC 3339"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/yo/testdata/outgoing.json
+++ b/handlers/yo/testdata/outgoing.json
@@ -1,0 +1,250 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smgw1.yo.co.ug:9100/sendsms*": [
+                {
+                    "status": 200,
+                    "body": "ybs_autocreate_status=OK"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Simple+Message&ybsacctno=yo-username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Blacklisted",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smgw1.yo.co.ug:9100/sendsms*": [
+                {
+                    "status": 200,
+                    "body": "ybs_autocreate_status=ERROR&ybs_autocreate_message=256794224665%3ABLACKLISTED"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Simple+Message&ybsacctno=yo-username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "contact opted out",
+            "log_error": {
+                "code": "contact_stopped",
+                "message": "Contact has opted-out of messages from this channel."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Errored wrong authorization",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smgw1.yo.co.ug:9100/sendsms*": [
+                {
+                    "status": 200,
+                    "body": "ybs_autocreate_status=ERROR&ybs_autocreate_message=YBS+AutoCreate+Subsystem%3A+Access+denied+due+to+wrong+authorization+code"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Simple+Message&ybsacctno=yo-username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "response content",
+            "log_error": {
+                "code": "response_content",
+                "message": "Response content indicates non-success."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smgw1.yo.co.ug:9100/sendsms*": [
+                {
+                    "status": 200,
+                    "body": "ybs_autocreate_status=OK"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=%E2%98%BA&ybsacctno=yo-username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smgw1.yo.co.ug:9100/sendsms*": [
+                {
+                    "status": 401,
+                    "body": "Error"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Error+Message&ybsacctno=yo-username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smgw1.yo.co.ug:9100/sendsms*": [
+                {
+                    "status": 429,
+                    "body": "Error"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Error+Message&ybsacctno=yo-username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Connection error",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://smgw1.yo.co.ug:9100/sendsms*": [
+                {
+                    "status": 500,
+                    "body": "Error"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Error+Message&ybsacctno=yo-username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel connection failed",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_failed",
+                "message": "Connection to server failed."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://smgw1.yo.co.ug:9100/sendsms*": [
+                {
+                    "status": 200,
+                    "body": "ybs_autocreate_status=OK"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&ybsacctno=yo-username",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "Courier/Dev"
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]


### PR DESCRIPTION
## Summary

Converts the tests of ten more handlers with no request signing hooks or multipart sends (yo, freshchat, dmark, m3tech, plivo, macrokiosk, dart, telesom, playmobile and rocketchat) to the file-based case format from #1167. Adds one capability to the format along the way: a body written as a string in a case file keeps its exact bytes, which handlers that sign over the body need.

## Changes

**Converted handlers** (`handlers/{yo,freshchat,dmark,m3tech,plivo,macrokiosk,dart,telesom,playmobile,rocketchat}/`)
- Cases moved to `testdata/incoming.json` and `testdata/outgoing.json`; each `handler_test.go` is now the channel definitions and the runner calls. Freshchat has a second incoming file for its handler variant without signature validation. Plivo, macrokiosk and dart keep their one-line max message length overrides in Go.
- Cases that shared a label are renamed to say what differs (macrokiosk's longcode receive, dart's part-suffix status and its two invalid-status variants, telesom's POST variants), since the runner requires unique labels within a file.
- Telesom no longer pins the clock in Go for predictable MD5 keys, and no longer leaks that pinned clock to later tests; the runner mocks time per case.

**Byte-exact bodies** (`handlers/handlertest/snapshots.go`, `incoming.go`)
- `HTTPBody` now remembers when a case file wrote a body as a string and writes it back the same way on `-update`. Freshchat verifies an RSA signature over the raw request body, and embedding that body as JSON re-serialised it, so its valid-signature case failed. Its two signed cases are stored as strings and record the expected outcomes.
- Empty bodies are omitted via `omitzero` now that the type is a struct.

## Behavior examples

A body that must reach the handler byte-for-byte is written as a string:

```json
"data": "{\"actor\":{\"actor_type\":\"user\",...},\"action\":\"message_create\",...}"
```

while one where only the content matters is written as JSON, as before:

```json
"data": {
    "update_id": 174114370,
    "message": { "...": "..." }
}
```

## Test plan

- [x] Every recorded outcome reviewed against the expectations in the old Go cases; all match, apart from telesom's MD5 keys which are now derived from the runner's per-case clock rather than a hand-pinned one
- [x] Each converted handler passes with and without `-update`, and a second run confirms the files are stable
- [x] Every previously converted handler still passes with the `HTTPBody` change
- [x] Full `go test -p=1 ./...` passes in the devcontainer
- [x] `go vet ./...` and `gofmt` clean