### PR TITLE
Convert external and mtarget handler tests to JSON case files

### DIFF
--- a/handlers/external/handler_test.go
+++ b/handlers/external/handler_test.go
@@ -2,1043 +2,160 @@ package external
 
 import (
 	"net/http"
-	"net/url"
 	"testing"
-	"time"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
+	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/urns"
 )
 
-const (
-	receiveURL = "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/"
-)
-
-var testChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US", []string{urns.Phone.Prefix}, nil),
-}
-
-var gmChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "GM", []string{urns.Phone.Prefix}, nil),
-}
-
-var handleTestCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid Message",
-		URL:                  receiveURL + "?sender=%2B2349067554729&text=Join",
-		Data:                 "empty",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2349067554729",
-	},
-	{
-		Label:                "Receive Valid Post",
-		URL:                  receiveURL,
-		Data:                 "sender=%2B2349067554729&text=Join",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2349067554729",
-	},
-	{
-		Label:                "Receive Valid Post multipart form",
-		URL:                  receiveURL,
-		MultipartForm:        map[string]string{"sender": "2349067554729", "text": "Join"},
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2349067554729",
-	},
-	{
-		Label:                "Receive Valid From",
-		URL:                  receiveURL + "?from=%2B2349067554729&text=Join",
-		Data:                 "empty",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2349067554729",
-	},
-	{
-		Label:                "Receive Country Parse",
-		URL:                  receiveURL + "?from=2349067554729&text=Join",
-		Data:                 "empty",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2349067554729",
-	},
-	{
-		Label:                "Receive Valid Message With Date",
-		URL:                  receiveURL + "?sender=%2B2349067554729&text=Join&date=2017-06-23T12:30:00.500Z",
-		Data:                 "empty",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2349067554729",
-		ExpectedDate:         time.Date(2017, 6, 23, 12, 30, 0, int(500*time.Millisecond), time.UTC),
-	},
-	{
-		Label:                "Receive Valid Message With Time",
-		URL:                  receiveURL + "?sender=%2B2349067554729&text=Join&time=2017-06-23T12:30:00Z",
-		Data:                 "empty",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2349067554729",
-		ExpectedDate:         time.Date(2017, 6, 23, 12, 30, 0, 0, time.UTC),
-	},
-	{
-		Label:                "Invalid URN",
-		URL:                  receiveURL + "?sender=MTN&text=Join",
-		Data:                 "empty",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "not a possible number",
-	},
-	{
-		Label:                "Receive No Params",
-		URL:                  receiveURL,
-		Data:                 "empty",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "must have one of 'sender' or 'from' set",
-	},
-	{
-		Label:              "Receive No Sender",
-		URL:                receiveURL + "?text=Join",
-		Data:               "empty",
-		ExpectedRespStatus: 400, ExpectedBodyContains: "must have one of 'sender' or 'from' set",
-	},
-	{
-		Label:                "Receive Invalid Date",
-		URL:                  receiveURL + "?sender=%2B2349067554729&text=Join&time=20170623T123000Z",
-		Data:                 "empty",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "invalid date format, must be RFC 3339",
-	},
-	{
-		Label:                "Failed No Params",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/failed/",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "parameters id or uuid should not be empty",
-	},
-	{
-		Label:                "Failed Valid",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/failed/?id=019a0719-ac96-7eb9-a837-cac215164834",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"status":"F"`,
-		ExpectedStatuses:     []ExpectedStatus{{MsgUUID: "019a0719-ac96-7eb9-a837-cac215164834", Status: models.MsgStatusFailed}},
-	},
-	{
-		Label:                "Invalid Status",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/wired/",
-		ExpectedRespStatus:   404,
-		ExpectedBodyContains: `page not found`,
-		NoLogsExpected:       true,
-	},
-	{
-		Label:                "Sent Valid",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/sent/?id=019a0719-ac96-7eb9-a837-cac215164834",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"status":"S"`,
-		ExpectedStatuses:     []ExpectedStatus{{MsgUUID: "019a0719-ac96-7eb9-a837-cac215164834", Status: models.MsgStatusSent}},
-	},
-	{
-		Label:                "Delivered Valid",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered/?id=019a0719-ac96-7eb9-a837-cac215164834",
-		Data:                 "nothing",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"status":"D"`,
-		ExpectedStatuses:     []ExpectedStatus{{MsgUUID: "019a0719-ac96-7eb9-a837-cac215164834", Status: models.MsgStatusDelivered}},
-	},
-	{
-		Label:                "Delivered Valid Post",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered/",
-		Data:                 "id=019a0719-ac96-7eb9-a837-cac215164834",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: `"status":"D"`,
-		ExpectedStatuses:     []ExpectedStatus{{MsgUUID: "019a0719-ac96-7eb9-a837-cac215164834", Status: models.MsgStatusDelivered}},
-	},
-	{
-		Label:                "Stopped Event",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/stopped/?from=%2B2349067554729",
-		Data:                 "nothing",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedEvents: []ExpectedEvent{
-			{Type: models.EventTypeStopContact, URN: "tel:+2349067554729"},
-		},
-	},
-	{
-		Label:                "Stopped Event Post",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/stopped/",
-		Data:                 "from=%2B2349067554729",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedEvents: []ExpectedEvent{
-			{Type: models.EventTypeStopContact, URN: "tel:+2349067554729"},
-		},
-	},
-	{
-		Label:                "Stopped Event Invalid URN",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/stopped/?from=MTN",
-		Data:                 "empty",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "not a possible number",
-	},
-	{
-		Label:                "Stopped event No Params",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/stopped/",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "field 'from' required",
-	},
-}
-
-var testSOAPReceiveChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			configTextXPath:             "//content",
-			configFromXPath:             "//source",
-			configMOResponse:            "<?xml version=“1.0”?><return>0</return>",
-			configMOResponseContentType: "text/xml",
-		},
-	),
-}
-
-var handleSOAPReceiveTestCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid Post SOAP",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
-		Data:                 `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:com="com.hero"><soapenv:Header/><soapenv:Body><com:moRequest><source>2349067554729</source><content>Join</content></com:moRequest></soapenv:Body></soapenv:Envelope>`,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "<?xml version=“1.0”?><return>0</return>",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2349067554729",
-	},
-	{
-		Label:                "Receive Invalid SOAP",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
-		Data:                 `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:com="com.hero"><soapenv:Header/><soapenv:Body></soapenv:Body></soapenv:Envelope>`,
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "missing from",
-	},
-}
-
-var gmTestCases = []IncomingTestCase{
-	{
-		Label:                "Receive Non Plus Message",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=2207222333&text=Join",
-		Data:                 "empty",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+2207222333",
-	},
-}
-
-var customChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			configMOFromField: "from_number",
-			configMODateField: "timestamp",
-			configMOTextField: "messageText",
-		},
-	),
-}
-
-var customTestCases = []IncomingTestCase{
-	{
-		Label:                "Receive Custom Message",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?from_number=12067799192&messageText=Join&timestamp=2017-06-23T12:30:00Z",
-		Data:                 "empty",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "tel:+12067799192",
-		ExpectedDate:         time.Date(2017, 6, 23, 12, 30, 0, 0, time.UTC),
-	},
-	{
-		Label:                "Receive Custom Missing",
-		URL:                  "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sent_from=12067799192&messageText=Join",
-		Data:                 "empty",
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "must have one of 'sender' or 'from' set",
-	},
-}
-
-var extChannels = []*models.Channel{
-	test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "GM", []string{urns.External.Prefix}, nil),
-}
-
-var extReceiveTestCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid Message",
-		URL:                  receiveURL + "?sender=%2B2349067554729&text=Join",
-		Data:                 "empty",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "ext:+2349067554729",
-	},
-	{
-		Label:                "Receive Valid Message trim spaces",
-		URL:                  receiveURL + "?sender=+2349067554729&text=Join",
-		Data:                 "empty",
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("Join"),
-		ExpectedURN:          "ext:2349067554729",
-	},
+func newChannel(country i18n.Country, schemes []string, config map[string]any) *models.Channel {
+	return test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", country, schemes, config)
 }
 
 func TestIncoming(t *testing.T) {
-	RunIncomingTestCases(t, testChannels, newHandler, handleTestCases)
-	RunIncomingTestCases(t, testSOAPReceiveChannels, newHandler, handleSOAPReceiveTestCases)
-	RunIncomingTestCases(t, gmChannels, newHandler, gmTestCases)
-	RunIncomingTestCases(t, customChannels, newHandler, customTestCases)
+	phone := []string{urns.Phone.Prefix}
 
-	RunIncomingTestCases(t, extChannels, newHandler, extReceiveTestCases)
-}
+	RunIncomingTests(t, []*models.Channel{newChannel("US", phone, nil)}, newHandler, "testdata/incoming.json", nil)
 
-var longSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Long Send",
-		MsgText: "This is a long message that will be longer than 30....... characters", MsgURN: "tel:+250788383383",
-		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "One"}},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send*": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Params: url.Values{
-					"text": {"This is a long message that"},
-					"to":   {"+250788383383"},
-					"from": {"2020"},
-				},
-			},
-			{
-				Params: url.Values{
-					"text": {"will be longer than 30......."},
-					"to":   {"+250788383383"},
-					"from": {"2020"},
-				},
-			},
-			{
-				Params: url.Values{
-					"text":        {"characters"},
-					"to":          {"+250788383383"},
-					"from":        {"2020"},
-					"quick_reply": {"One"},
-				},
-			},
-		},
-	},
-}
+	soapChannel := newChannel("US", phone, map[string]any{
+		configTextXPath:             "//content",
+		configFromXPath:             "//source",
+		configMOResponse:            "<?xml version=“1.0”?><return>0</return>",
+		configMOResponseContentType: "text/xml",
+	})
+	RunIncomingTests(t, []*models.Channel{soapChannel}, newHandler, "testdata/incoming_soap.json", nil)
 
-var getSendSmartEncodingTestCases = []OutgoingTestCase{
-	{
-		Label:   "Smart Encoding",
-		MsgText: "Fancy “Smart” Quotes",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send*": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Params: url.Values{
-				"text": {`Fancy "Smart" Quotes`},
-				"to":   {"+250788383383"},
-				"from": {"2020"},
-			},
-		}},
-	},
-}
+	RunIncomingTests(t, []*models.Channel{newChannel("GM", phone, nil)}, newHandler, "testdata/incoming_gm.json", nil)
 
-var postSendSmartEncodingTestCases = []OutgoingTestCase{
-	{
-		Label:   "Smart Encoding",
-		MsgText: "Fancy “Smart” Quotes",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Form: url.Values{
-				"text": {`Fancy "Smart" Quotes`},
-				"to":   {"+250788383383"},
-				"from": {"2020"},
-			},
-		}},
-	},
-}
+	customFieldsChannel := newChannel("US", phone, map[string]any{
+		configMOFromField: "from_number",
+		configMODateField: "timestamp",
+		configMOTextField: "messageText",
+	})
+	RunIncomingTests(t, []*models.Channel{customFieldsChannel}, newHandler, "testdata/incoming_custom_fields.json", nil)
 
-var getSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send*": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Params: url.Values{
-				"text": {"Simple Message"},
-				"to":   {"+250788383383"},
-				"from": {"2020"},
-			},
-		}},
-	},
-	{
-		Label:   "Unicode Send",
-		MsgText: "☺", MsgURN: "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send*": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Params: url.Values{
-				"text": {"☺"},
-				"to":   {"+250788383383"},
-				"from": {"2020"},
-			},
-		}},
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send*": {
-				httpx.NewMockResponse(401, nil, []byte(`1: Unknown channel`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Params: url.Values{
-				"text": {`Error Message`},
-				"to":   {"+250788383383"},
-				"from": {"2020"},
-			},
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send*": {
-				httpx.NewMockResponse(429, nil, []byte(`1: Unknown channel`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Params: url.Values{
-				"text": {`Error Message`},
-				"to":   {"+250788383383"},
-				"from": {"2020"},
-			},
-		}},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send*": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Params: url.Values{
-				"text": {"My pic!\nhttps://foo.bar/image.jpg"},
-				"to":   {"+250788383383"},
-				"from": {"2020"},
-			},
-		}},
-	},
-}
-
-var postSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Form: url.Values{
-				"text": {"Simple Message"},
-				"to":   {"+250788383383"},
-				"from": {"2020"},
-			},
-		}},
-	},
-	{
-		Label:   "Unicode Send",
-		MsgText: "☺",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Form: url.Values{
-				"text": {"☺"},
-				"to":   {"+250788383383"},
-				"from": {"2020"},
-			},
-		}},
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(401, nil, []byte(`1: Unknown channel`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Form: url.Values{
-				"text": {`Error Message`},
-				"to":   {"+250788383383"},
-				"from": {"2020"},
-			},
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Form: url.Values{
-				"text": {"My pic!\nhttps://foo.bar/image.jpg"},
-				"to":   {"+250788383383"},
-				"from": {"2020"},
-			},
-		}},
-	},
-}
-
-var postSendCustomContentTypeTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded; charset=utf-8"},
-			Form: url.Values{
-				"text": {"Simple Message"},
-				"to":   {"250788383383"},
-				"from": {"2020"},
-			},
-		}},
-	},
-}
-
-var jsonSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Authorization": "Token ABCDEF", "Content-Type": "application/json"},
-			Body:    `{ "to":"+250788383383", "text":"Simple Message", "from":"2020", "quick_replies":[] }`,
-		}},
-	},
-	{
-		Label:   "Unicode Send",
-		MsgText: `☺ "hi!"`,
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Authorization": "Token ABCDEF", "Content-Type": "application/json"},
-			Body:    `{ "to":"+250788383383", "text":"☺ \"hi!\"", "from":"2020", "quick_replies":[] }`,
-		}},
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(401, nil, []byte(`1: Unknown channel`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Authorization": "Token ABCDEF", "Content-Type": "application/json"},
-			Body:    `{ "to":"+250788383383", "text":"Error Message", "from":"2020", "quick_replies":[] }`,
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Authorization": "Token ABCDEF", "Content-Type": "application/json"},
-			Body:    `{ "to":"+250788383383", "text":"My pic!\nhttps://foo.bar/image.jpg", "from":"2020", "quick_replies":[] }`,
-		}},
-	},
-	{
-		Label:           "Send Quick Replies",
-		MsgText:         "Some message",
-		MsgURN:          "tel:+250788383383",
-		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "One"}, {Type: "text", Text: "Two"}, {Type: "text", Text: "Three"}},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Authorization": "Token ABCDEF", "Content-Type": "application/json"},
-			Body:    `{ "to":"+250788383383", "text":"Some message", "from":"2020", "quick_replies":["One","Two","Three"] }`,
-		}},
-	},
-}
-
-var jsonLongSendTestCases = []OutgoingTestCase{
-	{
-		Label:           "Send Long message JSON",
-		MsgText:         "This is a long message that will be longer than 30....... characters",
-		MsgURN:          "tel:+250788383383",
-		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "One"}, {Type: "text", Text: "Two"}, {Type: "text", Text: "Three"}},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"*": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Headers: map[string]string{"Authorization": "Token ABCDEF", "Content-Type": "application/json"},
-				Body:    `{ "to":"+250788383383", "text":"This is a long message that", "from":"2020", "quick_replies":[] }`,
-			},
-			{
-				Headers: map[string]string{"Authorization": "Token ABCDEF", "Content-Type": "application/json"},
-				Body:    `{ "to":"+250788383383", "text":"will be longer than 30.......", "from":"2020", "quick_replies":[] }`,
-			},
-			{
-				Headers: map[string]string{"Authorization": "Token ABCDEF", "Content-Type": "application/json"},
-				Body:    `{ "to":"+250788383383", "text":"characters", "from":"2020", "quick_replies":["One","Two","Three"] }`,
-			},
-		},
-	},
-}
-
-var xmlSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-			Body:    `<msg><to>+250788383383</to><text>Simple Message</text><from>2020</from><quick_replies></quick_replies></msg>`,
-		}},
-	},
-	{
-		Label:   "Unicode Send",
-		MsgText: `☺`,
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-			Body:    `<msg><to>+250788383383</to><text>☺</text><from>2020</from><quick_replies></quick_replies></msg>`,
-		}},
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(401, nil, []byte(`1: Unknown channel`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-			Body:    `<msg><to>+250788383383</to><text>Error Message</text><from>2020</from><quick_replies></quick_replies></msg>`,
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-			Body:    `<msg><to>+250788383383</to><text>My pic!&#xA;https://foo.bar/image.jpg</text><from>2020</from><quick_replies></quick_replies></msg>`,
-		}},
-	},
-	{
-		Label:           "Send Quick Replies",
-		MsgText:         "Some message",
-		MsgURN:          "tel:+250788383383",
-		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "One"}, {Type: "text", Text: "Two"}, {Type: "text", Text: "Three"}},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-			Body:    "<msg><to>+250788383383</to><text>Some message</text><from>2020</from><quick_replies><item>One</item><item>Two</item><item>Three</item></quick_replies></msg>",
-		}},
-	},
-}
-
-var xmlLongSendTestCases = []OutgoingTestCase{
-	{
-		Label:           "Send Long message XML",
-		MsgText:         "This is a long message that will be longer than 30....... characters",
-		MsgURN:          "tel:+250788383383",
-		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "One"}, {Type: "text", Text: "Two"}, {Type: "text", Text: "Three"}},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"*": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{
-				Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-				Body:    "<msg><to>+250788383383</to><text>This is a long message that</text><from>2020</from><quick_replies></quick_replies></msg>",
-			},
-			{
-				Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-				Body:    "<msg><to>+250788383383</to><text>will be longer than 30.......</text><from>2020</from><quick_replies></quick_replies></msg>",
-			},
-			{
-				Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-				Body:    "<msg><to>+250788383383</to><text>characters</text><from>2020</from><quick_replies><item>One</item><item>Two</item><item>Three</item></quick_replies></msg>",
-			},
-		},
-	},
-}
-
-var xmlSendWithResponseContentTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`<return>0</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-			Body:    `<msg><to>+250788383383</to><text>Simple Message</text><from>2020</from><quick_replies></quick_replies></msg>`,
-		}},
-	},
-	{
-		Label:   "Unicode Send",
-		MsgText: `☺`,
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`<return>0</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-			Body:    `<msg><to>+250788383383</to><text>☺</text><from>2020</from><quick_replies></quick_replies></msg>`,
-		}},
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(401, nil, []byte(`<return>0</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-			Body:    `<msg><to>+250788383383</to><text>Error Message</text><from>2020</from><quick_replies></quick_replies></msg>`,
-		}},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Error Sending with 200 status code",
-		MsgText: "Error Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`<return>1</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-			Body:    `<msg><to>+250788383383</to><text>Error Message</text><from>2020</from><quick_replies></quick_replies></msg>`,
-		}},
-		ExpectedError: channels.ErrResponseContent,
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`<return>0</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-			Body:    `<msg><to>+250788383383</to><text>My pic!&#xA;https://foo.bar/image.jpg</text><from>2020</from><quick_replies></quick_replies></msg>`,
-		}},
-	},
-	{
-		Label:           "Send Quick Replies",
-		MsgText:         "Some message",
-		MsgURN:          "tel:+250788383383",
-		MsgQuickReplies: []models.QuickReply{{Type: "text", Text: "One"}, {Type: "text", Text: "Two"}, {Type: "text", Text: "Three"}},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send": {
-				httpx.NewMockResponse(200, nil, []byte(`<return>0</return>`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "text/xml; charset=utf-8"},
-			Body:    `<msg><to>+250788383383</to><text>Some message</text><from>2020</from><quick_replies><item>One</item><item>Two</item><item>Three</item></quick_replies></msg>`,
-		}},
-	},
-}
-
-var nationalGetSendTestCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"http://example.com/send*": {
-				httpx.NewMockResponse(200, nil, []byte(`0: Accepted for delivery`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{{
-			Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-			Params: url.Values{
-				"text": {"Simple Message"},
-				"to":   {"788383383"},
-				"from": {"2020"},
-			},
-		}},
-	},
+	extChannel := newChannel("GM", []string{urns.External.Prefix}, nil)
+	RunIncomingTests(t, []*models.Channel{extChannel}, newHandler, "testdata/incoming_ext_urns.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
-	var getChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:    "http://example.com/send?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
-			models.ConfigSendMethod: http.MethodGet})
+	phone := []string{urns.Phone.Prefix}
 
-	var getSmartChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:    "http://example.com/send?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
-			configEncoding:          encodingSmart,
-			models.ConfigSendMethod: http.MethodGet})
+	getChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:    "http://example.com/send?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
+		models.ConfigSendMethod: http.MethodGet,
+	})
+	RunOutgoingTests(t, getChannel, newHandler, "testdata/outgoing_get.json", nil)
 
-	var postChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:    "http://example.com/send",
-			models.ConfigSendBody:   "to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
-			models.ConfigSendMethod: http.MethodPost})
+	getSmartChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:    "http://example.com/send?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
+		configEncoding:          encodingSmart,
+		models.ConfigSendMethod: http.MethodGet,
+	})
+	RunOutgoingTests(t, getSmartChannel, newHandler, "testdata/outgoing_get_smart.json", nil)
+	RunOutgoingTests(t, getSmartChannel, newHandler, "testdata/outgoing_get_smart_encoding.json", nil)
 
-	var postChannelCustomContentType = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:     "http://example.com/send",
-			models.ConfigSendBody:    "to={{to_no_plus}}&text={{text}}&from={{from_no_plus}}{{quick_replies}}",
-			models.ConfigContentType: "application/x-www-form-urlencoded; charset=utf-8",
-			models.ConfigSendMethod:  http.MethodPost})
+	postChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:    "http://example.com/send",
+		models.ConfigSendBody:   "to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
+		models.ConfigSendMethod: http.MethodPost,
+	})
+	RunOutgoingTests(t, postChannel, newHandler, "testdata/outgoing_post.json", nil)
 
-	var postSmartChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:    "http://example.com/send",
-			models.ConfigSendBody:   "to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
-			configEncoding:          encodingSmart,
-			models.ConfigSendMethod: http.MethodPost})
+	postContentTypeChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:     "http://example.com/send",
+		models.ConfigSendBody:    "to={{to_no_plus}}&text={{text}}&from={{from_no_plus}}{{quick_replies}}",
+		models.ConfigContentType: "application/x-www-form-urlencoded; charset=utf-8",
+		models.ConfigSendMethod:  http.MethodPost,
+	})
+	RunOutgoingTests(t, postContentTypeChannel, newHandler, "testdata/outgoing_post_content_type.json", nil)
 
-	var jsonChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:     "http://example.com/send",
-			models.ConfigSendBody:    `{ "to":{{to}}, "text":{{text}}, "from":{{from}}, "quick_replies":{{quick_replies}} }`,
-			models.ConfigContentType: contentJSON,
-			models.ConfigSendMethod:  http.MethodPost,
-			models.ConfigSendHeaders: map[string]any{"Authorization": "Token ABCDEF", "foo": "bar"},
-		})
+	postSmartChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:    "http://example.com/send",
+		models.ConfigSendBody:   "to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
+		configEncoding:          encodingSmart,
+		models.ConfigSendMethod: http.MethodPost,
+	})
+	RunOutgoingTests(t, postSmartChannel, newHandler, "testdata/outgoing_post_smart.json", nil)
+	RunOutgoingTests(t, postSmartChannel, newHandler, "testdata/outgoing_post_smart_encoding.json", nil)
 
-	var xmlChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:     "http://example.com/send",
-			models.ConfigSendBody:    `<msg><to>{{to}}</to><text>{{text}}</text><from>{{from}}</from><quick_replies>{{quick_replies}}</quick_replies></msg>`,
-			models.ConfigContentType: contentXML,
-			models.ConfigSendMethod:  http.MethodPut,
-		})
+	jsonChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:     "http://example.com/send",
+		models.ConfigSendBody:    `{ "to":{{to}}, "text":{{text}}, "from":{{from}}, "quick_replies":{{quick_replies}} }`,
+		models.ConfigContentType: contentJSON,
+		models.ConfigSendMethod:  http.MethodPost,
+		models.ConfigSendHeaders: map[string]any{"Authorization": "Token ABCDEF", "foo": "bar"},
+	})
+	RunOutgoingTests(t, jsonChannel, newHandler, "testdata/outgoing_json.json", nil)
 
-	var xmlChannelWithResponseContent = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:     "http://example.com/send",
-			models.ConfigSendBody:    `<msg><to>{{to}}</to><text>{{text}}</text><from>{{from}}</from><quick_replies>{{quick_replies}}</quick_replies></msg>`,
-			configMTResponseCheck:    "<return>0</return>",
-			models.ConfigContentType: contentXML,
-			models.ConfigSendMethod:  http.MethodPut,
-		})
+	xmlChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:     "http://example.com/send",
+		models.ConfigSendBody:    `<msg><to>{{to}}</to><text>{{text}}</text><from>{{from}}</from><quick_replies>{{quick_replies}}</quick_replies></msg>`,
+		models.ConfigContentType: contentXML,
+		models.ConfigSendMethod:  http.MethodPut,
+	})
+	RunOutgoingTests(t, xmlChannel, newHandler, "testdata/outgoing_xml.json", nil)
 
-	RunOutgoingTestCases(t, getChannel, newHandler, getSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, getSmartChannel, newHandler, getSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, getSmartChannel, newHandler, getSendSmartEncodingTestCases, nil, nil)
-	RunOutgoingTestCases(t, postChannel, newHandler, postSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, postChannelCustomContentType, newHandler, postSendCustomContentTypeTestCases, nil, nil)
-	RunOutgoingTestCases(t, postSmartChannel, newHandler, postSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, postSmartChannel, newHandler, postSendSmartEncodingTestCases, nil, nil)
-	RunOutgoingTestCases(t, jsonChannel, newHandler, jsonSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, xmlChannel, newHandler, xmlSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, xmlChannelWithResponseContent, newHandler, xmlSendWithResponseContentTestCases, nil, nil)
+	xmlResponseCheckChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:     "http://example.com/send",
+		models.ConfigSendBody:    `<msg><to>{{to}}</to><text>{{text}}</text><from>{{from}}</from><quick_replies>{{quick_replies}}</quick_replies></msg>`,
+		configMTResponseCheck:    "<return>0</return>",
+		models.ConfigContentType: contentXML,
+		models.ConfigSendMethod:  http.MethodPut,
+	})
+	RunOutgoingTests(t, xmlResponseCheckChannel, newHandler, "testdata/outgoing_xml_response_check.json", nil)
 
-	var getChannel30IntLength = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigMaxLength:  30,
-			models.ConfigSendURL:    "http://example.com/send?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
-			models.ConfigSendMethod: http.MethodGet})
+	// max length can be configured as an int or a string
+	getMaxLengthChannel := newChannel("US", phone, map[string]any{
+		models.ConfigMaxLength:  30,
+		models.ConfigSendURL:    "http://example.com/send?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
+		models.ConfigSendMethod: http.MethodGet,
+	})
+	RunOutgoingTests(t, getMaxLengthChannel, newHandler, "testdata/outgoing_get_max_length.json", nil)
 
-	var getChannel30StrLength = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigMaxLength:  "30",
-			models.ConfigSendURL:    "http://example.com/send?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
-			models.ConfigSendMethod: http.MethodGet})
+	getMaxLengthStrChannel := newChannel("US", phone, map[string]any{
+		models.ConfigMaxLength:  "30",
+		models.ConfigSendURL:    "http://example.com/send?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
+		models.ConfigSendMethod: http.MethodGet,
+	})
+	RunOutgoingTests(t, getMaxLengthStrChannel, newHandler, "testdata/outgoing_get_max_length_str.json", nil)
 
-	var jsonChannel30IntLength = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:     "http://example.com/send",
-			models.ConfigMaxLength:   30,
-			models.ConfigSendBody:    `{ "to":{{to}}, "text":{{text}}, "from":{{from}}, "quick_replies":{{quick_replies}} }`,
-			models.ConfigContentType: contentJSON,
-			models.ConfigSendMethod:  http.MethodPost,
-			models.ConfigSendHeaders: map[string]any{"Authorization": "Token ABCDEF", "foo": "bar"},
-		})
+	jsonMaxLengthChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:     "http://example.com/send",
+		models.ConfigMaxLength:   30,
+		models.ConfigSendBody:    `{ "to":{{to}}, "text":{{text}}, "from":{{from}}, "quick_replies":{{quick_replies}} }`,
+		models.ConfigContentType: contentJSON,
+		models.ConfigSendMethod:  http.MethodPost,
+		models.ConfigSendHeaders: map[string]any{"Authorization": "Token ABCDEF", "foo": "bar"},
+	})
+	RunOutgoingTests(t, jsonMaxLengthChannel, newHandler, "testdata/outgoing_json_max_length.json", nil)
 
-	var xmlChannel30IntLength = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:     "http://example.com/send",
-			models.ConfigMaxLength:   30,
-			models.ConfigSendBody:    `<msg><to>{{to}}</to><text>{{text}}</text><from>{{from}}</from><quick_replies>{{quick_replies}}</quick_replies></msg>`,
-			models.ConfigContentType: contentXML,
-			models.ConfigSendMethod:  http.MethodPost,
-			models.ConfigSendHeaders: map[string]any{"Authorization": "Token ABCDEF", "foo": "bar"},
-		})
+	xmlMaxLengthChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:     "http://example.com/send",
+		models.ConfigMaxLength:   30,
+		models.ConfigSendBody:    `<msg><to>{{to}}</to><text>{{text}}</text><from>{{from}}</from><quick_replies>{{quick_replies}}</quick_replies></msg>`,
+		models.ConfigContentType: contentXML,
+		models.ConfigSendMethod:  http.MethodPost,
+		models.ConfigSendHeaders: map[string]any{"Authorization": "Token ABCDEF", "foo": "bar"},
+	})
+	RunOutgoingTests(t, xmlMaxLengthChannel, newHandler, "testdata/outgoing_xml_max_length.json", nil)
 
-	RunOutgoingTestCases(t, getChannel30IntLength, newHandler, longSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, getChannel30StrLength, newHandler, longSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, jsonChannel30IntLength, newHandler, jsonLongSendTestCases, nil, nil)
-	RunOutgoingTestCases(t, xmlChannel30IntLength, newHandler, xmlLongSendTestCases, nil, nil)
+	nationalChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:    "http://example.com/send?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
+		"use_national":          true,
+		models.ConfigSendMethod: http.MethodGet,
+	})
+	RunOutgoingTests(t, nationalChannel, newHandler, "testdata/outgoing_get_national.json", nil)
 
-	var nationalChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:    "http://example.com/send?to={{to}}&text={{text}}&from={{from}}{{quick_replies}}",
-			"use_national":          true,
-			models.ConfigSendMethod: http.MethodGet})
-
-	RunOutgoingTestCases(t, nationalChannel, newHandler, nationalGetSendTestCases, nil, nil)
-
-	var jsonChannelWithSendAuthorization = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "EX", "2020", "US",
-		[]string{urns.Phone.Prefix},
-		map[string]any{
-			models.ConfigSendURL:           "http://example.com/send",
-			models.ConfigSendBody:          `{ "to":{{to}}, "text":{{text}}, "from":{{from}}, "quick_replies":{{quick_replies}} }`,
-			models.ConfigContentType:       contentJSON,
-			models.ConfigSendMethod:        http.MethodPost,
-			models.ConfigSendAuthorization: "Token ABCDEF",
-		})
-	RunOutgoingTestCases(t, jsonChannelWithSendAuthorization, newHandler, jsonSendTestCases, []string{"Token ABCDEF"}, nil)
+	jsonAuthorizationChannel := newChannel("US", phone, map[string]any{
+		models.ConfigSendURL:           "http://example.com/send",
+		models.ConfigSendBody:          `{ "to":{{to}}, "text":{{text}}, "from":{{from}}, "quick_replies":{{quick_replies}} }`,
+		models.ConfigContentType:       contentJSON,
+		models.ConfigSendMethod:        http.MethodPost,
+		models.ConfigSendAuthorization: "Token ABCDEF",
+	})
+	RunOutgoingTests(t, jsonAuthorizationChannel, newHandler, "testdata/outgoing_json_authorization.json", &OutgoingOptions{CheckRedacted: []string{"Token ABCDEF"}})
 }

--- a/handlers/external/testdata/incoming.json
+++ b/handlers/external/testdata/incoming.json
@@ -1,0 +1,623 @@
+[
+    {
+        "label": "Receive Valid Message",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=%2B2349067554729&text=Join",
+        "data": "empty",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-11-01T05:43:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-11-01T05:43:04Z",
+                "received_on": "2025-11-01T05:43:03Z",
+                "log_uuids": [
+                    "019a3df0-c688-7000-aac1-d0d96ed17383"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid Post",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "sender=%2B2349067554729\u0026text=Join",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-10-28T22:18:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-10-28T22:18:04Z",
+                "received_on": "2025-10-28T22:18:03Z",
+                "log_uuids": [
+                    "019a2ce6-49a8-7000-8ed8-c814f412c2ca"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid Post multipart form",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "multipart_form": {
+            "sender": "2349067554729",
+            "text": "Join"
+        },
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-11-17T21:28:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-11-17T21:28:04Z",
+                "received_on": "2025-11-17T21:28:03Z",
+                "log_uuids": [
+                    "019a93b7-b2e8-7000-a8f0-d57562257571"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid From",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?from=%2B2349067554729&text=Join",
+        "data": "empty",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-11-08T21:04:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-11-08T21:04:04Z",
+                "received_on": "2025-11-08T21:04:03Z",
+                "log_uuids": [
+                    "019a6548-7de8-7000-b837-178187882754"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Country Parse",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?from=2349067554729&text=Join",
+        "data": "empty",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-11-19T08:51:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-11-19T08:51:04Z",
+                "received_on": "2025-11-19T08:51:03Z",
+                "log_uuids": [
+                    "019a9b4f-5d08-7000-b74c-ec9e0080d5ca"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid Message With Date",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=%2B2349067554729&text=Join&date=2017-06-23T12:30:00.500Z",
+        "data": "empty",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2017-06-23T12:30:00.5Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-10-29T10:23:04Z",
+                "received_on": "2017-06-23T12:30:00.5Z",
+                "log_uuids": [
+                    "019a2f7e-0b88-7000-9854-09ae5f93f47f"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid Message With Time",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=%2B2349067554729&text=Join&time=2017-06-23T12:30:00Z",
+        "data": "empty",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2017-06-23T12:30:00Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-12-07T04:02:04Z",
+                "received_on": "2017-06-23T12:30:00Z",
+                "log_uuids": [
+                    "019af6f9-3ea8-7000-a05e-c14f249cf2ce"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid URN",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=MTN&text=Join",
+        "data": "empty",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "not a possible number"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No Params",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "empty",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "must have one of 'sender' or 'from' set"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive No Sender",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?text=Join",
+        "data": "empty",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "must have one of 'sender' or 'from' set"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Invalid Date",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=%2B2349067554729&text=Join&time=20170623T123000Z",
+        "data": "empty",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "invalid date format, must be RFC 3339"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Failed No Params",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/failed/",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "parameters id or uuid should not be empty"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Failed Valid",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/failed/?id=019a0719-ac96-7eb9-a837-cac215164834",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "F"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "msg_uuid": "019a0719-ac96-7eb9-a837-cac215164834",
+                "status": "F",
+                "log_uuid": "019ad424-0228-7000-952b-151632c35a86"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid Status",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/wired/",
+        "response": {
+            "status": 404,
+            "body": "404 page not found\n"
+        },
+        "log": null
+    },
+    {
+        "label": "Sent Valid",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/sent/?id=019a0719-ac96-7eb9-a837-cac215164834",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "S"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "msg_uuid": "019a0719-ac96-7eb9-a837-cac215164834",
+                "status": "S",
+                "log_uuid": "019a624f-b048-7000-b88a-04e1e059d4ff"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Delivered Valid",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered/?id=019a0719-ac96-7eb9-a837-cac215164834",
+        "data": "nothing",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "D"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "msg_uuid": "019a0719-ac96-7eb9-a837-cac215164834",
+                "status": "D",
+                "log_uuid": "019b2f72-5648-7000-a7df-390823822520"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Delivered Valid Post",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/delivered/",
+        "data": "id=019a0719-ac96-7eb9-a837-cac215164834",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "D"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "msg_uuid": "019a0719-ac96-7eb9-a837-cac215164834",
+                "status": "D",
+                "log_uuid": "019b1ff4-45c8-7000-9294-187f54f363bd"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Stopped Event",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/stopped/?from=%2B2349067554729",
+        "data": "nothing",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Event Accepted",
+                "data": [
+                    {
+                        "type": "event",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "event_type": "stop_contact",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-10-18T17:18:04Z"
+                    }
+                ]
+            }
+        },
+        "events": [
+            {
+                "uuid": "0199f854-10f8-7000-99d2-132fee1ff094",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "event_type": "stop_contact",
+                "occurred_on": "2025-10-18T17:18:04Z",
+                "log_uuids": [
+                    "0199f854-0928-7000-b1a0-3305ff75f44c"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Stopped Event Post",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/stopped/",
+        "data": "from=%2B2349067554729",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Event Accepted",
+                "data": [
+                    {
+                        "type": "event",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "event_type": "stop_contact",
+                        "urn": "tel:+2349067554729",
+                        "received_on": "2025-11-30T01:00:04Z"
+                    }
+                ]
+            }
+        },
+        "events": [
+            {
+                "uuid": "019ad246-2238-7000-a8c4-2bff4b2de0fa",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "event_type": "stop_contact",
+                "occurred_on": "2025-11-30T01:00:04Z",
+                "log_uuids": [
+                    "019ad246-1a68-7000-a8ce-9b39396f54ac"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Stopped Event Invalid URN",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/stopped/?from=MTN",
+        "data": "empty",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "not a possible number"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Stopped event No Params",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/stopped/",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "Key: 'stopContactForm.From' Error:Field validation for 'From' failed on the 'required' tag"
+                    },
+                    {
+                        "type": "error",
+                        "error": "field 'from' required"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/external/testdata/incoming_custom_fields.json
+++ b/handlers/external/testdata/incoming_custom_fields.json
@@ -1,0 +1,61 @@
+[
+    {
+        "label": "Receive Custom Message",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?from_number=12067799192&messageText=Join&timestamp=2017-06-23T12:30:00Z",
+        "data": "empty",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019b3e07-00c8-7000-841b-80131c303e5c",
+                        "text": "Join",
+                        "urn": "tel:+12067799192",
+                        "received_on": "2017-06-23T12:30:00Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019b3e07-00c8-7000-841b-80131c303e5c",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+12067799192",
+                "text": "Join",
+                "created_on": "2025-12-20T23:10:04Z",
+                "received_on": "2017-06-23T12:30:00Z",
+                "log_uuids": [
+                    "019b3e06-f128-7000-a14b-f3a813d10e74"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Custom Missing",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sent_from=12067799192&messageText=Join",
+        "data": "empty",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "must have one of 'sender' or 'from' set"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/external/testdata/incoming_ext_urns.json
+++ b/handlers/external/testdata/incoming_ext_urns.json
@@ -1,0 +1,78 @@
+[
+    {
+        "label": "Receive Valid Message",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=%2B2349067554729&text=Join",
+        "data": "empty",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                        "text": "Join",
+                        "urn": "ext:+2349067554729",
+                        "received_on": "2025-11-01T05:43:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d628-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "ext:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-11-01T05:43:04Z",
+                "received_on": "2025-11-01T05:43:03Z",
+                "log_uuids": [
+                    "019a3df0-c688-7000-aac1-d0d96ed17383"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Valid Message trim spaces",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=+2349067554729&text=Join",
+        "data": "empty",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019b2881-5c08-7000-bbdd-7b9a2db54ca8",
+                        "text": "Join",
+                        "urn": "ext:2349067554729",
+                        "received_on": "2025-12-16T18:52:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019b2881-5c08-7000-bbdd-7b9a2db54ca8",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "ext:2349067554729",
+                "text": "Join",
+                "created_on": "2025-12-16T18:52:04Z",
+                "received_on": "2025-12-16T18:52:03Z",
+                "log_uuids": [
+                    "019b2881-4c68-7000-9212-147762cb30d0"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/external/testdata/incoming_gm.json
+++ b/handlers/external/testdata/incoming_gm.json
@@ -1,0 +1,40 @@
+[
+    {
+        "label": "Receive Non Plus Message",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/?sender=2207222333&text=Join",
+        "data": "empty",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a650a-4c08-7000-813c-5f0054f68c99",
+                        "text": "Join",
+                        "urn": "tel:+2207222333",
+                        "received_on": "2025-11-08T19:56:03Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a650a-4c08-7000-813c-5f0054f68c99",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2207222333",
+                "text": "Join",
+                "created_on": "2025-11-08T19:56:04Z",
+                "received_on": "2025-11-08T19:56:03Z",
+                "log_uuids": [
+                    "019a650a-3c68-7000-beb4-508824851c03"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/external/testdata/incoming_soap.json
+++ b/handlers/external/testdata/incoming_soap.json
@@ -1,0 +1,49 @@
+[
+    {
+        "label": "Receive Valid Post SOAP",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "\u003csoapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:com=\"com.hero\"\u003e\u003csoapenv:Header/\u003e\u003csoapenv:Body\u003e\u003ccom:moRequest\u003e\u003csource\u003e2349067554729\u003c/source\u003e\u003ccontent\u003eJoin\u003c/content\u003e\u003c/com:moRequest\u003e\u003c/soapenv:Body\u003e\u003c/soapenv:Envelope\u003e",
+        "response": {
+            "status": 200,
+            "body": "\u003c?xml version=“1.0”?\u003e\u003creturn\u003e0\u003c/return\u003e"
+        },
+        "msgs": [
+            {
+                "uuid": "019ac445-dfe8-7000-8283-9d5d3b1a8512",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+2349067554729",
+                "text": "Join",
+                "created_on": "2025-11-27T07:45:04Z",
+                "received_on": "2025-11-27T07:45:03Z",
+                "log_uuids": [
+                    "019ac445-d048-7000-a97f-1e6be18b2ce2"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Invalid SOAP",
+        "url": "/c/ex/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive/",
+        "data": "\u003csoapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:com=\"com.hero\"\u003e\u003csoapenv:Header/\u003e\u003csoapenv:Body\u003e\u003c/soapenv:Body\u003e\u003c/soapenv:Envelope\u003e",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing from at: //source or text at: //content node"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    }
+]

--- a/handlers/external/testdata/outgoing_get.json
+++ b/handlers/external/testdata/outgoing_get.json
@@ -1,0 +1,145 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=Simple+Message&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=%E2%98%BA&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 401,
+                    "body": "1: Unknown channel"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=Error+Message&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 429,
+                    "body": "1: Unknown channel"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=Error+Message&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_get_max_length.json
+++ b/handlers/external/testdata/outgoing_get_max_length.json
@@ -1,0 +1,55 @@
+[
+    {
+        "label": "Long Send",
+        "msg": {
+            "text": "This is a long message that will be longer than 30....... characters",
+            "urn": "tel:+250788383383",
+            "quick_replies": [
+                {
+                    "type": "text",
+                    "text": "One"
+                }
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                },
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                },
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=This+is+a+long+message+that&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            },
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=will+be+longer+than+30.......&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            },
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=characters&from=2020&quick_reply=One",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_get_max_length_str.json
+++ b/handlers/external/testdata/outgoing_get_max_length_str.json
@@ -1,0 +1,55 @@
+[
+    {
+        "label": "Long Send",
+        "msg": {
+            "text": "This is a long message that will be longer than 30....... characters",
+            "urn": "tel:+250788383383",
+            "quick_replies": [
+                {
+                    "type": "text",
+                    "text": "One"
+                }
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                },
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                },
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=This+is+a+long+message+that&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            },
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=will+be+longer+than+30.......&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            },
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=characters&from=2020&quick_reply=One",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_get_national.json
+++ b/handlers/external/testdata/outgoing_get_national.json
@@ -1,0 +1,27 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=788383383&text=Simple+Message&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_get_smart.json
+++ b/handlers/external/testdata/outgoing_get_smart.json
@@ -1,0 +1,145 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=Simple+Message&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=%E2%98%BA&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 401,
+                    "body": "1: Unknown channel"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=Error+Message&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 429,
+                    "body": "1: Unknown channel"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=Error+Message&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_get_smart_encoding.json
+++ b/handlers/external/testdata/outgoing_get_smart_encoding.json
@@ -1,0 +1,27 @@
+[
+    {
+        "label": "Smart Encoding",
+        "msg": {
+            "text": "Fancy “Smart” Quotes",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "GET",
+                "url": "http://example.com/send?to=%2B250788383383&text=Fancy+%22Smart%22+Quotes&from=2020",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_json.json
+++ b/handlers/external/testdata/outgoing_json.json
@@ -1,0 +1,195 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json",
+                    "Foo": "bar"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "Simple Message",
+                    "from": "2020",
+                    "quick_replies": []
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺ \"hi!\"",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json",
+                    "Foo": "bar"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "☺ \"hi!\"",
+                    "from": "2020",
+                    "quick_replies": []
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 401,
+                    "body": "1: Unknown channel"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json",
+                    "Foo": "bar"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "Error Message",
+                    "from": "2020",
+                    "quick_replies": []
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json",
+                    "Foo": "bar"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "My pic!\nhttps://foo.bar/image.jpg",
+                    "from": "2020",
+                    "quick_replies": []
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Quick Replies",
+        "msg": {
+            "text": "Some message",
+            "urn": "tel:+250788383383",
+            "quick_replies": [
+                {
+                    "type": "text",
+                    "text": "One"
+                },
+                {
+                    "type": "text",
+                    "text": "Two"
+                },
+                {
+                    "type": "text",
+                    "text": "Three"
+                }
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json",
+                    "Foo": "bar"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "Some message",
+                    "from": "2020",
+                    "quick_replies": [
+                        "One",
+                        "Two",
+                        "Three"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_json_authorization.json
+++ b/handlers/external/testdata/outgoing_json_authorization.json
@@ -1,0 +1,190 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "Simple Message",
+                    "from": "2020",
+                    "quick_replies": []
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺ \"hi!\"",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "☺ \"hi!\"",
+                    "from": "2020",
+                    "quick_replies": []
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 401,
+                    "body": "1: Unknown channel"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "Error Message",
+                    "from": "2020",
+                    "quick_replies": []
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "My pic!\nhttps://foo.bar/image.jpg",
+                    "from": "2020",
+                    "quick_replies": []
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Quick Replies",
+        "msg": {
+            "text": "Some message",
+            "urn": "tel:+250788383383",
+            "quick_replies": [
+                {
+                    "type": "text",
+                    "text": "One"
+                },
+                {
+                    "type": "text",
+                    "text": "Two"
+                },
+                {
+                    "type": "text",
+                    "text": "Three"
+                }
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "Some message",
+                    "from": "2020",
+                    "quick_replies": [
+                        "One",
+                        "Two",
+                        "Three"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_json_max_length.json
+++ b/handlers/external/testdata/outgoing_json_max_length.json
@@ -1,0 +1,91 @@
+[
+    {
+        "label": "Send Long message JSON",
+        "msg": {
+            "text": "This is a long message that will be longer than 30....... characters",
+            "urn": "tel:+250788383383",
+            "quick_replies": [
+                {
+                    "type": "text",
+                    "text": "One"
+                },
+                {
+                    "type": "text",
+                    "text": "Two"
+                },
+                {
+                    "type": "text",
+                    "text": "Three"
+                }
+            ]
+        },
+        "http_mocks": {
+            "*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                },
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                },
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json",
+                    "Foo": "bar"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "This is a long message that",
+                    "from": "2020",
+                    "quick_replies": []
+                }
+            },
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json",
+                    "Foo": "bar"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "will be longer than 30.......",
+                    "from": "2020",
+                    "quick_replies": []
+                }
+            },
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "application/json",
+                    "Foo": "bar"
+                },
+                "body": {
+                    "to": "+250788383383",
+                    "text": "characters",
+                    "from": "2020",
+                    "quick_replies": [
+                        "One",
+                        "Two",
+                        "Three"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_post.json
+++ b/handlers/external/testdata/outgoing_post.json
@@ -1,0 +1,156 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "text": [
+                        "Simple Message"
+                    ],
+                    "to": [
+                        "+250788383383"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "text": [
+                        "☺"
+                    ],
+                    "to": [
+                        "+250788383383"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 401,
+                    "body": "1: Unknown channel"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "text": [
+                        "Error Message"
+                    ],
+                    "to": [
+                        "+250788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "text": [
+                        "My pic!\nhttps://foo.bar/image.jpg"
+                    ],
+                    "to": [
+                        "+250788383383"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_post_content_type.json
+++ b/handlers/external/testdata/outgoing_post_content_type.json
@@ -1,0 +1,38 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded; charset=utf-8"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "text": [
+                        "Simple Message"
+                    ],
+                    "to": [
+                        "250788383383"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_post_smart.json
+++ b/handlers/external/testdata/outgoing_post_smart.json
@@ -1,0 +1,156 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "text": [
+                        "Simple Message"
+                    ],
+                    "to": [
+                        "+250788383383"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "text": [
+                        "☺"
+                    ],
+                    "to": [
+                        "+250788383383"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 401,
+                    "body": "1: Unknown channel"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "text": [
+                        "Error Message"
+                    ],
+                    "to": [
+                        "+250788383383"
+                    ]
+                }
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "text": [
+                        "My pic!\nhttps://foo.bar/image.jpg"
+                    ],
+                    "to": [
+                        "+250788383383"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_post_smart_encoding.json
+++ b/handlers/external/testdata/outgoing_post_smart_encoding.json
@@ -1,0 +1,38 @@
+[
+    {
+        "label": "Smart Encoding",
+        "msg": {
+            "text": "Fancy “Smart” Quotes",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                },
+                "form": {
+                    "from": [
+                        "2020"
+                    ],
+                    "text": [
+                        "Fancy \"Smart\" Quotes"
+                    ],
+                    "to": [
+                        "+250788383383"
+                    ]
+                }
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_xml.json
+++ b/handlers/external/testdata/outgoing_xml.json
@@ -1,0 +1,156 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "PUT",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003eSimple Message\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "PUT",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003e☺\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 401,
+                    "body": "1: Unknown channel"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "PUT",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003eError Message\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "PUT",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003eMy pic!\u0026#xA;https://foo.bar/image.jpg\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Quick Replies",
+        "msg": {
+            "text": "Some message",
+            "urn": "tel:+250788383383",
+            "quick_replies": [
+                {
+                    "type": "text",
+                    "text": "One"
+                },
+                {
+                    "type": "text",
+                    "text": "Two"
+                },
+                {
+                    "type": "text",
+                    "text": "Three"
+                }
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "PUT",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003eSome message\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003citem\u003eOne\u003c/item\u003e\u003citem\u003eTwo\u003c/item\u003e\u003citem\u003eThree\u003c/item\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_xml_max_length.json
+++ b/handlers/external/testdata/outgoing_xml_max_length.json
@@ -1,0 +1,72 @@
+[
+    {
+        "label": "Send Long message XML",
+        "msg": {
+            "text": "This is a long message that will be longer than 30....... characters",
+            "urn": "tel:+250788383383",
+            "quick_replies": [
+                {
+                    "type": "text",
+                    "text": "One"
+                },
+                {
+                    "type": "text",
+                    "text": "Two"
+                },
+                {
+                    "type": "text",
+                    "text": "Three"
+                }
+            ]
+        },
+        "http_mocks": {
+            "*": [
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                },
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                },
+                {
+                    "status": 200,
+                    "body": "0: Accepted for delivery"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "text/xml; charset=utf-8",
+                    "Foo": "bar"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003eThis is a long message that\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            },
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "text/xml; charset=utf-8",
+                    "Foo": "bar"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003ewill be longer than 30.......\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            },
+            {
+                "method": "POST",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Authorization": "Token ABCDEF",
+                    "Content-Type": "text/xml; charset=utf-8",
+                    "Foo": "bar"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003echaracters\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003citem\u003eOne\u003c/item\u003e\u003citem\u003eTwo\u003c/item\u003e\u003citem\u003eThree\u003c/item\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/external/testdata/outgoing_xml_response_check.json
+++ b/handlers/external/testdata/outgoing_xml_response_check.json
@@ -1,0 +1,189 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "<return>0</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "PUT",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003eSimple Message\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "<return>0</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "PUT",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003e☺\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 401,
+                    "body": "<return>0</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "PUT",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003eError Message\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending with 200 status code",
+        "msg": {
+            "text": "Error Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "<return>1</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "PUT",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003eError Message\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "error": {
+            "message": "response content",
+            "log_error": {
+                "code": "response_content",
+                "message": "Response content indicates non-success."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "<return>0</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "PUT",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003eMy pic!\u0026#xA;https://foo.bar/image.jpg\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Quick Replies",
+        "msg": {
+            "text": "Some message",
+            "urn": "tel:+250788383383",
+            "quick_replies": [
+                {
+                    "type": "text",
+                    "text": "One"
+                },
+                {
+                    "type": "text",
+                    "text": "Two"
+                },
+                {
+                    "type": "text",
+                    "text": "Three"
+                }
+            ]
+        },
+        "http_mocks": {
+            "http://example.com/send": [
+                {
+                    "status": 200,
+                    "body": "<return>0</return>"
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "PUT",
+                "url": "http://example.com/send",
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8"
+                },
+                "body": "\u003cmsg\u003e\u003cto\u003e+250788383383\u003c/to\u003e\u003ctext\u003eSome message\u003c/text\u003e\u003cfrom\u003e2020\u003c/from\u003e\u003cquick_replies\u003e\u003citem\u003eOne\u003c/item\u003e\u003citem\u003eTwo\u003c/item\u003e\u003citem\u003eThree\u003c/item\u003e\u003c/quick_replies\u003e\u003c/msg\u003e"
+            }
+        ],
+        "log_errors": []
+    }
+]

--- a/handlers/mtarget/handler_test.go
+++ b/handlers/mtarget/handler_test.go
@@ -1,206 +1,24 @@
 package mtarget
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/nyaruka/courier/v26/core/channels"
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
 	"github.com/nyaruka/courier/v26/test"
-	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 )
-
-var (
-	receiveURL = "/c/mt/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive"
-
-	receiveValidMessage = "Msisdn=+923161909799&Content=hello+world&Keyword=Default&MsgId=foo"
-	receiveInvalidURN   = "Msisdn=MTN&Content=hello+world&Keyword=Default"
-	receiveStop         = "Msisdn=+923161909799&Content=Stop&Keyword=Stop"
-	receiveMissingFrom  = "Content=hello&Keyword=Default"
-
-	receivePart2 = "Msisdn=+923161909799&Content=world&Keyword=Default&msglong.id=longmsg&msglong.msgcount=2&msglong.msgref=2"
-	receivePart1 = "Msisdn=+923161909799&Content=hello+&Keyword=Default&msglong.id=longmsg&msglong.msgcount=2&msglong.msgref=1"
-
-	statusURL = "/c/mt/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status"
-
-	statusDelivered = "MsgId=12a7ee90-50ce-11e7-80ae-00000a0a643c&Status=3"
-	statusFailed    = "MsgId=12a7ee90-50ce-11e7-80ae-00000a0a643c&Status=4"
-	statusMissingID = "status?Status=4"
-)
-
-var incomingCases = []IncomingTestCase{
-	{
-		Label:                "Receive Valid Message",
-		URL:                  receiveURL,
-		Data:                 receiveValidMessage,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("hello world"),
-		ExpectedURN:          "tel:+923161909799",
-		ExpectedExternalID:   "foo",
-	},
-	{
-		Label:                "Invalid URN",
-		URL:                  receiveURL,
-		Data:                 receiveInvalidURN,
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "not a possible number",
-	},
-	{
-		Label:              "Receive Stop",
-		URL:                receiveURL,
-		Data:               receiveStop,
-		ExpectedRespStatus: 200,
-		// this arrives on the receive route but produces a channel event, so it answers as an event - naming
-		// the envelope rather than matching "Accepted", which both envelopes contain
-		ExpectedBodyContains: `{"message":"Event Accepted","data":[{"type":"event"`,
-		ExpectedEvents: []ExpectedEvent{
-			{Type: models.EventTypeStopContact, URN: "tel:+923161909799"},
-		},
-	},
-	{
-		Label:                "Receive Missing From",
-		URL:                  receiveURL,
-		Data:                 receiveMissingFrom,
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "missing required field 'Msisdn'",
-	},
-	{
-		Label:                "Receive Part 2",
-		URL:                  receiveURL,
-		Data:                 receivePart2,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "received",
-	},
-	{
-		Label:                "Receive Part 1",
-		URL:                  receiveURL,
-		Data:                 receivePart1,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedMsgText:      Sp("hello world"),
-		ExpectedURN:          "tel:+923161909799",
-	},
-	{
-		Label:                "Status Delivered",
-		URL:                  statusURL,
-		Data:                 statusDelivered,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedStatuses: []ExpectedStatus{
-			{ExternalID: "12a7ee90-50ce-11e7-80ae-00000a0a643c", Status: models.MsgStatusDelivered},
-		},
-	},
-	{
-		Label:                "Status Failed",
-		URL:                  statusURL,
-		Data:                 statusFailed,
-		ExpectedRespStatus:   200,
-		ExpectedBodyContains: "Accepted",
-		ExpectedStatuses: []ExpectedStatus{
-			{ExternalID: "12a7ee90-50ce-11e7-80ae-00000a0a643c", Status: models.MsgStatusFailed},
-		},
-	},
-	{
-		Label:                "Status Missing ID",
-		URL:                  statusURL,
-		Data:                 statusMissingID,
-		ExpectedRespStatus:   400,
-		ExpectedBodyContains: "missing required field 'MsgId'",
-	},
-}
 
 func TestIncoming(t *testing.T) {
 	chs := []*models.Channel{
 		test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MT", "2020", "FR", []string{urns.Phone.Prefix}, nil),
 	}
 
-	RunIncomingTestCases(t, chs, newHandler, incomingCases)
-}
-
-var outgoingCases = []OutgoingTestCase{
-	{
-		Label:   "Plain Send",
-		MsgText: "Simple Message",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api-public.mtarget.fr/api-sms.json*": {
-				httpx.NewMockResponse(200, nil, []byte(`{"results":[{"code": "0", "ticket": "externalID"}]}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{Params: url.Values{"msisdn": {"+250788383383"}, "msg": {"Simple Message"}, "username": {"Username"}, "password": {"Password"}, "serviceid": {"2020"}, "allowunicode": {"true"}}},
-		},
-		ExpectedExtIDs: []string{"externalID"},
-	},
-	{
-		Label:   "Unicode Send",
-		MsgText: "☺",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api-public.mtarget.fr/api-sms.json*": {
-				httpx.NewMockResponse(200, nil, []byte(`{"results":[{"code": "0", "ticket": "externalID"}]}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{Params: url.Values{"msisdn": {"+250788383383"}, "msg": {"☺"}, "username": {"Username"}, "password": {"Password"}, "serviceid": {"2020"}, "allowunicode": {"true"}}},
-		},
-		ExpectedExtIDs: []string{"externalID"},
-	},
-	{
-		Label:          "Send Attachment",
-		MsgText:        "My pic!",
-		MsgURN:         "tel:+250788383383",
-		MsgAttachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api-public.mtarget.fr/api-sms.json*": {
-				httpx.NewMockResponse(200, nil, []byte(`{"results":[{"code": "0", "ticket": "externalID"}]}`)),
-			},
-		},
-		ExpectedRequests: []ExpectedRequest{
-			{Params: url.Values{"msisdn": {"+250788383383"}, "msg": {"My pic!\nhttps://foo.bar/image.jpg"}, "username": {"Username"}, "password": {"Password"}, "serviceid": {"2020"}, "allowunicode": {"true"}}},
-		},
-		ExpectedExtIDs: []string{"externalID"},
-	},
-	{
-		Label:   "Error Sending",
-		MsgText: "Error Sending",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api-public.mtarget.fr/api-sms.json*": {
-				httpx.NewMockResponse(403, nil, []byte(`{"results":[{"code": "3", "reason": "FAILED", "ticket": "null"}]}`)),
-			},
-		},
-		ExpectedError: channels.ErrResponseStatus,
-	},
-	{
-		Label:   "Throttled",
-		MsgText: "Error Sending",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api-public.mtarget.fr/api-sms.json*": {
-				httpx.NewMockResponse(429, nil, []byte(`{"results":[{"code": "3", "reason": "FAILED", "ticket": "null"}]}`)),
-			},
-		},
-		ExpectedError: channels.ErrConnectionThrottled,
-	},
-	{
-		Label:   "Error Response",
-		MsgText: "Error Sending",
-		MsgURN:  "tel:+250788383383",
-		MockResponses: map[string][]*httpx.MockResponse{
-			"https://api-public.mtarget.fr/api-sms.json*": {
-				httpx.NewMockResponse(200, nil, []byte(`{"results":[{"code": "3", "reason": "FAILED", "ticket": "null"}]}`)),
-			},
-		},
-		ExpectedError: channels.ErrFailedWithReason("3", "FAILED"),
-	},
+	RunIncomingTests(t, chs, newHandler, "testdata/incoming.json", nil)
 }
 
 func TestOutgoing(t *testing.T) {
-	var defaultChannel = test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MT", "2020", "FR",
+	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "MT", "2020", "FR",
 		[]string{urns.Phone.Prefix},
 		map[string]any{
 			"password": "Password",
@@ -208,5 +26,5 @@ func TestOutgoing(t *testing.T) {
 		},
 	)
 
-	RunOutgoingTestCases(t, defaultChannel, newHandler, outgoingCases, []string{"Password"}, nil)
+	RunOutgoingTests(t, ch, newHandler, "testdata/outgoing.json", &OutgoingOptions{CheckRedacted: []string{"Password"}})
 }

--- a/handlers/mtarget/testdata/incoming.json
+++ b/handlers/mtarget/testdata/incoming.json
@@ -1,0 +1,264 @@
+[
+    {
+        "label": "Receive Valid Message",
+        "url": "/c/mt/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive",
+        "data": "Msisdn=+923161909799\u0026Content=hello+world\u0026Keyword=Default\u0026MsgId=foo",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a3df0-d240-7000-a841-50246e59817e",
+                        "text": "hello world",
+                        "urn": "tel:+923161909799",
+                        "external_id": "foo",
+                        "received_on": "2025-11-01T05:43:05Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a3df0-d240-7000-a841-50246e59817e",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+923161909799",
+                "text": "hello world",
+                "external_id": "foo",
+                "created_on": "2025-11-01T05:43:03Z",
+                "received_on": "2025-11-01T05:43:05Z",
+                "log_uuids": [
+                    "019a3df0-c688-7000-aac1-d0d96ed17383"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Invalid URN",
+        "url": "/c/mt/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive",
+        "data": "Msisdn=MTN\u0026Content=hello+world\u0026Keyword=Default",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "not a possible number"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Stop",
+        "url": "/c/mt/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive",
+        "data": "Msisdn=+923161909799\u0026Content=Stop\u0026Keyword=Stop",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Event Accepted",
+                "data": [
+                    {
+                        "type": "event",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "event_type": "stop_contact",
+                        "urn": "tel:+923161909799",
+                        "received_on": "2025-11-26T20:06:04Z"
+                    }
+                ]
+            }
+        },
+        "events": [
+            {
+                "uuid": "019ac1c5-e3f8-7000-9b0b-af7021a28da6",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+923161909799",
+                "event_type": "stop_contact",
+                "occurred_on": "2025-11-26T20:06:04Z",
+                "log_uuids": [
+                    "019ac1c5-dc28-7000-9203-f9e59e2d98a9"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Missing From",
+        "url": "/c/mt/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive",
+        "data": "Content=hello\u0026Keyword=Default",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing required field 'Msisdn'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Part 2",
+        "url": "/c/mt/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive",
+        "data": "Msisdn=+923161909799\u0026Content=world\u0026Keyword=Default\u0026msglong.id=longmsg\u0026msglong.msgcount=2\u0026msglong.msgref=2",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Ignored",
+                "data": [
+                    {
+                        "type": "info",
+                        "info": "Message part received"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Receive Part 1",
+        "url": "/c/mt/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/receive",
+        "data": "Msisdn=+923161909799\u0026Content=hello+\u0026Keyword=Default\u0026msglong.id=longmsg\u0026msglong.msgcount=2\u0026msglong.msgref=1",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Message Accepted",
+                "data": [
+                    {
+                        "type": "msg",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "msg_uuid": "019a0bf2-aa20-7000-aea5-603301cad4c4",
+                        "text": "hello world",
+                        "urn": "tel:+923161909799",
+                        "received_on": "2025-10-22T12:44:05Z"
+                    }
+                ]
+            }
+        },
+        "msgs": [
+            {
+                "uuid": "019a0bf2-aa20-7000-aea5-603301cad4c4",
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "urn": "tel:+923161909799",
+                "text": "hello world",
+                "created_on": "2025-10-22T12:44:03Z",
+                "received_on": "2025-10-22T12:44:05Z",
+                "log_uuids": [
+                    "019a0bf2-9e68-7000-93d2-d4e1615c1e90"
+                ]
+            }
+        ],
+        "log": {
+            "type": "receive",
+            "errors": []
+        }
+    },
+    {
+        "label": "Status Delivered",
+        "url": "/c/mt/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status",
+        "data": "MsgId=12a7ee90-50ce-11e7-80ae-00000a0a643c\u0026Status=3",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "D",
+                        "external_id": "12a7ee90-50ce-11e7-80ae-00000a0a643c"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "external_identifier": "12a7ee90-50ce-11e7-80ae-00000a0a643c",
+                "status": "D",
+                "log_uuid": "0199f07e-1d88-7000-bf1c-2e310ab8165f"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Status Failed",
+        "url": "/c/mt/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status",
+        "data": "MsgId=12a7ee90-50ce-11e7-80ae-00000a0a643c\u0026Status=4",
+        "response": {
+            "status": 200,
+            "body": {
+                "message": "Status Update Accepted",
+                "data": [
+                    {
+                        "type": "status",
+                        "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                        "status": "F",
+                        "external_id": "12a7ee90-50ce-11e7-80ae-00000a0a643c"
+                    }
+                ]
+            }
+        },
+        "statuses": [
+            {
+                "channel_uuid": "8eb23e93-5ecb-45ba-b726-3b064e0c56ab",
+                "channel_id": 101,
+                "external_identifier": "12a7ee90-50ce-11e7-80ae-00000a0a643c",
+                "status": "F",
+                "log_uuid": "019ab73c-b768-7000-a62d-0aac2a54fb36"
+            }
+        ],
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    },
+    {
+        "label": "Status Missing ID",
+        "url": "/c/mt/8eb23e93-5ecb-45ba-b726-3b064e0c56ab/status",
+        "data": "status?Status=4",
+        "response": {
+            "status": 400,
+            "body": {
+                "message": "Error",
+                "data": [
+                    {
+                        "type": "error",
+                        "error": "missing required field 'MsgId'"
+                    }
+                ]
+            }
+        },
+        "log": {
+            "type": "msg_status",
+            "errors": []
+        }
+    }
+]

--- a/handlers/mtarget/testdata/outgoing.json
+++ b/handlers/mtarget/testdata/outgoing.json
@@ -1,0 +1,214 @@
+[
+    {
+        "label": "Plain Send",
+        "msg": {
+            "text": "Simple Message",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api-public.mtarget.fr/api-sms.json*": [
+                {
+                    "status": 200,
+                    "body": {
+                        "results": [
+                            {
+                                "code": "0",
+                                "ticket": "externalID"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api-public.mtarget.fr/api-sms.json?allowunicode=true&msg=Simple+Message&msisdn=%2B250788383383&password=Password&serviceid=2020&username=Username"
+            }
+        ],
+        "external_ids": [
+            "externalID"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Unicode Send",
+        "msg": {
+            "text": "☺",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api-public.mtarget.fr/api-sms.json*": [
+                {
+                    "status": 200,
+                    "body": {
+                        "results": [
+                            {
+                                "code": "0",
+                                "ticket": "externalID"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api-public.mtarget.fr/api-sms.json?allowunicode=true&msg=%E2%98%BA&msisdn=%2B250788383383&password=Password&serviceid=2020&username=Username"
+            }
+        ],
+        "external_ids": [
+            "externalID"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Send Attachment",
+        "msg": {
+            "text": "My pic!",
+            "urn": "tel:+250788383383",
+            "attachments": [
+                "image/jpeg:https://foo.bar/image.jpg"
+            ]
+        },
+        "http_mocks": {
+            "https://api-public.mtarget.fr/api-sms.json*": [
+                {
+                    "status": 200,
+                    "body": {
+                        "results": [
+                            {
+                                "code": "0",
+                                "ticket": "externalID"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api-public.mtarget.fr/api-sms.json?allowunicode=true&msg=My+pic%21%0Ahttps%3A%2F%2Ffoo.bar%2Fimage.jpg&msisdn=%2B250788383383&password=Password&serviceid=2020&username=Username"
+            }
+        ],
+        "external_ids": [
+            "externalID"
+        ],
+        "log_errors": []
+    },
+    {
+        "label": "Error Sending",
+        "msg": {
+            "text": "Error Sending",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api-public.mtarget.fr/api-sms.json*": [
+                {
+                    "status": 403,
+                    "body": {
+                        "results": [
+                            {
+                                "code": "3",
+                                "reason": "FAILED",
+                                "ticket": "null"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api-public.mtarget.fr/api-sms.json?allowunicode=true&msg=Error+Sending&msisdn=%2B250788383383&password=Password&serviceid=2020&username=Username"
+            }
+        ],
+        "error": {
+            "message": "response status code",
+            "log_error": {
+                "code": "response_status",
+                "message": "Response has non-success status code."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Throttled",
+        "msg": {
+            "text": "Error Sending",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api-public.mtarget.fr/api-sms.json*": [
+                {
+                    "status": 429,
+                    "body": {
+                        "results": [
+                            {
+                                "code": "3",
+                                "reason": "FAILED",
+                                "ticket": "null"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api-public.mtarget.fr/api-sms.json?allowunicode=true&msg=Error+Sending&msisdn=%2B250788383383&password=Password&serviceid=2020&username=Username"
+            }
+        ],
+        "error": {
+            "message": "channel rate limited",
+            "retryable": true,
+            "log_error": {
+                "code": "connection_throttled",
+                "message": "Connection to server has been rate limited."
+            }
+        },
+        "log_errors": []
+    },
+    {
+        "label": "Error Response",
+        "msg": {
+            "text": "Error Sending",
+            "urn": "tel:+250788383383"
+        },
+        "http_mocks": {
+            "https://api-public.mtarget.fr/api-sms.json*": [
+                {
+                    "status": 200,
+                    "body": {
+                        "results": [
+                            {
+                                "code": "3",
+                                "reason": "FAILED",
+                                "ticket": "null"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "requests": [
+            {
+                "method": "POST",
+                "url": "https://api-public.mtarget.fr/api-sms.json?allowunicode=true&msg=Error+Sending&msisdn=%2B250788383383&password=Password&serviceid=2020&username=Username"
+            }
+        ],
+        "error": {
+            "message": "channel rejected send with reason",
+            "log_error": {
+                "code": "rejected_with_reason",
+                "ext_code": "3",
+                "message": "FAILED"
+            }
+        },
+        "log_errors": []
+    }
+]


### PR DESCRIPTION
## Summary

Continues the move of handler tests to JSON case files with the external and mtarget handlers. Neither needed runner changes: the external handler's incoming multipart form case was already supported by the file-based runner, and mtarget is a plain conversion.

## Changes

- **mtarget** — `testdata/incoming.json` and `testdata/outgoing.json`, with the password checked for redaction in channel logs.
- **external** — every channel configuration the old test exercised keeps its own run, so each gets its own case file named for what it covers:
  - incoming: `incoming.json` (default), `incoming_soap.json`, `incoming_gm.json`, `incoming_custom_fields.json`, `incoming_ext_urns.json`
  - outgoing: `outgoing_get.json`, `outgoing_get_smart.json`, `outgoing_get_smart_encoding.json`, `outgoing_post.json`, `outgoing_post_content_type.json`, `outgoing_post_smart.json`, `outgoing_post_smart_encoding.json`, `outgoing_json.json`, `outgoing_json_authorization.json`, `outgoing_xml.json`, `outgoing_xml_response_check.json`, `outgoing_get_max_length.json`, `outgoing_get_max_length_str.json`, `outgoing_json_max_length.json`, `outgoing_xml_max_length.json`, `outgoing_get_national.json`

  Case sets the old test reused across channels (e.g. the GET cases against both the plain and smart-encoding channels) are separate files, since their recorded outcomes differ by channel. A small `newChannel` helper builds each configuration.

## Test plan

- [x] `go test ./handlers/external/ ./handlers/mtarget/ -update` then again without `-update` — files are stable
- [x] Recorded outcomes reviewed against the previous `Expected*` values: query params, form fields, JSON and XML bodies, headers (custom content type, send headers, send authorization), smart-encoding replacements, 30-character message splits, national number formatting, statuses by message UUID, stop events and the unlogged 404 all match (only label-derived timestamps differ)