### PR TITLE
Tidy handler test helpers now that every handler uses case files

### DIFF
--- a/handlers/handlertest/doc.go
+++ b/handlers/handlertest/doc.go
@@ -1,0 +1,12 @@
+// Package handlertest runs the tests for channel handlers. Test cases live in JSON files under a handler's testdata
+// directory, each file holding the cases for one channel configuration: a file of incoming cases is run with
+// RunIncomingTests and a file of outgoing cases with RunOutgoingTests. A case is its inputs (the request or message,
+// and any mocked HTTP responses) followed by what the handler did with them, which is written by running the tests
+// with -update and checked against on every other run:
+//
+//	go test ./handlers/telegram/ -update
+//
+// Only requests answered by a case's mocks are captured, and any other request a handler makes fails, so a case
+// has to mock every call its handler makes. Time, UUIDs and random values are derived from the case's label, so
+// labels must be unique within a file.
+package handlertest

--- a/handlers/handlertest/handlertest.go
+++ b/handlers/handlertest/handlertest.go
@@ -4,18 +4,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
-	"log"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/courier/v26/core/models"
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/web"
+	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,14 +24,14 @@ import (
 // RequestPrepFunc is our type for a hook for tests to use before a request is fired in a test
 type RequestPrepFunc func(*http.Request)
 
-func makeHandlerRequest(tb testing.TB, s *web.Server, path string, headers map[string]string, data string, multipartFormFields map[string]string, requestPrepFunc RequestPrepFunc) (int, []byte) {
+func makeHandlerRequest(t *testing.T, s *web.Server, path string, headers map[string]string, data string, multipartFormFields map[string]string, requestPrepFunc RequestPrepFunc) (int, []byte) {
 	var req *http.Request
 	var err error
 	url := fmt.Sprintf("https://%s%s", s.Runtime().Config.Domain, path)
 
 	if data != "" {
 		req, err = http.NewRequest(http.MethodPost, url, strings.NewReader(data))
-		require.Nil(tb, err)
+		require.Nil(t, err)
 
 		// guess our content type
 		contentType := "application/x-www-form-urlencoded"
@@ -46,15 +46,15 @@ func makeHandlerRequest(tb testing.TB, s *web.Server, path string, headers map[s
 		bodyMultipartWriter := multipart.NewWriter(&body)
 		for k, v := range multipartFormFields {
 			fieldWriter, err := bodyMultipartWriter.CreateFormField(k)
-			require.Nil(tb, err)
+			require.Nil(t, err)
 			_, err = fieldWriter.Write([]byte(v))
-			require.Nil(tb, err)
+			require.Nil(t, err)
 		}
 		contentType := fmt.Sprintf("multipart/form-data;boundary=%v", bodyMultipartWriter.Boundary())
 		bodyMultipartWriter.Close()
 
 		req, err = http.NewRequest(http.MethodPost, url, bytes.NewReader(body.Bytes()))
-		require.Nil(tb, err)
+		require.Nil(t, err)
 		req.Header.Set("Content-Type", contentType)
 	} else {
 		req, err = http.NewRequest(http.MethodGet, url, nil)
@@ -64,7 +64,7 @@ func makeHandlerRequest(tb testing.TB, s *web.Server, path string, headers map[s
 		req.Header.Set(key, val)
 	}
 
-	require.Nil(tb, err)
+	require.Nil(t, err)
 
 	if requestPrepFunc != nil {
 		requestPrepFunc(req)
@@ -76,22 +76,37 @@ func makeHandlerRequest(tb testing.TB, s *web.Server, path string, headers map[s
 	return rr.Code, rr.Body.Bytes()
 }
 
-// localOnlyTransport passes through requests to test servers on this host and rejects everything else
-type localOnlyTransport struct {
-	http.RoundTripper
+// noNetworkTransport fails every request, so that a call a handler makes which its case hasn't mocked is caught here
+// rather than reaching a real API
+type noNetworkTransport struct{}
+
+func (t noNetworkTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("handler tests can't make unmocked requests: %s %s", r.Method, r.URL)
 }
 
-func (t localOnlyTransport) RoundTrip(r *http.Request) (*http.Response, error) {
-	if host := r.URL.Hostname(); host != "localhost" && host != "127.0.0.1" && host != "::1" {
-		return nil, fmt.Errorf("handler tests can't make requests outside this host: %s", r.URL)
+// gives the runtime a single HTTP client, shared by all three of its clients so that a case's transport intercepts
+// every request a handler makes via any of them
+func installTestClient(rt *runtime.Runtime) *http.Client {
+	client := &http.Client{Transport: httpx.WithTraces(noNetworkTransport{}), Timeout: 30 * time.Second}
+	rt.HTTP.Default = client
+	rt.HTTP.Proxied = client
+	rt.HTTP.Attachments = client
+	return client
+}
+
+// gives the client the transport for a case: one answering with the case's mocks if it has any, and otherwise one
+// which fails every request. Tracing is wrapped around either, since that's what produces the channel logs.
+func setCaseTransport(client *http.Client, mocks map[string][]*httpx.MockResponse) *httpx.MocksTransport {
+	if len(mocks) == 0 {
+		client.Transport = httpx.WithTraces(noNetworkTransport{})
+		return nil
 	}
-	return t.RoundTripper.RoundTrip(r)
+	mockHTTP := httpx.WithMocks(nil, mocks)
+	client.Transport = httpx.WithTraces(mockHTTP)
+	return mockHTTP
 }
 
 func newServer(rt *runtime.Runtime) *web.Server {
-	// for benchmarks, log to null
-	log.SetOutput(io.Discard)
-
 	rt.Config.FacebookWebhookSecret = "fb_webhook_secret"
 	rt.Config.FacebookApplicationSecret = "fb_app_secret"
 	rt.Config.WhatsappAdminSystemUserToken = "wac_admin_system_user_token"
@@ -103,8 +118,8 @@ func contactQueueKey(ch *models.Channel, msg *models.MsgOut) string {
 	return fmt.Sprintf("c:%d:%d", ch.OrgID(), msg.Contact_.ID)
 }
 
-// asserts which contact_changed task the completed send queued: expectedNewURN is empty for the cases where none
-// should be, which is what covers a send reporting a URN the contact already has.
+// returns the new URNs of the contact_changed tasks queued for the contact of the given message, which is how a send
+// reporting a URN the contact already has can be seen to queue none
 func queuedContactChangedURNs(t *testing.T, rt *runtime.Runtime, ch *models.Channel, msg *models.MsgOut) []urns.URN {
 	rc := rt.VK.Get()
 	defer rc.Close()

--- a/handlers/handlertest/incoming.go
+++ b/handlers/handlertest/incoming.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"slices"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -92,13 +91,7 @@ func RunIncomingTests(t *testing.T, chs []*models.Channel, newFn channels.NewHan
 	testsuite.ResetDB(t, rt)
 	testsuite.ResetValkey(t, rt)
 
-	// cases which mock HTTP get a mocking transport, and the rest fail anything leaving the host so that a handler
-	// which isn't pointed at a test server is caught here rather than calling a real channel API. Either way tracing
-	// stays wrapped around the transport since that's what produces the channel logs.
-	client := &http.Client{Transport: httpx.WithTraces(localOnlyTransport{http.DefaultTransport}), Timeout: 30 * time.Second}
-	rt.HTTP.Default = client
-	rt.HTTP.Proxied = client
-	rt.HTTP.Attachments = client
+	client := installTestClient(rt)
 
 	// data: attachments are saved to storage as they're received so ensure the bucket exists
 	rt.S3.Client.CreateBucket(t.Context(), &s3.CreateBucketInput{Bucket: aws.String(rt.Config.S3AttachmentsBucket)})
@@ -135,13 +128,7 @@ func RunIncomingTests(t *testing.T, chs []*models.Channel, newFn channels.NewHan
 			handledEvents = nil
 			handledLogs = nil
 
-			var mockHTTP *httpx.MocksTransport
-			if len(tc.HTTPMocks) > 0 {
-				mockHTTP = httpx.WithMocks(nil, tc.HTTPMocks)
-				client.Transport = httpx.WithTraces(mockHTTP)
-			} else {
-				client.Transport = httpx.WithTraces(localOnlyTransport{http.DefaultTransport})
-			}
+			mockHTTP := setCaseTransport(client, tc.HTTPMocks)
 
 			status, body := makeHandlerRequest(t, s, tc.URL, tc.Headers, string(tc.Data.Bytes()), tc.MultipartForm, opts.signer(tc))
 

--- a/handlers/handlertest/outgoing.go
+++ b/handlers/handlertest/outgoing.go
@@ -3,7 +3,6 @@ package handlertest
 import (
 	"context"
 	"encoding/json"
-	"net/http"
 	"slices"
 	"testing"
 	"time"
@@ -121,13 +120,7 @@ func RunOutgoingTests(t *testing.T, ch *models.Channel, newFn channels.NewHandle
 	testsuite.ResetDB(t, rt)
 	testsuite.ResetValkey(t, rt)
 
-	// use a plain HTTP client so per-case mock transports can be installed, shared by all three clients so
-	// installing a mocking transport intercepts every request a handler makes via any of them. Tracing stays
-	// wrapped around whatever transport a case installs, since that's what produces the channel logs.
-	client := &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTP.Default = client
-	rt.HTTP.Proxied = client
-	rt.HTTP.Attachments = client
+	client := installTestClient(rt)
 
 	if opts.Setup != nil {
 		opts.Setup(t, rt)
@@ -155,14 +148,7 @@ func RunOutgoingTests(t *testing.T, ch *models.Channel, newFn channels.NewHandle
 			rc.Close()
 			require.NoError(t, err)
 
-			// reset to the default transport each case, then install a mocking transport when the case provides
-			// mocks - always inside tracing, which is what the handler's channel log is built from
-			var mockHTTP *httpx.MocksTransport
-			client.Transport = httpx.WithTraces(nil)
-			if len(tc.HTTPMocks) > 0 {
-				mockHTTP = httpx.WithMocks(nil, tc.HTTPMocks)
-				client.Transport = httpx.WithTraces(mockHTTP)
-			}
+			mockHTTP := setCaseTransport(client, tc.HTTPMocks)
 
 			clog := models.NewChannelLogForSend(msg, handler.RedactValues(ch))
 			sendCtx, cancel := context.WithTimeout(ctx, time.Millisecond*100)
@@ -179,8 +165,6 @@ func RunOutgoingTests(t *testing.T, ch *models.Channel, newFn channels.NewHandle
 			actual.NewURN = ""
 
 			if mockHTTP != nil {
-				client.Transport = httpx.WithTraces(nil)
-
 				assert.False(t, mockHTTP.HasUnused(), "unused HTTP mocks")
 
 				for _, r := range mockHTTP.Requests() {

--- a/handlers/handlertest/snapshots.go
+++ b/handlers/handlertest/snapshots.go
@@ -24,11 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Handler test cases live in JSON files alongside the tests, each file holding the cases for one channel
-// configuration. A case is its inputs (the request or message, and any mocked HTTP responses) followed by what the
-// handler did with them, which is written by running the tests with -update and checked against on every other run.
-// The types below are the building blocks of those files.
-
 // HTTPBody is a request or response body. In test files a body which is a JSON object or array is written as
 // that JSON, and any other body is written as a string. A body can also be written as a string even though it's
 // JSON, which preserves its exact bytes - needed when a signature is calculated over them.

--- a/handlers/jiochat/handler_test.go
+++ b/handlers/jiochat/handler_test.go
@@ -3,10 +3,7 @@ package jiochat
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/nyaruka/courier/v26/core/models"
 	. "github.com/nyaruka/courier/v26/handlers/handlertest"
@@ -30,58 +27,19 @@ func setupBackend(t *testing.T, rt *runtime.Runtime) {
 	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 }
 
-func buildMockJCAPI() *httptest.Server {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		authorizationHeader := r.Header.Get("Authorization")
-		defer r.Body.Close()
-
-		// a request for an access token is the one request that doesn't carry one
-		if strings.HasSuffix(r.URL.Path, "auth/token.action") {
-			w.Write([]byte(`{"access_token": "ACCESS_TOKEN"}`))
-			return
-		}
-
-		if authorizationHeader != "Bearer ACCESS_TOKEN" {
-			http.Error(w, "invalid file", http.StatusForbidden)
-			return
-		}
-
-		if strings.HasSuffix(r.URL.Path, "user/info.action") {
-			openID := r.URL.Query().Get("openid")
-
-			// user has a name
-			if strings.HasSuffix(openID, "1337") {
-				w.Write([]byte(`{ "nickname": "John Doe"}`))
-				return
-			}
-
-			// no name
-			w.Write([]byte(`{ "nickname": ""}`))
-
-		}
-
-	}))
-	sendURL = server.URL
-
-	return server
-}
-
 func TestDescribeURN(t *testing.T) {
-	defer func(u string) { sendURL = u }(sendURL)
-	JCAPI := buildMockJCAPI()
-	defer JCAPI.Close()
-
 	_, rt := testsuite.Runtime(t)
 	testsuite.ResetValkey(t, rt)
+	setupBackend(t, rt)
 
-	// use a plain client so the handler can reach the mock API on localhost
-	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTP.Proxied = rt.HTTP.Default
-
-	// ensure there's a cached access token
-	rc := rt.VK.Get()
-	defer rc.Close()
-	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
+	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+		"https://channels.jiochat.com/user/info.action?openid=1337": {
+			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"nickname": "John Doe"}`)),
+		},
+		"https://channels.jiochat.com/user/info.action?openid=4567": {
+			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"nickname": ""}`)),
+		},
+	})
 
 	s := web.NewServer(rt)
 	handler := s.MountHandler(newHandler).(*handler)
@@ -97,8 +55,12 @@ func TestDescribeURN(t *testing.T) {
 
 	for _, tc := range tcs {
 		metadata, _ := handler.DescribeURN(context.Background(), testChannels[0], tc.urn, clog)
-		assert.Equal(t, metadata, tc.expectedMetadata)
+		assert.Equal(t, tc.expectedMetadata, metadata)
 	}
+
+	// lookups are made with the cached access token
+	assert.Len(t, clog.HttpLogs, 2)
+	assert.Contains(t, clog.HttpLogs[0].Request, "Authorization: Bearer ACCESS_TOKEN")
 
 	AssertChannelLogRedaction(t, clog, []string{"secret123"})
 }
@@ -106,14 +68,8 @@ func TestDescribeURN(t *testing.T) {
 func TestBuildAttachmentRequest(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	// reset send URL
-	sendURL = "https://channels.jiochat.com"
-
 	// ensure that we start with no cached token
 	testsuite.ResetValkey(t, rt)
-
-	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTP.Proxied = rt.HTTP.Default
 
 	s := web.NewServer(rt)
 	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{

--- a/handlers/meta/facebook_test.go
+++ b/handlers/meta/facebook_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -34,12 +32,18 @@ func TestFacebookIncoming(t *testing.T) {
 }
 
 func TestFacebookDescribeURN(t *testing.T) {
-	defer func(u string) { graphURL = u }(graphURL)
-	fbGraph := buildMockFBGraphFBA()
-	defer fbGraph.Close()
+	rt := runtime.NewTestRuntime(runtime.NewDefaultConfig())
+	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+		"https://graph.facebook.com/1337?access_token=a123&fields=first_name%2Clast_name": {
+			httpx.NewMockResponse(200, nil, []byte(`{"first_name": "John", "last_name": "Doe"}`)),
+		},
+		"https://graph.facebook.com/4567?access_token=a123&fields=first_name%2Clast_name": {
+			httpx.NewMockResponse(200, nil, []byte(`{"first_name": "", "last_name": ""}`)),
+		},
+	})
 
 	channel := facebookTestChannels[0]
-	handler := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(newHandler("FBA", "Facebook"))
+	handler := web.NewServer(rt).MountHandler(newHandler("FBA", "Facebook"))
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, channel, nil, handler.RedactValues(channel))
 
 	tcs := []struct {
@@ -159,28 +163,4 @@ func addValidSignature(r *http.Request) {
 	body, _ := ReadBody(r, maxRequestBodyBytes)
 	sig, _ := fbCalculateSignature("fb_app_secret", body)
 	r.Header.Set(signatureHeader, fmt.Sprintf("sha256=%s", string(sig)))
-}
-
-// mocks the call to the Facebook graph API
-func buildMockFBGraphFBA() *httptest.Server {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		accessToken := r.URL.Query().Get("access_token")
-		defer r.Body.Close()
-
-		// invalid auth token
-		if accessToken != "a123" {
-			http.Error(w, "invalid auth token", http.StatusForbidden)
-		}
-
-		// user has a name
-		if strings.HasSuffix(r.URL.Path, "1337") {
-			w.Write([]byte(`{ "first_name": "John", "last_name": "Doe"}`))
-			return
-		}
-		// no name
-		w.Write([]byte(`{ "first_name": "", "last_name": ""}`))
-	}))
-	graphURL = server.URL
-
-	return server
 }

--- a/handlers/meta/instagram_test.go
+++ b/handlers/meta/instagram_test.go
@@ -3,8 +3,6 @@ package meta
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/nyaruka/courier/v26/core/models"
@@ -12,6 +10,7 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/web"
+	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,12 +35,18 @@ func TestInstagramOutgoing(t *testing.T) {
 }
 
 func TestInstagramDescribeURN(t *testing.T) {
-	defer func(u string) { graphURL = u }(graphURL)
-	fbGraph := buildMockFBGraphIG()
-	defer fbGraph.Close()
+	rt := runtime.NewTestRuntime(runtime.NewDefaultConfig())
+	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+		"https://graph.facebook.com/1337?access_token=a123": {
+			httpx.NewMockResponse(200, nil, []byte(`{"name": "John Doe"}`)),
+		},
+		"https://graph.facebook.com/4567?access_token=a123": {
+			httpx.NewMockResponse(200, nil, []byte(`{"name": ""}`)),
+		},
+	})
 
 	channel := instgramTestChannels[0]
-	handler := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(newHandler("IG", "Instagram"))
+	handler := web.NewServer(rt).MountHandler(newHandler("IG", "Instagram"))
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, channel, nil, handler.RedactValues(channel))
 
 	tcs := []struct {
@@ -67,29 +72,4 @@ func TestInstagramBuildAttachmentRequest(t *testing.T) {
 	req, _ := handler.BuildAttachmentRequest(context.Background(), facebookTestChannels[0], "https://example.org/v1/media/41", nil)
 	assert.Equal(t, "https://example.org/v1/media/41", req.URL.String())
 	assert.Equal(t, http.Header{}, req.Header)
-}
-
-// mocks the call to the Facebook graph API
-func buildMockFBGraphIG() *httptest.Server {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		accessToken := r.URL.Query().Get("access_token")
-		defer r.Body.Close()
-
-		// invalid auth token
-		if accessToken != "a123" {
-			http.Error(w, "invalid auth token", http.StatusForbidden)
-		}
-
-		// user has a name
-		if strings.HasSuffix(r.URL.Path, "1337") {
-			w.Write([]byte(`{ "name": "John Doe"}`))
-			return
-		}
-
-		// no name
-		w.Write([]byte(`{ "name": ""}`))
-	}))
-	graphURL = server.URL
-
-	return server
 }

--- a/handlers/meta/whatsapp_test.go
+++ b/handlers/meta/whatsapp_test.go
@@ -73,16 +73,9 @@ func newServerWithWAC() *web.Server {
 }
 
 func TestWhatsAppSendEvent(t *testing.T) {
-	// other tests repoint graphURL at mock servers, so pin it for this test
-	defer func(u string) { graphURL = u }(graphURL)
-	graphURL = "https://graph.facebook.com/v25.0/"
-
 	channel := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WAC", "12345_ID", "", []string{urns.WhatsApp.Prefix}, map[string]any{models.ConfigAuthToken: "a123"})
 
-	cfg := runtime.NewDefaultConfig()
-	cfg.WhatsappAdminSystemUserToken = "wac_admin_system_user_token"
-	s := web.NewServer(runtime.NewTestRuntime(cfg))
-
+	s := newServerWithWAC()
 	h := s.MountHandler(newHandler("WAC", "WhatsApp Cloud")).(*handler)
 
 	s.Runtime().HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{

--- a/handlers/slack/handler_test.go
+++ b/handlers/slack/handler_test.go
@@ -2,8 +2,6 @@ package slack
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/nyaruka/courier/v26/core/models"
@@ -11,6 +9,7 @@ import (
 	"github.com/nyaruka/courier/v26/runtime"
 	"github.com/nyaruka/courier/v26/test"
 	"github.com/nyaruka/courier/v26/web"
+	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,25 +30,15 @@ func TestOutgoing(t *testing.T) {
 	RunOutgoingTests(t, testChannels[0], newHandler, "testdata/outgoing.json", opts)
 }
 
-func buildMockSlackService() *httptest.Server {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/users.info" {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"user":{"real_name":"dummy user"}}`))
-		}
-	}))
-
-	apiURL = server.URL
-
-	return server
-}
-
 func TestDescribeURN(t *testing.T) {
-	defer func(u string) { apiURL = u }(apiURL)
-	server := buildMockSlackService()
-	defer server.Close()
+	rt := runtime.NewTestRuntime(runtime.NewDefaultConfig())
+	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+		"https://slack.com/api/users.info?user=U012345": {
+			httpx.NewMockResponse(200, nil, []byte(`{"user":{"real_name":"dummy user"}}`)),
+		},
+	})
 
-	handler := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(newHandler)
+	handler := web.NewServer(rt).MountHandler(newHandler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 	urn, _ := urns.New(urns.Slack, "U012345")
 

--- a/handlers/vk/handler_test.go
+++ b/handlers/vk/handler_test.go
@@ -2,9 +2,6 @@ package vk
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -41,30 +38,15 @@ func TestIncoming(t *testing.T) {
 	RunIncomingTests(t, testChannels, newHandler, "testdata/incoming.json", nil)
 }
 
-func buildMockVKService() *httptest.Server {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, actionGetUser) {
-			userId := r.URL.Query()["user_ids"][0]
-
-			if userId == "123456789" {
-				_, _ = w.Write([]byte(`{"response": [{"id": 123456789, "first_name": "John", "last_name": "Doe"}]}`))
-				return
-			}
-			_, _ = w.Write([]byte(`{"response": []}`))
-		}
-	}))
-
-	apiBaseURL = server.URL
-
-	return server
-}
-
 func TestDescribeURN(t *testing.T) {
-	defer func(u string) { apiBaseURL = u }(apiBaseURL)
-	server := buildMockVKService()
-	defer server.Close()
+	rt := runtime.NewTestRuntime(runtime.NewDefaultConfig())
+	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+		"https://api.vk.com/method/users.get.json?*": {
+			httpx.NewMockResponse(200, nil, []byte(`{"response": [{"id": 123456789, "first_name": "John", "last_name": "Doe"}]}`)),
+		},
+	})
 
-	handler := web.NewServer(runtime.NewTestRuntime(runtime.NewDefaultConfig())).MountHandler(newHandler)
+	handler := web.NewServer(rt).MountHandler(newHandler)
 	clog := models.NewChannelLog(models.ChannelLogTypeUnknown, testChannels[0], nil, handler.RedactValues(testChannels[0]))
 	urn, _ := urns.New(urns.VK, "123456789")
 	data := map[string]string{"name": "John Doe"}
@@ -72,6 +54,8 @@ func TestDescribeURN(t *testing.T) {
 	describe, err := handler.(models.URNDescriber).DescribeURN(context.Background(), testChannels[0], urn, clog)
 	assert.Nil(t, err)
 	assert.Equal(t, data, describe)
+	assert.Len(t, clog.HttpLogs, 1)
+	assert.Contains(t, clog.HttpLogs[0].URL, "user_ids=123456789")
 
 	AssertChannelLogRedaction(t, clog, []string{"token123xyz", "abc123xyz"})
 }

--- a/handlers/wechat/handler_test.go
+++ b/handlers/wechat/handler_test.go
@@ -3,8 +3,6 @@ package wechat
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -35,58 +33,20 @@ func setupBackend(t *testing.T, rt *runtime.Runtime) {
 	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
 }
 
-func buildMockWCAPI() *httptest.Server {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		accessToken := r.URL.Query().Get("access_token")
-		defer r.Body.Close()
-
-		// a request for an access token is the one request that doesn't carry one
-		if strings.HasSuffix(r.URL.Path, "/token") {
-			w.Write([]byte(`{"access_token": "ACCESS_TOKEN"}`))
-			return
-		}
-
-		if accessToken != "ACCESS_TOKEN" {
-			http.Error(w, "invalid file", http.StatusForbidden)
-			return
-		}
-
-		if strings.HasSuffix(r.URL.Path, "user/info") {
-			openID := r.URL.Query().Get("openid")
-
-			// user has a name
-			if strings.HasSuffix(openID, "KNOWN_OPEN_ID") {
-				w.Write([]byte(`{ "nickname": "John Doe"}`))
-				return
-			}
-
-			// no name
-			w.Write([]byte(`{ "nickname": ""}`))
-
-		}
-
-	}))
-	sendURL = server.URL
-
-	return server
-}
-
 func TestDescribeURN(t *testing.T) {
-	defer func(u string) { sendURL = u }(sendURL)
-	WCAPI := buildMockWCAPI()
-	defer WCAPI.Close()
-
 	_, rt := testsuite.Runtime(t)
 	testsuite.ResetValkey(t, rt)
+	setupBackend(t, rt)
 
-	// use a plain client so the handler can reach the mock API on localhost
-	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTP.Proxied = rt.HTTP.Default
-
-	// ensure there's a cached access token
-	rc := rt.VK.Get()
-	defer rc.Close()
-	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
+	// lookups are made with the cached access token
+	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
+		"https://api.weixin.qq.com/cgi-bin/user/info?access_token=ACCESS_TOKEN&openid=abcdeKNOWN_OPEN_ID": {
+			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"nickname": "John Doe"}`)),
+		},
+		"https://api.weixin.qq.com/cgi-bin/user/info?access_token=ACCESS_TOKEN&openid=foo__NOT__KNOWN": {
+			httpx.NewMockResponse(http.StatusOK, nil, []byte(`{"nickname": ""}`)),
+		},
+	})
 
 	s := web.NewServer(rt)
 	handler := s.MountHandler(newHandler).(*handler)
@@ -102,7 +62,7 @@ func TestDescribeURN(t *testing.T) {
 
 	for _, tc := range tcs {
 		metadata, _ := handler.DescribeURN(context.Background(), testChannels[0], tc.urn, clog)
-		assert.Equal(t, metadata, tc.expectedMetadata)
+		assert.Equal(t, tc.expectedMetadata, metadata)
 	}
 
 	AssertChannelLogRedaction(t, clog, []string{"secret123"})
@@ -111,14 +71,8 @@ func TestDescribeURN(t *testing.T) {
 func TestBuildAttachmentRequest(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	// reset send URL
-	sendURL = "https://api.weixin.qq.com/cgi-bin"
-
 	// ensure that we start with no cached token
 	testsuite.ResetValkey(t, rt)
-
-	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTP.Proxied = rt.HTTP.Default
 
 	s := web.NewServer(rt)
 	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
@@ -148,14 +102,8 @@ func TestBuildAttachmentRequest(t *testing.T) {
 func TestFetchAccessTokenThrottled(t *testing.T) {
 	_, rt := testsuite.Runtime(t)
 
-	// reset send URL
-	sendURL = "https://api.weixin.qq.com/cgi-bin"
-
 	// ensure that we start with no cached token
 	testsuite.ResetValkey(t, rt)
-
-	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTP.Proxied = rt.HTTP.Default
 
 	s := web.NewServer(rt)
 	rt.HTTP.Default.Transport = test.MockTransport(map[string][]*httpx.MockResponse{
@@ -172,22 +120,11 @@ func TestFetchAccessTokenThrottled(t *testing.T) {
 }
 
 func TestSendEvent(t *testing.T) {
-	// other tests repoint sendURL at mock servers, so pin it for this test
-	defer func(u string) { sendURL = u }(sendURL)
-	sendURL = "https://api.weixin.qq.com/cgi-bin"
-
 	ch := test.NewMockChannel("8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "WC", "2020", "US", []string{urns.WeChat.Prefix}, map[string]any{configAppSecret: "secret123", configAppID: "app-id"})
 
 	_, rt := testsuite.Runtime(t)
 	testsuite.ResetValkey(t, rt)
-
-	rt.HTTP.Default = &http.Client{Transport: httpx.WithTraces(nil), Timeout: 30 * time.Second}
-	rt.HTTP.Proxied = rt.HTTP.Default
-
-	// ensure there's a cached access token
-	rc := rt.VK.Get()
-	defer rc.Close()
-	rc.Do("SET", "channel-token:8eb23e93-5ecb-45ba-b726-3b064e0c56ab", "ACCESS_TOKEN")
+	setupBackend(t, rt)
 
 	s := web.NewServer(rt)
 	h := s.MountHandler(newHandler).(*handler)


### PR DESCRIPTION
## Summary

Follow-up cleanup after the migration of handler tests to JSON case files: the test runners no longer let unmocked requests reach the network, the shared setup is factored into helpers, and the last tests that started their own HTTP servers now use mock transports like everything else.

## Changes

**`handlers/handlertest`**
- Both runners install one transport that fails any request a case hasn't mocked. Previously only the incoming runner did this (with a localhost pass-through for the old test servers), while the outgoing runner fell through to the real network for cases without mocks.
- The client and per-case transport setup shared by the two runners moves into `installTestClient` and `setCaseTransport`.
- Adds a package doc describing the case file layout, the `-update` flag, the mock requirement and the unique-label rule, which the floating comment in `snapshots.go` was standing in for.
- Drops the leftover benchmark logging redirect, the `testing.TB` parameter and a doc comment that still described the removed legacy assertion.

**Handler tests**
- The `DescribeURN` tests in jiochat, wechat, slack, vk and the Meta handlers used `httptest` servers and repointed package URL variables at them. They now use `test.MockTransport` against the real URLs, matching the `SendEvent` tests alongside them. That also removes the workarounds other tests in those packages needed to pin the URLs back, and the redundant client and token-seeding blocks in the jiochat and wechat tests.
- Renames the misspelled `whataspp_test.go` to `whatsapp_test.go`.

`facebook_legacy` keeps its test server since that handler is being removed.

## Test plan

- [x] `go test -p=1 ./...` passes in the devcontainer
- [x] The converted `DescribeURN`, `SendEvent`, `BuildAttachmentRequest` and token tests pass individually
- [x] `gofmt` and `go vet` clean