### PR TITLE
Leave the User-Agent header out of requests captured in handler test files

### DIFF
--- a/handlers/arabiacell/testdata/outgoing.json
+++ b/handlers/arabiacell/testdata/outgoing.json
@@ -22,8 +22,7 @@
                 "url": "https://acsdp.arabiacell.net",
                 "headers": {
                     "Accept": "application/xml",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chargingLevel": [
@@ -75,8 +74,7 @@
                 "url": "https://acsdp.arabiacell.net",
                 "headers": {
                     "Accept": "application/xml",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chargingLevel": [
@@ -133,8 +131,7 @@
                 "url": "https://acsdp.arabiacell.net",
                 "headers": {
                     "Accept": "application/xml",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chargingLevel": [
@@ -190,8 +187,7 @@
                 "url": "https://acsdp.arabiacell.net",
                 "headers": {
                     "Accept": "application/xml",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chargingLevel": [
@@ -248,8 +244,7 @@
                 "url": "https://acsdp.arabiacell.net",
                 "headers": {
                     "Accept": "application/xml",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chargingLevel": [

--- a/handlers/burstsms/testdata/outgoing.json
+++ b/handlers/burstsms/testdata/outgoing.json
@@ -27,8 +27,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic dXNlcjE6cGFzczE=",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [
@@ -69,8 +68,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic dXNlcjE6cGFzczE=",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [
@@ -118,8 +116,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic dXNlcjE6cGFzczE=",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [
@@ -164,8 +161,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic dXNlcjE6cGFzczE=",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [
@@ -211,8 +207,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic dXNlcjE6cGFzczE=",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [

--- a/handlers/dart/testdata/outgoing.json
+++ b/handlers/dart/testdata/outgoing.json
@@ -18,8 +18,7 @@
                 "method": "GET",
                 "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=Simple+Message&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -48,16 +47,14 @@
                 "method": "GET",
                 "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=This+is+a+longer+message+than+160+characters+and+will+cause+us+to+split+it+into+two+separate+parts%2C+isn%27t+that+right+but+it+is+even+longer+than+before+I+say%2C&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             },
             {
                 "method": "GET",
                 "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=I+need+to+keep+adding+more+things+to+make+it+work&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b.2&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -85,8 +82,7 @@
                 "method": "GET",
                 "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -111,8 +107,7 @@
                 "method": "GET",
                 "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=Error+Message&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -144,8 +139,7 @@
                 "method": "GET",
                 "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=Error+Message&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -178,8 +172,7 @@
                 "method": "GET",
                 "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=Simple+Message&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -212,8 +205,7 @@
                 "method": "GET",
                 "url": "http://202.43.169.11/APIhttpU/receive2waysms.php?dcs=0&message=Simple+Message&messageid=0191e180-7d60-7000-aded-7d8b151cbd5b&original=2020&password=Password&sendto=250788383383&udhl=0&userid=Username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],

--- a/handlers/dmark/testdata/outgoing.json
+++ b/handlers/dmark/testdata/outgoing.json
@@ -23,8 +23,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Token Authy",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "dlr_url": [
@@ -70,8 +69,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Token Authy",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "dlr_url": [
@@ -121,8 +119,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Token Authy",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "dlr_url": [
@@ -172,8 +169,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Token Authy",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "dlr_url": [

--- a/handlers/freshchat/testdata/outgoing.json
+++ b/handlers/freshchat/testdata/outgoing.json
@@ -19,8 +19,7 @@
                 "url": "https://api.freshchat.com/v2/conversations",
                 "headers": {
                     "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [
@@ -70,8 +69,7 @@
                 "url": "https://api.freshchat.com/v2/conversations",
                 "headers": {
                     "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [
@@ -125,8 +123,7 @@
                 "url": "https://api.freshchat.com/v2/conversations",
                 "headers": {
                     "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [
@@ -173,8 +170,7 @@
                 "url": "https://api.freshchat.com/v2/conversations",
                 "headers": {
                     "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [
@@ -228,8 +224,7 @@
                 "url": "https://api.freshchat.com/v2/conversations",
                 "headers": {
                     "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [
@@ -284,8 +279,7 @@
                 "url": "https://api.freshchat.com/v2/conversations",
                 "headers": {
                     "Authorization": "Bearer enYtdXNlcm5hbWU6enYtcGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [

--- a/handlers/handlertest/snapshots.go
+++ b/handlers/handlertest/snapshots.go
@@ -87,7 +87,8 @@ type HandlerLog struct {
 }
 
 // CapturedRequest is an HTTP request a handler made which was answered by a mock. A form encoded body is written as
-// its decoded values so that the file stays readable.
+// its decoded values so that the file stays readable. The User-Agent header is left out because every request
+// carries the same one and a change to it would otherwise touch every file.
 type CapturedRequest struct {
 	Method  string            `json:"method"`
 	URL     string            `json:"url"`
@@ -99,7 +100,9 @@ type CapturedRequest struct {
 func captureRequest(r *http.Request) *CapturedRequest {
 	c := &CapturedRequest{Method: r.Method, URL: r.URL.String(), Headers: make(map[string]string, len(r.Header))}
 	for k := range r.Header {
-		c.Headers[k] = r.Header.Get(k)
+		if k != "User-Agent" {
+			c.Headers[k] = r.Header.Get(k)
+		}
 	}
 
 	var body []byte

--- a/handlers/i2sms/testdata/outgoing.json
+++ b/handlers/i2sms/testdata/outgoing.json
@@ -29,8 +29,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic dXNlcjE6cGFzczE=",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "action": [
@@ -74,8 +73,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic dXNlcjE6cGFzczE=",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "action": [
@@ -128,8 +126,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic dXNlcjE6cGFzczE=",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "action": [
@@ -178,8 +175,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic dXNlcjE6cGFzczE=",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "action": [
@@ -228,8 +224,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic dXNlcjE6cGFzczE=",
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "action": [

--- a/handlers/m3tech/testdata/outgoing.json
+++ b/handlers/m3tech/testdata/outgoing.json
@@ -20,10 +20,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Simple+Message&SMSChannel=0&SMSType=0&Telco=0&UserId=Username",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Simple+Message&SMSChannel=0&SMSType=0&Telco=0&UserId=Username"
             }
         ],
         "log_errors": []
@@ -49,10 +46,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=%E2%98%BA&SMSChannel=0&SMSType=7&Telco=0&UserId=Username",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=%E2%98%BA&SMSChannel=0&SMSType=7&Telco=0&UserId=Username"
             }
         ],
         "log_errors": []
@@ -78,10 +72,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Fancy+%22Smart%22+Quotes&SMSChannel=0&SMSType=0&Telco=0&UserId=Username",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Fancy+%22Smart%22+Quotes&SMSChannel=0&SMSType=0&Telco=0&UserId=Username"
             }
         ],
         "log_errors": []
@@ -110,10 +101,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&SMSChannel=0&SMSType=0&Telco=0&UserId=Username",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&SMSChannel=0&SMSType=0&Telco=0&UserId=Username"
             }
         ],
         "log_errors": []
@@ -139,10 +127,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Error+Sending&SMSChannel=0&SMSType=0&Telco=0&UserId=Username",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Error+Sending&SMSChannel=0&SMSType=0&Telco=0&UserId=Username"
             }
         ],
         "error": {
@@ -175,10 +160,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Error+Sending&SMSChannel=0&SMSType=0&Telco=0&UserId=Username",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://secure.m3techservice.com/GenericServiceRestAPI/api/SendSMS?AuthKey=m3-Tech&HandsetPort=0&MobileNo=250788383383&MsgHeader=2020&MsgId=0191e180-7d60-7000-aded-7d8b151cbd5b&Password=Password&SMS=Error+Sending&SMSChannel=0&SMSType=0&Telco=0&UserId=Username"
             }
         ],
         "error": {

--- a/handlers/macrokiosk/testdata/outgoing.json
+++ b/handlers/macrokiosk/testdata/outgoing.json
@@ -21,8 +21,7 @@
                 "url": "https://www.etracker.cc/bulksms/send",
                 "headers": {
                     "Accept": "application/json",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "Username",
@@ -68,8 +67,7 @@
                 "url": "https://www.etracker.cc/bulksms/send",
                 "headers": {
                     "Accept": "application/json",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "Username",
@@ -86,8 +84,7 @@
                 "url": "https://www.etracker.cc/bulksms/send",
                 "headers": {
                     "Accept": "application/json",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "Username",
@@ -131,8 +128,7 @@
                 "url": "https://www.etracker.cc/bulksms/send",
                 "headers": {
                     "Accept": "application/json",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "Username",
@@ -172,8 +168,7 @@
                 "url": "https://www.etracker.cc/bulksms/send",
                 "headers": {
                     "Accept": "application/json",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "Username",
@@ -215,8 +210,7 @@
                 "url": "https://www.etracker.cc/bulksms/send",
                 "headers": {
                     "Accept": "application/json",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "Username",
@@ -260,8 +254,7 @@
                 "url": "https://www.etracker.cc/bulksms/send",
                 "headers": {
                     "Accept": "application/json",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "Username",

--- a/handlers/messangi/testdata/outgoing.json
+++ b/handlers/messangi/testdata/outgoing.json
@@ -16,10 +16,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/U2ltcGxlIE1lc3NhZ2Ug4pi6/my-public-key/f69bc6a924480d3ed82970d9679c4be90589bd3064add51c47e8bf50a211d55f",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/U2ltcGxlIE1lc3NhZ2Ug4pi6/my-public-key/f69bc6a924480d3ed82970d9679c4be90589bd3064add51c47e8bf50a211d55f"
             }
         ],
         "log_errors": []
@@ -45,17 +42,11 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/VGhpcyBpcyBhIGxvbmdlciBtZXNzYWdlIHRoYW4gMTYwIGNoYXJhY3RlcnMgYW5kIHdpbGwgY2F1c2UgdXMgdG8gc3BsaXQgaXQgaW50byB0d28gc2VwYXJhdGUgcGFydHMsIGlzbid0IHRoYXQgcmlnaHQgYnV0IGl0IGlzIGV2ZW4gbG9uZ2VyIHRoYW4gYmVmb3JlIEkgc2F5LA/my-public-key/48c658e8db8635843ac3d3e497a81cf79cc0d75b8630dae03c6e7d93a749ab90",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/VGhpcyBpcyBhIGxvbmdlciBtZXNzYWdlIHRoYW4gMTYwIGNoYXJhY3RlcnMgYW5kIHdpbGwgY2F1c2UgdXMgdG8gc3BsaXQgaXQgaW50byB0d28gc2VwYXJhdGUgcGFydHMsIGlzbid0IHRoYXQgcmlnaHQgYnV0IGl0IGlzIGV2ZW4gbG9uZ2VyIHRoYW4gYmVmb3JlIEkgc2F5LA/my-public-key/48c658e8db8635843ac3d3e497a81cf79cc0d75b8630dae03c6e7d93a749ab90"
             },
             {
                 "method": "GET",
-                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/SSBuZWVkIHRvIGtlZXAgYWRkaW5nIG1vcmUgdGhpbmdzIHRvIG1ha2UgaXQgd29yaw/my-public-key/ba305915a6cf56c1255071655de42b4408071460317bb5bf3419bb9f865c5078",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/SSBuZWVkIHRvIGtlZXAgYWRkaW5nIG1vcmUgdGhpbmdzIHRvIG1ha2UgaXQgd29yaw/my-public-key/ba305915a6cf56c1255071655de42b4408071460317bb5bf3419bb9f865c5078"
             }
         ],
         "log_errors": []
@@ -80,10 +71,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/TXkgcGljIQpodHRwczovL2Zvby5iYXIvaW1hZ2UuanBn/my-public-key/4babdf316c0b5c7b6b40855329b421b1da1b8e63690d59eb5c231049dc4067fd",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/TXkgcGljIQpodHRwczovL2Zvby5iYXIvaW1hZ2UuanBn/my-public-key/4babdf316c0b5c7b6b40855329b421b1da1b8e63690d59eb5c231049dc4067fd"
             }
         ],
         "log_errors": []
@@ -105,10 +93,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/SW52YWxpZCBQYXJhbWV0ZXJz/my-public-key/f3d2ea825cf61226925dee2db3c14b7fc00f3183f11809d2183d1e2dbd230df6",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/SW52YWxpZCBQYXJhbWV0ZXJz/my-public-key/f3d2ea825cf61226925dee2db3c14b7fc00f3183f11809d2183d1e2dbd230df6"
             }
         ],
         "error": {
@@ -137,10 +122,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/SW52YWxpZCBQYXJhbWV0ZXJz/my-public-key/f3d2ea825cf61226925dee2db3c14b7fc00f3183f11809d2183d1e2dbd230df6",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/SW52YWxpZCBQYXJhbWV0ZXJz/my-public-key/f3d2ea825cf61226925dee2db3c14b7fc00f3183f11809d2183d1e2dbd230df6"
             }
         ],
         "error": {
@@ -170,10 +152,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/RXJyb3IgUmVzcG9uc2U/my-public-key/27f4c67fa00848ea6029cc0b1797aae6d05e2970ecb6e44ca486b463b933e61a",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "https://flow.messangi.me/mmc/rest/api/sendMT/7/2020/2/18765422035/RXJyb3IgUmVzcG9uc2U/my-public-key/27f4c67fa00848ea6029cc0b1797aae6d05e2970ecb6e44ca486b463b933e61a"
             }
         ],
         "error": {

--- a/handlers/novo/testdata/outgoing.json
+++ b/handlers/novo/testdata/outgoing.json
@@ -21,10 +21,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Simple+Message+%E2%98%BA&signature=29f1fe56b81979aaf9dfb693b91ad16c87a9303951f38abcc2794501da79fff0&to=18686846481",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Simple+Message+%E2%98%BA&signature=29f1fe56b81979aaf9dfb693b91ad16c87a9303951f38abcc2794501da79fff0&to=18686846481"
             }
         ],
         "log_errors": []
@@ -60,17 +57,11 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=This+is+a+longer+message+than+160+characters+and+will+cause+us+to+split+it+into+two+separate+parts%2C+isn%27t+that+right+but+it+is+even+longer+than+before+I+say%2C&signature=974f711ede732846e4d4da9bc95bf9452ae2337d5452c7417a19ed4034afd197&to=18686846481",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=This+is+a+longer+message+than+160+characters+and+will+cause+us+to+split+it+into+two+separate+parts%2C+isn%27t+that+right+but+it+is+even+longer+than+before+I+say%2C&signature=974f711ede732846e4d4da9bc95bf9452ae2337d5452c7417a19ed4034afd197&to=18686846481"
             },
             {
                 "method": "GET",
-                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=I+need+to+keep+adding+more+things+to+make+it+work&signature=d6251beaa3398cb00c9354fd2fa80cc14ff0d9d42f6d6d488ad0f51b0719d89b&to=18686846481",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=I+need+to+keep+adding+more+things+to+make+it+work&signature=d6251beaa3398cb00c9354fd2fa80cc14ff0d9d42f6d6d488ad0f51b0719d89b&to=18686846481"
             }
         ],
         "log_errors": []
@@ -100,10 +91,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&signature=77a0feaf9a39e593f3e87d8cd3798e8aeabc1646501df7331c8d3bc3a54277fb&to=18686846481",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&signature=77a0feaf9a39e593f3e87d8cd3798e8aeabc1646501df7331c8d3bc3a54277fb&to=18686846481"
             }
         ],
         "log_errors": []
@@ -128,10 +116,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Invalid+Parameters&signature=4b640a668fd83223e38d429b15ea737ef58e1ab025b756baaca4743f3adb3f77&to=18686846481",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Invalid+Parameters&signature=4b640a668fd83223e38d429b15ea737ef58e1ab025b756baaca4743f3adb3f77&to=18686846481"
             }
         ],
         "error": {
@@ -163,10 +148,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Error+Response&signature=9fe49f073109de29f8c6d5108fd5719ee0b70c22cedb23fffdbabc8a99b9a0a9&to=18686846481",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Error+Response&signature=9fe49f073109de29f8c6d5108fd5719ee0b70c22cedb23fffdbabc8a99b9a0a9&to=18686846481"
             }
         ],
         "error": {
@@ -198,10 +180,7 @@
         "requests": [
             {
                 "method": "GET",
-                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Error+Response&signature=9fe49f073109de29f8c6d5108fd5719ee0b70c22cedb23fffdbabc8a99b9a0a9&to=18686846481",
-                "headers": {
-                    "User-Agent": "Courier/Dev"
-                }
+                "url": "http://novosmstools.com/novo_te/my-merchant-id/sendSMS?from=2020&msg=Error+Response&signature=9fe49f073109de29f8c6d5108fd5719ee0b70c22cedb23fffdbabc8a99b9a0a9&to=18686846481"
             }
         ],
         "error": {

--- a/handlers/playmobile/testdata/outgoing.json
+++ b/handlers/playmobile/testdata/outgoing.json
@@ -20,8 +20,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [
@@ -66,8 +65,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [
@@ -90,8 +88,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [
@@ -148,8 +145,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [
@@ -190,8 +186,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [
@@ -239,8 +234,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic VXNlcm5hbWU6UGFzc3dvcmQ=",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "messages": [

--- a/handlers/plivo/testdata/outgoing.json
+++ b/handlers/plivo/testdata/outgoing.json
@@ -24,8 +24,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "src": "2020",
@@ -74,8 +73,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "src": "2020",
@@ -91,8 +89,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "src": "2020",
@@ -137,8 +134,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "src": "2020",
@@ -177,8 +173,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "src": "2020",
@@ -221,8 +216,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "src": "2020",
@@ -265,8 +259,7 @@
                 "headers": {
                     "Accept": "application/json",
                     "Authorization": "Basic QXV0aElEOkF1dGhUb2tlbg==",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "src": "2020",

--- a/handlers/rocketchat/testdata/outgoing.json
+++ b/handlers/rocketchat/testdata/outgoing.json
@@ -21,8 +21,7 @@
                 "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
                 "headers": {
                     "Authorization": "Token 123456789",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "direct:john.doe",
@@ -60,8 +59,7 @@
                 "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
                 "headers": {
                     "Authorization": "Token 123456789",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "livechat:onrMgdKbpX9Qqtvoi",
@@ -105,8 +103,7 @@
                 "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
                 "headers": {
                     "Authorization": "Token 123456789",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "direct:john.doe",
@@ -146,8 +143,7 @@
                 "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
                 "headers": {
                     "Authorization": "Token 123456789",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "direct:john.doe",
@@ -185,8 +181,7 @@
                 "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
                 "headers": {
                     "Authorization": "Token 123456789",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "direct:john.doe",
@@ -225,8 +220,7 @@
                 "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
                 "headers": {
                     "Authorization": "Token 123456789",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "direct:john.doe",
@@ -267,8 +261,7 @@
                 "url": "https://my.rocket.chat/api/apps/public/684202ed-1461-4983-9ea7-fde74b15026c/message",
                 "headers": {
                     "Authorization": "Token 123456789",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/json"
                 },
                 "body": {
                     "user": "direct:john.doe",

--- a/handlers/smscentral/testdata/outgoing.json
+++ b/handlers/smscentral/testdata/outgoing.json
@@ -22,8 +22,7 @@
                 "method": "POST",
                 "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "content": [
@@ -66,8 +65,7 @@
                 "method": "POST",
                 "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "content": [
@@ -113,8 +111,7 @@
                 "method": "POST",
                 "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "content": [
@@ -155,8 +152,7 @@
                 "method": "POST",
                 "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "content": [
@@ -204,8 +200,7 @@
                 "method": "POST",
                 "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "content": [
@@ -254,8 +249,7 @@
                 "method": "POST",
                 "url": "http://smail.smscentral.com.np/bp/ApiSms.php",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "content": [

--- a/handlers/telegram/testdata/incoming.json
+++ b/handlers/telegram/testdata/incoming.json
@@ -248,8 +248,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/bota123/getFile",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "file_id": [
@@ -369,8 +368,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/bota123/getFile",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "file_id": [
@@ -477,8 +475,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/bota123/getFile",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "file_id": [
@@ -577,8 +574,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/bota123/getFile",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "file_id": [
@@ -677,8 +673,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/bota123/getFile",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "file_id": [
@@ -1123,8 +1118,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/bota123/getFile",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "file_id": [
@@ -1201,8 +1195,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/bota123/getFile",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "file_id": [
@@ -1274,8 +1267,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/bota123/getFile",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "file_id": [
@@ -1355,8 +1347,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/bota123/getFile",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "file_id": [
@@ -1439,8 +1430,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/bota123/getFile",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "file_id": [
@@ -1515,8 +1505,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/bota123/getFile",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "file_id": [

--- a/handlers/telegram/testdata/outgoing.json
+++ b/handlers/telegram/testdata/outgoing.json
@@ -23,8 +23,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -81,8 +80,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -139,8 +137,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -198,8 +195,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -256,8 +252,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -320,8 +315,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -383,8 +377,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -446,8 +439,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendPhoto",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "caption": [
@@ -503,8 +495,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -578,8 +569,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -645,8 +635,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -707,8 +696,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -791,8 +779,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -813,8 +800,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendDocument",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "caption": [
@@ -838,8 +824,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendDocument",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "caption": [
@@ -925,8 +910,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -947,8 +931,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendDocument",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "caption": [
@@ -972,8 +955,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendDocument",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "caption": [
@@ -1024,8 +1006,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -1079,8 +1060,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -1131,8 +1111,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [
@@ -1186,8 +1165,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendPhoto",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "caption": [
@@ -1240,8 +1218,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendVideo",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "caption": [
@@ -1294,8 +1271,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendAudio",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "audio": [
@@ -1348,8 +1324,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendDocument",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "caption": [
@@ -1399,8 +1374,7 @@
                 "method": "POST",
                 "url": "https://api.telegram.org/botauth_token/sendMessage",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "chat_id": [

--- a/handlers/telesom/testdata/outgoing.json
+++ b/handlers/telesom/testdata/outgoing.json
@@ -18,8 +18,7 @@
                 "method": "POST",
                 "url": "http://telesom.com/sendsms_other",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [
@@ -58,8 +57,7 @@
                 "method": "POST",
                 "url": "http://telesom.com/sendsms_other",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [
@@ -98,8 +96,7 @@
                 "method": "POST",
                 "url": "http://telesom.com/sendsms_other",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [
@@ -145,8 +142,7 @@
                 "method": "POST",
                 "url": "http://telesom.com/sendsms_other",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [
@@ -196,8 +192,7 @@
                 "method": "POST",
                 "url": "http://telesom.com/sendsms_other",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [
@@ -236,8 +231,7 @@
                 "method": "POST",
                 "url": "http://telesom.com/sendsms_other",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [
@@ -284,8 +278,7 @@
                 "method": "POST",
                 "url": "http://telesom.com/sendsms_other",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 },
                 "form": {
                     "from": [

--- a/handlers/yo/testdata/outgoing.json
+++ b/handlers/yo/testdata/outgoing.json
@@ -18,8 +18,7 @@
                 "method": "GET",
                 "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Simple+Message&ybsacctno=yo-username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -44,8 +43,7 @@
                 "method": "GET",
                 "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Simple+Message&ybsacctno=yo-username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -77,8 +75,7 @@
                 "method": "GET",
                 "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Simple+Message&ybsacctno=yo-username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -110,8 +107,7 @@
                 "method": "GET",
                 "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=%E2%98%BA&ybsacctno=yo-username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -136,8 +132,7 @@
                 "method": "GET",
                 "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Error+Message&ybsacctno=yo-username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -169,8 +164,7 @@
                 "method": "GET",
                 "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Error+Message&ybsacctno=yo-username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -203,8 +197,7 @@
                 "method": "GET",
                 "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=Error+Message&ybsacctno=yo-username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],
@@ -240,8 +233,7 @@
                 "method": "GET",
                 "url": "http://smgw1.yo.co.ug:9100/sendsms?destinations=250788383383&origin=2020&password=yo-password&sms_content=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&ybsacctno=yo-username",
                 "headers": {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "User-Agent": "Courier/Dev"
+                    "Content-Type": "application/x-www-form-urlencoded"
                 }
             }
         ],


### PR DESCRIPTION
## Summary

Requests captured in the file-based handler tests no longer record the `User-Agent` header. Every request a handler makes carries the same one, so recording it added nothing and meant any change to it would touch every test file at once.

## Changes

- `handlers/handlertest/snapshots.go`: `captureRequest` skips `User-Agent` when copying request headers.
- The seventeen converted handlers' `testdata/*.json` files regenerated with `-update`. The only differences are the removed header and JSON reflow where a request had no other headers and the `headers` object dropped out.

## Test plan

- [x] All converted handlers pass with and without `-update`, and a second run confirms the files are stable
- [x] Diff of the regenerated files inspected: only `User-Agent` lines and resulting reflow changed
- [x] Full `go test -p=1 ./...` passes in the devcontainer
- [x] `go vet ./...` and `gofmt` clean